### PR TITLE
Fix range check on bool

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -379,15 +379,18 @@ fn render_signal(mut w: impl Write, signal: &Signal, dbc: &DBC, msg: &Message) -
     )?;
     {
         let mut w = PadAdapter::wrap(&mut w);
-        writeln!(w, r##"#[cfg(feature = "range_checked")]"##)?;
-        writeln!(
-            w,
-            r##"if value < {min}_{typ} || {max}_{typ} < value {{ return Err(CanError::ParameterOutOfRange{{ message_id: {message_id} }}); }}"##,
-            typ = signal_to_rust_type(&signal),
-            message_id = msg.message_id().0,
-            min = signal.min(),
-            max = signal.max(),
-        )?;
+
+        if signal.signal_size != 1 {
+            writeln!(w, r##"#[cfg(feature = "range_checked")]"##)?;
+            writeln!(
+                w,
+                r##"if value < {min}_{typ} || {max}_{typ} < value {{ return Err(CanError::ParameterOutOfRange{{ message_id: {message_id} }}); }}"##,
+                typ = signal_to_rust_type(&signal),
+                message_id = msg.message_id().0,
+                min = signal.min(),
+                max = signal.max(),
+            )?;
+        }
         signal_to_payload(&mut w, signal)?;
     }
     writeln!(&mut w, "}}")?;

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -180,12 +180,13 @@ impl Bar {
     pub const MESSAGE_ID: u32 = 512;
 
     /// Construct new Bar from values
-    pub fn new(one: u8, two: f32, three: u8, four: u8) -> Result<Self, CanError> {
+    pub fn new(one: u8, two: f32, three: u8, four: u8, five: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 8] };
         res.set_one(one)?;
         res.set_two(two)?;
         res.set_three(three)?;
         res.set_four(four)?;
+        res.set_five(five)?;
         Ok(res)
     }
 
@@ -364,6 +365,42 @@ impl Bar {
         }
         let start_bit = 10;
         let bits = 2;
+        value.pack_be_bits(&mut self.raw, start_bit, bits);
+        Ok(())
+    }
+
+    /// Five
+    ///
+    /// - Min: 0
+    /// - Max: 1
+    /// - Unit: "boolean"
+    /// - Receivers: Dolor
+    #[inline(always)]
+    pub fn five(&self) -> bool {
+        self.five_raw()
+    }
+
+    /// Get raw value of Five
+    ///
+    /// - Start bit: 30
+    /// - Signal size: 1 bits
+    /// - Factor: 1
+    /// - Offset: 0
+    /// - Byte order: BigEndian
+    /// - Value type: Unsigned
+    #[inline(always)]
+    pub fn five_raw(&self) -> bool {
+        let signal = u8::unpack_be_bits(&self.raw, (30 - (1 - 1)), 1);
+
+        signal == 1
+    }
+
+    /// Set value of Five
+    #[inline(always)]
+    pub fn set_five(&mut self, value: bool) -> Result<(), CanError> {
+        let value = value as u8;
+        let start_bit = 30;
+        let bits = 1;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -17,6 +17,7 @@ BO_ 512 Bar: 8 Ipsum
  SG_ Two : 7|8@0+ (0.39,0) [0.00|100] "%" Dolor
  SG_ Three : 13|3@0+ (1,0) [0|7] "" Dolor
  SG_ Four : 10|2@0+ (1,0) [0|3] "" Dolor
+ SG_ Five : 30|1@0+ (1,0) [0|1] "boolean" Dolor
 
 
 


### PR DESCRIPTION
Avoid range checks on bool they lead to the following error. Does not really make sense to do to a range check on boolean values anyway.

```
error: invalid suffix `bool` for number literal
   --> testing/can-messages/src/messages.rs:390:30
    |
390 |         if value < 0_bool || 1_bool < value { return Err(CanError::ParameterOutOfRange{ message_id: 512 }); }
    |                              ^^^^^^ invalid suffix `bool`
    |
```