### PR TITLE
Correct casing of enum variants according to Rust conventions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,13 @@ fn render_signal(mut w: impl Write, signal: &Signal, dbc: &DBC, msg: &Message) -
                 let mut w = PadAdapter::wrap(&mut w);
                 for variant in variants {
                     let literal = match_on_raw_type(*variant.a());
-                    writeln!(&mut w, "{} => {}::{},", literal, type_name, variant.b())?;
+                    writeln!(
+                        &mut w,
+                        "{} => {}::{},",
+                        literal,
+                        type_name,
+                        enum_variant_name(variant.b())
+                    )?;
                 }
                 writeln!(&mut w, "x => {}::Other(x),", type_name,)?;
             }
@@ -450,7 +456,7 @@ fn write_enum(
     {
         let mut w = PadAdapter::wrap(&mut w);
         for variant in variants {
-            writeln!(w, "{},", variant.b())?;
+            writeln!(w, "{},", enum_variant_name(variant.b()))?;
         }
         writeln!(w, "Other({}),", signal_to_rust_type(signal))?;
     }
@@ -504,4 +510,8 @@ fn enum_name(msg: &Message, signal: &Signal) -> String {
         msg.message_name().to_camel_case(),
         signal.name().to_camel_case()
     )
+}
+
+fn enum_variant_name(x: &str) -> String {
+    x.to_camel_case()
 }

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -259,8 +259,14 @@ impl Bar {
     /// - Unit: ""
     /// - Receivers: Dolor
     #[inline(always)]
-    pub fn three(&self) -> u8 {
-        self.three_raw()
+    pub fn three(&self) -> BarThree {
+        match self.three_raw() {
+            0 => BarThree::Off,
+            1 => BarThree::On,
+            2 => BarThree::Oner,
+            3 => BarThree::Onest,
+            x => BarThree::Other(x),
+        }
     }
 
     /// Get raw value of Three
@@ -343,6 +349,16 @@ impl core::convert::TryFrom<&[u8]> for Bar {
     }
 }
 
+/// Defined values for Three
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub enum BarThree {
+    Off,
+    On,
+    Oner,
+    Onest,
+    Other(u8),
+}
 /// Defined values for Four
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "debug", derive(Debug))]

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -26,4 +26,5 @@ BO_ 512 Bar: 8 Ipsum
 
 
 
+VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";
 VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";

--- a/testing/rust-integration/tests/compare_to_socketcan.rs
+++ b/testing/rust-integration/tests/compare_to_socketcan.rs
@@ -26,7 +26,7 @@ fn weirdly_aligned_bigendian_message_1() {
 
     assert_eq!(msg.one(), 2);
     assert_f32_eq(msg.two(), 2_f32);
-    assert_eq!(msg.three(), 2);
+    assert!(matches!(msg.three(), messages::BarThree::Oner));
     assert!(matches!(msg.four(), messages::BarFour::Oner));
 }
 
@@ -37,7 +37,7 @@ fn weirdly_aligned_bigendian_message_2() {
 
     assert_eq!(msg.one(), 1);
     assert_f32_eq(msg.two(), 2_f32);
-    assert_eq!(msg.three(), 3);
+    assert!(matches!(msg.three(), messages::BarThree::Onest));
     assert!(matches!(msg.four(), messages::BarFour::On));
 }
 


### PR DESCRIPTION
Enum variant names are generated based on Rust conventions. Previously this ended up generating codes that produces warnings in case the casing in the DBC does not match the Rust convention.

previously:
"ONER" => `BarThree::ONER`
after fix: 
"ONER" => `BarThree::Oner`