### PR TITLE
Derive PartialEq in enums

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -444,7 +444,7 @@ fn write_enum(
     variants: &[ValDescription],
 ) -> Result<()> {
     writeln!(w, "/// Defined values for {}", signal.name())?;
-    writeln!(w, "#[derive(Clone, Copy)]")?;
+    writeln!(w, "#[derive(Clone, Copy, PartialEq)]")?;
     writeln!(w, r##"#[cfg_attr(feature = "debug", derive(Debug))]"##)?;
     writeln!(w, "pub enum {} {{", enum_name(msg, signal))?;
     {

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -344,7 +344,7 @@ impl core::convert::TryFrom<&[u8]> for Bar {
 }
 
 /// Defined values for Four
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum BarFour {
     Off,


### PR DESCRIPTION
Make enums compareable. Only derive PartialEq due to possible floats.