### PR TITLE
Add check for range of value parameter when setting signal

### DIFF
--- a/src/includes/errors.rs
+++ b/src/includes/errors.rs
@@ -5,10 +5,8 @@ pub enum CanError {
     /// Signal parameter is not within the range
     /// defined in the dbc
     ParameterOutOfRange {
-        /// Minimum value defined in DBC
-        min: f64,
-        /// Maximum value defined in DBC
-        max: f64,
+        /// dbc message id
+        message_id: u32,
     },
     InvalidPayloadSize,
 }

--- a/src/includes/errors.rs
+++ b/src/includes/errors.rs
@@ -5,9 +5,9 @@ pub enum CanError {
     /// Signal parameter is not within the range
     /// defined in the dbc
     ParameterOutOfRange {
-        /// Minimum value defined in DBC for signal
+        /// Minimum value defined in DBC
         min: f64,
-        /// Maximum value defined in DBC for signal
+        /// Maximum value defined in DBC
         max: f64,
     },
     InvalidPayloadSize,

--- a/src/includes/errors.rs
+++ b/src/includes/errors.rs
@@ -1,6 +1,14 @@
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum CanError {
     UnknownMessageId(u32),
+    /// Signal parameter is not within the range
+    /// defined in the dbc
+    ParameterOutOfRange {
+        /// Minimum value defined in DBC for signal
+        min: f64,
+        /// Maximum value defined in DBC for signal
+        max: f64,
+    },
     InvalidPayloadSize,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,6 +379,15 @@ fn render_signal(mut w: impl Write, signal: &Signal, dbc: &DBC, msg: &Message) -
     )?;
     {
         let mut w = PadAdapter::wrap(&mut w);
+        writeln!(w, r##"#[cfg(feature = "range_checked")]"##)?;
+        writeln!(
+            w,
+            r##"assert!({}{} <= value && value <= {}{});"##,
+            signal.min(),
+            signal_to_rust_type(&signal),
+            signal.max(),
+            signal_to_rust_type(&signal)
+        )?;
         signal_to_payload(&mut w, signal)?;
     }
     writeln!(&mut w, "}}")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -382,11 +382,10 @@ fn render_signal(mut w: impl Write, signal: &Signal, dbc: &DBC, msg: &Message) -
         writeln!(w, r##"#[cfg(feature = "range_checked")]"##)?;
         writeln!(
             w,
-            r##"assert!({}{} <= value && value <= {}{});"##,
-            signal.min(),
-            signal_to_rust_type(&signal),
-            signal.max(),
-            signal_to_rust_type(&signal)
+            r##"if value < {min}{typ} || {max}{typ} < value {{ return Err(CanError::ParameterOutOfRange{{ min: {min}f64 , max: {max}f64 }}); }}"##,
+            typ = signal_to_rust_type(&signal),
+            min = signal.min(),
+            max = signal.max(),
         )?;
         signal_to_payload(&mut w, signal)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -382,8 +382,9 @@ fn render_signal(mut w: impl Write, signal: &Signal, dbc: &DBC, msg: &Message) -
         writeln!(w, r##"#[cfg(feature = "range_checked")]"##)?;
         writeln!(
             w,
-            r##"if value < {min}_{typ} || {max}_{typ} < value {{ return Err(CanError::ParameterOutOfRange{{ min: {min}_f64 , max: {max}_f64 }}); }}"##,
+            r##"if value < {min}_{typ} || {max}_{typ} < value {{ return Err(CanError::ParameterOutOfRange{{ message_id: {message_id} }}); }}"##,
             typ = signal_to_rust_type(&signal),
+            message_id = msg.message_id().0,
             min = signal.min(),
             max = signal.max(),
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -382,7 +382,7 @@ fn render_signal(mut w: impl Write, signal: &Signal, dbc: &DBC, msg: &Message) -
         writeln!(w, r##"#[cfg(feature = "range_checked")]"##)?;
         writeln!(
             w,
-            r##"if value < {min}{typ} || {max}{typ} < value {{ return Err(CanError::ParameterOutOfRange{{ min: {min}f64 , max: {max}f64 }}); }}"##,
+            r##"if value < {min}_{typ} || {max}_{typ} < value {{ return Err(CanError::ParameterOutOfRange{{ min: {min}_f64 , max: {max}_f64 }}); }}"##,
             typ = signal_to_rust_type(&signal),
             min = signal.min(),
             max = signal.max(),

--- a/testing/can-messages/Cargo.toml
+++ b/testing/can-messages/Cargo.toml
@@ -10,3 +10,4 @@ bitsh = { git = "https://github.com/bitbleep/bitsh/" }
 [features]
 default = ["debug"]
 debug = []
+range_checked = []

--- a/testing/can-messages/src/lib.rs
+++ b/testing/can-messages/src/lib.rs
@@ -3,6 +3,17 @@ pub use messages::*;
 
 #[test]
 #[cfg(feature = "range_checked")]
-fn change_range_value() {
-    let bar = messages::Bar::new(1, 2.0, 3, 3);
+fn check_range_value_error() {
+    let result = messages::Bar::new(1, 2.0, 3, 4);
+    assert!(matches!(
+        result,
+        Err(CanError::ParameterOutOfRange { min: 0.0, max: 3.0 })
+    ));
+}
+
+#[test]
+#[cfg(feature = "range_checked")]
+fn check_range_value_valid() {
+    let result = messages::Bar::new(1, 2.0, 3, 3);
+    assert!(result.is_ok());
 }

--- a/testing/can-messages/src/lib.rs
+++ b/testing/can-messages/src/lib.rs
@@ -1,2 +1,8 @@
 mod messages;
 pub use messages::*;
+
+#[test]
+#[cfg(feature = "range_checked")]
+fn change_range_value() {
+    let bar = messages::Bar::new(1, 2.0, 3, 3);
+}

--- a/testing/can-messages/src/lib.rs
+++ b/testing/can-messages/src/lib.rs
@@ -7,7 +7,7 @@ fn check_range_value_error() {
     let result = messages::Bar::new(1, 2.0, 3, 4);
     assert!(matches!(
         result,
-        Err(CanError::ParameterOutOfRange { min: 0.0, max: 3.0 })
+        Err(CanError::ParameterOutOfRange { message_id: 512 })
     ));
 }
 

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -92,10 +92,10 @@ impl Foo {
     #[inline(always)]
     pub fn set_voltage(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0f32 || 63.9990234375f32 < value {
+        if value < 0_f32 || 63.9990234375_f32 < value {
             return Err(CanError::ParameterOutOfRange {
-                min: 0f64,
-                max: 63.9990234375f64,
+                min: 0_f64,
+                max: 63.9990234375_f64,
             });
         }
         let factor = 0.000976562_f32;
@@ -140,10 +140,10 @@ impl Foo {
     #[inline(always)]
     pub fn set_current(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < -2048f32 || 2047.9375f32 < value {
+        if value < -2048_f32 || 2047.9375_f32 < value {
             return Err(CanError::ParameterOutOfRange {
-                min: -2048f64,
-                max: 2047.9375f64,
+                min: -2048_f64,
+                max: 2047.9375_f64,
             });
         }
         let factor = 0.0625_f32;
@@ -230,10 +230,10 @@ impl Bar {
     #[inline(always)]
     pub fn set_one(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0u8 || 3u8 < value {
+        if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
-                min: 0f64,
-                max: 3f64,
+                min: 0_f64,
+                max: 3_f64,
             });
         }
         let start_bit = 15;
@@ -274,10 +274,10 @@ impl Bar {
     #[inline(always)]
     pub fn set_two(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0f32 || 100f32 < value {
+        if value < 0_f32 || 100_f32 < value {
             return Err(CanError::ParameterOutOfRange {
-                min: 0f64,
-                max: 100f64,
+                min: 0_f64,
+                max: 100_f64,
             });
         }
         let factor = 0.39_f32;
@@ -326,10 +326,10 @@ impl Bar {
     #[inline(always)]
     pub fn set_three(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0u8 || 7u8 < value {
+        if value < 0_u8 || 7_u8 < value {
             return Err(CanError::ParameterOutOfRange {
-                min: 0f64,
-                max: 7f64,
+                min: 0_f64,
+                max: 7_f64,
             });
         }
         let start_bit = 13;
@@ -374,10 +374,10 @@ impl Bar {
     #[inline(always)]
     pub fn set_four(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0u8 || 3u8 < value {
+        if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
-                min: 0f64,
-                max: 3f64,
+                min: 0_f64,
+                max: 3_f64,
             });
         }
         let start_bit = 10;
@@ -432,9 +432,9 @@ pub enum CanError {
     /// Signal parameter is not within the range
     /// defined in the dbc
     ParameterOutOfRange {
-        /// Minimum value defined in DBC
+        /// Minimum value defined in DBC for signal
         min: f64,
-        /// Maximum value defined in DBC
+        /// Maximum value defined in DBC for signal
         max: f64,
     },
     InvalidPayloadSize,

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -93,10 +93,7 @@ impl Foo {
     pub fn set_voltage(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
         if value < 0_f32 || 63.9990234375_f32 < value {
-            return Err(CanError::ParameterOutOfRange {
-                min: 0_f64,
-                max: 63.9990234375_f64,
-            });
+            return Err(CanError::ParameterOutOfRange { message_id: 256 });
         }
         let factor = 0.000976562_f32;
         let offset = 0_f32;
@@ -141,10 +138,7 @@ impl Foo {
     pub fn set_current(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
         if value < -2048_f32 || 2047.9375_f32 < value {
-            return Err(CanError::ParameterOutOfRange {
-                min: -2048_f64,
-                max: 2047.9375_f64,
-            });
+            return Err(CanError::ParameterOutOfRange { message_id: 256 });
         }
         let factor = 0.0625_f32;
         let offset = 0_f32;
@@ -231,10 +225,7 @@ impl Bar {
     pub fn set_one(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
         if value < 0_u8 || 3_u8 < value {
-            return Err(CanError::ParameterOutOfRange {
-                min: 0_f64,
-                max: 3_f64,
-            });
+            return Err(CanError::ParameterOutOfRange { message_id: 512 });
         }
         let start_bit = 15;
         let bits = 2;
@@ -275,10 +266,7 @@ impl Bar {
     pub fn set_two(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
         if value < 0_f32 || 100_f32 < value {
-            return Err(CanError::ParameterOutOfRange {
-                min: 0_f64,
-                max: 100_f64,
-            });
+            return Err(CanError::ParameterOutOfRange { message_id: 512 });
         }
         let factor = 0.39_f32;
         let offset = 0_f32;
@@ -327,10 +315,7 @@ impl Bar {
     pub fn set_three(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
         if value < 0_u8 || 7_u8 < value {
-            return Err(CanError::ParameterOutOfRange {
-                min: 0_f64,
-                max: 7_f64,
-            });
+            return Err(CanError::ParameterOutOfRange { message_id: 512 });
         }
         let start_bit = 13;
         let bits = 3;
@@ -375,10 +360,7 @@ impl Bar {
     pub fn set_four(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
         if value < 0_u8 || 3_u8 < value {
-            return Err(CanError::ParameterOutOfRange {
-                min: 0_f64,
-                max: 3_f64,
-            });
+            return Err(CanError::ParameterOutOfRange { message_id: 512 });
         }
         let start_bit = 10;
         let bits = 2;
@@ -432,10 +414,8 @@ pub enum CanError {
     /// Signal parameter is not within the range
     /// defined in the dbc
     ParameterOutOfRange {
-        /// Minimum value defined in DBC for signal
-        min: f64,
-        /// Maximum value defined in DBC for signal
-        max: f64,
+        /// dbc message id
+        message_id: u32,
     },
     InvalidPayloadSize,
 }

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -92,7 +92,12 @@ impl Foo {
     #[inline(always)]
     pub fn set_voltage(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        assert!(0f32 <= value && value <= 63.9990234375f32);
+        if value < 0f32 || 63.9990234375f32 < value {
+            return Err(CanError::ParameterOutOfRange {
+                min: 0f64,
+                max: 63.9990234375f64,
+            });
+        }
         let factor = 0.000976562_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u16;
@@ -135,7 +140,12 @@ impl Foo {
     #[inline(always)]
     pub fn set_current(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        assert!(-2048f32 <= value && value <= 2047.9375f32);
+        if value < -2048f32 || 2047.9375f32 < value {
+            return Err(CanError::ParameterOutOfRange {
+                min: -2048f64,
+                max: 2047.9375f64,
+            });
+        }
         let factor = 0.0625_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as i16;
@@ -220,7 +230,12 @@ impl Bar {
     #[inline(always)]
     pub fn set_one(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        assert!(0u8 <= value && value <= 3u8);
+        if value < 0u8 || 3u8 < value {
+            return Err(CanError::ParameterOutOfRange {
+                min: 0f64,
+                max: 3f64,
+            });
+        }
         let start_bit = 15;
         let bits = 2;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
@@ -259,7 +274,12 @@ impl Bar {
     #[inline(always)]
     pub fn set_two(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        assert!(0f32 <= value && value <= 100f32);
+        if value < 0f32 || 100f32 < value {
+            return Err(CanError::ParameterOutOfRange {
+                min: 0f64,
+                max: 100f64,
+            });
+        }
         let factor = 0.39_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u8;
@@ -306,7 +326,12 @@ impl Bar {
     #[inline(always)]
     pub fn set_three(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        assert!(0u8 <= value && value <= 7u8);
+        if value < 0u8 || 7u8 < value {
+            return Err(CanError::ParameterOutOfRange {
+                min: 0f64,
+                max: 7f64,
+            });
+        }
         let start_bit = 13;
         let bits = 3;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
@@ -349,7 +374,12 @@ impl Bar {
     #[inline(always)]
     pub fn set_four(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        assert!(0u8 <= value && value <= 3u8);
+        if value < 0u8 || 3u8 < value {
+            return Err(CanError::ParameterOutOfRange {
+                min: 0f64,
+                max: 3f64,
+            });
+        }
         let start_bit = 10;
         let bits = 2;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
@@ -395,9 +425,17 @@ pub enum BarFour {
 /// This is just to make testing easier
 fn main() {}
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum CanError {
     UnknownMessageId(u32),
+    /// Signal parameter is not within the range
+    /// defined in the dbc
+    ParameterOutOfRange {
+        /// Minimum value defined in DBC
+        min: f64,
+        /// Maximum value defined in DBC
+        max: f64,
+    },
     InvalidPayloadSize,
 }

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -91,6 +91,8 @@ impl Foo {
     /// Set value of Voltage
     #[inline(always)]
     pub fn set_voltage(&mut self, value: f32) -> Result<(), CanError> {
+        #[cfg(feature = "range_checked")]
+        assert!(0f32 <= value && value <= 63.9990234375f32);
         let factor = 0.000976562_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u16;
@@ -132,6 +134,8 @@ impl Foo {
     /// Set value of Current
     #[inline(always)]
     pub fn set_current(&mut self, value: f32) -> Result<(), CanError> {
+        #[cfg(feature = "range_checked")]
+        assert!(-2048f32 <= value && value <= 2047.9375f32);
         let factor = 0.0625_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as i16;
@@ -215,6 +219,8 @@ impl Bar {
     /// Set value of One
     #[inline(always)]
     pub fn set_one(&mut self, value: u8) -> Result<(), CanError> {
+        #[cfg(feature = "range_checked")]
+        assert!(0u8 <= value && value <= 3u8);
         let start_bit = 15;
         let bits = 2;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
@@ -252,6 +258,8 @@ impl Bar {
     /// Set value of Two
     #[inline(always)]
     pub fn set_two(&mut self, value: f32) -> Result<(), CanError> {
+        #[cfg(feature = "range_checked")]
+        assert!(0f32 <= value && value <= 100f32);
         let factor = 0.39_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u8;
@@ -297,6 +305,8 @@ impl Bar {
     /// Set value of Three
     #[inline(always)]
     pub fn set_three(&mut self, value: u8) -> Result<(), CanError> {
+        #[cfg(feature = "range_checked")]
+        assert!(0u8 <= value && value <= 7u8);
         let start_bit = 13;
         let bits = 3;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
@@ -338,6 +348,8 @@ impl Bar {
     /// Set value of Four
     #[inline(always)]
     pub fn set_four(&mut self, value: u8) -> Result<(), CanError> {
+        #[cfg(feature = "range_checked")]
+        assert!(0u8 <= value && value <= 3u8);
         let start_bit = 10;
         let bits = 2;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
@@ -360,7 +372,7 @@ impl core::convert::TryFrom<&[u8]> for Bar {
 }
 
 /// Defined values for Three
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum BarThree {
     Off,


### PR DESCRIPTION
Add a feature that asserts that values are within the min/max range defined in the DBC.