### PR TITLE
Provide access to message raw value

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,15 @@ fn render_message(mut w: impl Write, msg: &Message, dbc: &DBC) -> Result<()> {
         writeln!(&mut w, "}}")?;
         writeln!(w)?;
 
+        writeln!(&mut w, "/// Access message payload raw value")?;
+        writeln!(&mut w, "pub fn raw(&self) -> &[u8] {{")?;
+        {
+            let mut w = PadAdapter::wrap(&mut w);
+            writeln!(&mut w, "&self.raw")?;
+        }
+        writeln!(&mut w, "}}")?;
+        writeln!(w)?;
+
         for signal in msg.signals().iter() {
             render_signal(&mut w, signal, dbc, msg)
                 .with_context(|| format!("write signal impl `{}`", signal.name()))?;

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -55,6 +55,11 @@ impl Foo {
         Ok(res)
     }
 
+    /// Access message payload raw value
+    pub fn raw(&self) -> &[u8] {
+        &self.raw
+    }
+
     /// Voltage
     ///
     /// - Min: 0
@@ -174,6 +179,11 @@ impl Bar {
         res.set_three(three)?;
         res.set_four(four)?;
         Ok(res)
+    }
+
+    /// Access message payload raw value
+    pub fn raw(&self) -> &[u8] {
+        &self.raw
     }
 
     /// One


### PR DESCRIPTION
I think there is no way right now to access the inner raw value in order to send a frame. Unless I missed something.