### PR TITLE
Prepend X to enum fields that start with a numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ cargo build --all
 
 # run all tests
 cargo test --all
+
+# format before commiting anything
+cargo fmt --all
 ```
 
 ## Generate .kdc from .dbc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,38 @@
-# CAN DBC code-gen for embedded Rust
+# CAN DBC code generator for Rust
 
-Experimental code generator.
-Use with caution.
-Breaking changes will happen when you least expect it.
+Generates Rust messages from a `dbc` file.
+
+⚠️ This is experimental - use with caution. Breaking changes will happen when you least expect it. ⚠️
+
+# Usage
+
+Generate `messages.rs` from `example.dbc`.
+```bash
+cargo run -- testing/dbc-examples/example.dbc dir/where/messages_rs/file/is/written
+```
+
+# Development
+
+```bash
+# generate messages.rs
+cargo run -- testing/dbc-examples/example.dbc testing/can-messages/src
+
+# build all binaries
+cargo build --all
+
+# run all tests
+cargo test --all
+```
+
+## Generate .kdc from .dbc
+
+Use [canmatrix](https://github.com/ebroecker/canmatrix) if you need to generate a new `.kcd` file from a `.dbc`.
+
+```bash
+# https://canmatrix.readthedocs.io/en/latest/installation.html
+pip install canmatrix
+pip install git+https://github.com/ebroecker/canmatrix#egg=canmatrix[kcd]
+
+# generate .kcd
+canconvert testing/dbc-examples/example.dbc testing/dbc-examples/example.kcd
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,5 +534,9 @@ fn enum_name(msg: &Message, signal: &Signal) -> String {
 }
 
 fn enum_variant_name(x: &str) -> String {
-    x.to_camel_case()
+    if !x.starts_with(|c: char| c.is_ascii_alphabetic()) {
+        format!("X{}", x.to_camel_case())
+    } else {
+        x.to_camel_case()
+    }
 }

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -23,7 +23,7 @@ impl Messages {
     #[inline(never)]
     pub fn from_can_message(id: u32, payload: &[u8]) -> Result<Self, CanError> {
         use core::convert::TryFrom;
-        
+
         let res = match id {
             256 => Messages::Foo(Foo::try_from(payload)?),
             512 => Messages::Bar(Bar::try_from(payload)?),
@@ -46,7 +46,7 @@ pub struct Foo {
 
 impl Foo {
     pub const MESSAGE_ID: u32 = 256;
-    
+
     /// Construct new Foo from values
     pub fn new(voltage: f32, current: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 4] };
@@ -54,12 +54,12 @@ impl Foo {
         res.set_current(current)?;
         Ok(res)
     }
-    
+
     /// Access message payload raw value
     pub fn raw(&self) -> &[u8] {
         &self.raw
     }
-    
+
     /// Voltage
     ///
     /// - Min: 0
@@ -70,7 +70,7 @@ impl Foo {
     pub fn voltage(&self) -> f32 {
         self.voltage_raw()
     }
-    
+
     /// Get raw value of Voltage
     ///
     /// - Start bit: 16
@@ -82,27 +82,29 @@ impl Foo {
     #[inline(always)]
     pub fn voltage_raw(&self) -> f32 {
         let signal = u16::unpack_le_bits(&self.raw, 16, 16);
-        
+
         let factor = 0.000976562_f32;
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    
+
     /// Set value of Voltage
     #[inline(always)]
     pub fn set_voltage(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_f32 || 63.9990234375_f32 < value { return Err(CanError::ParameterOutOfRange{ message_id: 256 }); }
+        if value < 0_f32 || 63.9990234375_f32 < value {
+            return Err(CanError::ParameterOutOfRange { message_id: 256 });
+        }
         let factor = 0.000976562_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u16;
-        
+
         let start_bit = 16;
         let bits = 16;
         value.pack_le_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-    
+
     /// Current
     ///
     /// - Min: -2048
@@ -113,7 +115,7 @@ impl Foo {
     pub fn current(&self) -> f32 {
         self.current_raw()
     }
-    
+
     /// Get raw value of Current
     ///
     /// - Start bit: 0
@@ -125,41 +127,43 @@ impl Foo {
     #[inline(always)]
     pub fn current_raw(&self) -> f32 {
         let signal = i16::unpack_le_bits(&self.raw, 0, 16);
-        
+
         let factor = 0.0625_f32;
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    
+
     /// Set value of Current
     #[inline(always)]
     pub fn set_current(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < -2048_f32 || 2047.9375_f32 < value { return Err(CanError::ParameterOutOfRange{ message_id: 256 }); }
+        if value < -2048_f32 || 2047.9375_f32 < value {
+            return Err(CanError::ParameterOutOfRange { message_id: 256 });
+        }
         let factor = 0.0625_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as i16;
-        
+
         let start_bit = 0;
         let bits = 16;
         value.pack_le_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-    
 }
 
 impl core::convert::TryFrom<&[u8]> for Foo {
     type Error = CanError;
-    
+
     #[inline(always)]
     fn try_from(payload: &[u8]) -> Result<Self, Self::Error> {
-        if payload.len() != 4 { return Err(CanError::InvalidPayloadSize); }
+        if payload.len() != 4 {
+            return Err(CanError::InvalidPayloadSize);
+        }
         let mut raw = [0u8; 4];
         raw.copy_from_slice(&payload[..4]);
         Ok(Self { raw })
     }
 }
-
 
 /// Bar
 ///
@@ -174,7 +178,7 @@ pub struct Bar {
 
 impl Bar {
     pub const MESSAGE_ID: u32 = 512;
-    
+
     /// Construct new Bar from values
     pub fn new(one: u8, two: f32, three: u8, four: u8, five: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 8] };
@@ -185,12 +189,12 @@ impl Bar {
         res.set_five(five)?;
         Ok(res)
     }
-    
+
     /// Access message payload raw value
     pub fn raw(&self) -> &[u8] {
         &self.raw
     }
-    
+
     /// One
     ///
     /// - Min: 0
@@ -201,7 +205,7 @@ impl Bar {
     pub fn one(&self) -> u8 {
         self.one_raw()
     }
-    
+
     /// Get raw value of One
     ///
     /// - Start bit: 15
@@ -213,21 +217,23 @@ impl Bar {
     #[inline(always)]
     pub fn one_raw(&self) -> u8 {
         let signal = u8::unpack_be_bits(&self.raw, (15 - (2 - 1)), 2);
-        
+
         signal
     }
-    
+
     /// Set value of One
     #[inline(always)]
     pub fn set_one(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_u8 || 3_u8 < value { return Err(CanError::ParameterOutOfRange{ message_id: 512 }); }
+        if value < 0_u8 || 3_u8 < value {
+            return Err(CanError::ParameterOutOfRange { message_id: 512 });
+        }
         let start_bit = 15;
         let bits = 2;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-    
+
     /// Two
     ///
     /// - Min: 0
@@ -238,7 +244,7 @@ impl Bar {
     pub fn two(&self) -> f32 {
         self.two_raw()
     }
-    
+
     /// Get raw value of Two
     ///
     /// - Start bit: 7
@@ -250,27 +256,29 @@ impl Bar {
     #[inline(always)]
     pub fn two_raw(&self) -> f32 {
         let signal = u8::unpack_be_bits(&self.raw, (7 - (8 - 1)), 8);
-        
+
         let factor = 0.39_f32;
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    
+
     /// Set value of Two
     #[inline(always)]
     pub fn set_two(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_f32 || 100_f32 < value { return Err(CanError::ParameterOutOfRange{ message_id: 512 }); }
+        if value < 0_f32 || 100_f32 < value {
+            return Err(CanError::ParameterOutOfRange { message_id: 512 });
+        }
         let factor = 0.39_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u8;
-        
+
         let start_bit = 7;
         let bits = 8;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-    
+
     /// Three
     ///
     /// - Min: 0
@@ -287,7 +295,7 @@ impl Bar {
             x => BarThree::Other(x),
         }
     }
-    
+
     /// Get raw value of Three
     ///
     /// - Start bit: 13
@@ -299,21 +307,23 @@ impl Bar {
     #[inline(always)]
     pub fn three_raw(&self) -> u8 {
         let signal = u8::unpack_be_bits(&self.raw, (13 - (3 - 1)), 3);
-        
+
         signal
     }
-    
+
     /// Set value of Three
     #[inline(always)]
     pub fn set_three(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_u8 || 7_u8 < value { return Err(CanError::ParameterOutOfRange{ message_id: 512 }); }
+        if value < 0_u8 || 7_u8 < value {
+            return Err(CanError::ParameterOutOfRange { message_id: 512 });
+        }
         let start_bit = 13;
         let bits = 3;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-    
+
     /// Four
     ///
     /// - Min: 0
@@ -330,7 +340,7 @@ impl Bar {
             x => BarFour::Other(x),
         }
     }
-    
+
     /// Get raw value of Four
     ///
     /// - Start bit: 10
@@ -342,21 +352,23 @@ impl Bar {
     #[inline(always)]
     pub fn four_raw(&self) -> u8 {
         let signal = u8::unpack_be_bits(&self.raw, (10 - (2 - 1)), 2);
-        
+
         signal
     }
-    
+
     /// Set value of Four
     #[inline(always)]
     pub fn set_four(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_u8 || 3_u8 < value { return Err(CanError::ParameterOutOfRange{ message_id: 512 }); }
+        if value < 0_u8 || 3_u8 < value {
+            return Err(CanError::ParameterOutOfRange { message_id: 512 });
+        }
         let start_bit = 10;
         let bits = 2;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-    
+
     /// Five
     ///
     /// - Min: 0
@@ -373,7 +385,7 @@ impl Bar {
             x => BarFive::Other(x),
         }
     }
-    
+
     /// Get raw value of Five
     ///
     /// - Start bit: 30
@@ -385,10 +397,10 @@ impl Bar {
     #[inline(always)]
     pub fn five_raw(&self) -> bool {
         let signal = u8::unpack_be_bits(&self.raw, (30 - (1 - 1)), 1);
-        
+
         signal == 1
     }
-    
+
     /// Set value of Five
     #[inline(always)]
     pub fn set_five(&mut self, value: bool) -> Result<(), CanError> {
@@ -398,15 +410,16 @@ impl Bar {
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-    
 }
 
 impl core::convert::TryFrom<&[u8]> for Bar {
     type Error = CanError;
-    
+
     #[inline(always)]
     fn try_from(payload: &[u8]) -> Result<Self, Self::Error> {
-        if payload.len() != 8 { return Err(CanError::InvalidPayloadSize); }
+        if payload.len() != 8 {
+            return Err(CanError::InvalidPayloadSize);
+        }
         let mut raw = [0u8; 8];
         raw.copy_from_slice(&payload[..8]);
         Ok(Self { raw })
@@ -444,7 +457,6 @@ pub enum BarFive {
     Other(bool),
 }
 
-
 /// This is just to make testing easier
 fn main() {}
 
@@ -460,4 +472,3 @@ pub enum CanError {
     },
     InvalidPayloadSize,
 }
-

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -23,7 +23,7 @@ impl Messages {
     #[inline(never)]
     pub fn from_can_message(id: u32, payload: &[u8]) -> Result<Self, CanError> {
         use core::convert::TryFrom;
-
+        
         let res = match id {
             256 => Messages::Foo(Foo::try_from(payload)?),
             512 => Messages::Bar(Bar::try_from(payload)?),
@@ -46,7 +46,7 @@ pub struct Foo {
 
 impl Foo {
     pub const MESSAGE_ID: u32 = 256;
-
+    
     /// Construct new Foo from values
     pub fn new(voltage: f32, current: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 4] };
@@ -54,12 +54,12 @@ impl Foo {
         res.set_current(current)?;
         Ok(res)
     }
-
+    
     /// Access message payload raw value
     pub fn raw(&self) -> &[u8] {
         &self.raw
     }
-
+    
     /// Voltage
     ///
     /// - Min: 0
@@ -70,7 +70,7 @@ impl Foo {
     pub fn voltage(&self) -> f32 {
         self.voltage_raw()
     }
-
+    
     /// Get raw value of Voltage
     ///
     /// - Start bit: 16
@@ -82,29 +82,27 @@ impl Foo {
     #[inline(always)]
     pub fn voltage_raw(&self) -> f32 {
         let signal = u16::unpack_le_bits(&self.raw, 16, 16);
-
+        
         let factor = 0.000976562_f32;
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-
+    
     /// Set value of Voltage
     #[inline(always)]
     pub fn set_voltage(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_f32 || 63.9990234375_f32 < value {
-            return Err(CanError::ParameterOutOfRange { message_id: 256 });
-        }
+        if value < 0_f32 || 63.9990234375_f32 < value { return Err(CanError::ParameterOutOfRange{ message_id: 256 }); }
         let factor = 0.000976562_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u16;
-
+        
         let start_bit = 16;
         let bits = 16;
         value.pack_le_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-
+    
     /// Current
     ///
     /// - Min: -2048
@@ -115,7 +113,7 @@ impl Foo {
     pub fn current(&self) -> f32 {
         self.current_raw()
     }
-
+    
     /// Get raw value of Current
     ///
     /// - Start bit: 0
@@ -127,43 +125,41 @@ impl Foo {
     #[inline(always)]
     pub fn current_raw(&self) -> f32 {
         let signal = i16::unpack_le_bits(&self.raw, 0, 16);
-
+        
         let factor = 0.0625_f32;
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-
+    
     /// Set value of Current
     #[inline(always)]
     pub fn set_current(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < -2048_f32 || 2047.9375_f32 < value {
-            return Err(CanError::ParameterOutOfRange { message_id: 256 });
-        }
+        if value < -2048_f32 || 2047.9375_f32 < value { return Err(CanError::ParameterOutOfRange{ message_id: 256 }); }
         let factor = 0.0625_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as i16;
-
+        
         let start_bit = 0;
         let bits = 16;
         value.pack_le_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
+    
 }
 
 impl core::convert::TryFrom<&[u8]> for Foo {
     type Error = CanError;
-
+    
     #[inline(always)]
     fn try_from(payload: &[u8]) -> Result<Self, Self::Error> {
-        if payload.len() != 4 {
-            return Err(CanError::InvalidPayloadSize);
-        }
+        if payload.len() != 4 { return Err(CanError::InvalidPayloadSize); }
         let mut raw = [0u8; 4];
         raw.copy_from_slice(&payload[..4]);
         Ok(Self { raw })
     }
 }
+
 
 /// Bar
 ///
@@ -178,7 +174,7 @@ pub struct Bar {
 
 impl Bar {
     pub const MESSAGE_ID: u32 = 512;
-
+    
     /// Construct new Bar from values
     pub fn new(one: u8, two: f32, three: u8, four: u8, five: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 8] };
@@ -189,12 +185,12 @@ impl Bar {
         res.set_five(five)?;
         Ok(res)
     }
-
+    
     /// Access message payload raw value
     pub fn raw(&self) -> &[u8] {
         &self.raw
     }
-
+    
     /// One
     ///
     /// - Min: 0
@@ -205,7 +201,7 @@ impl Bar {
     pub fn one(&self) -> u8 {
         self.one_raw()
     }
-
+    
     /// Get raw value of One
     ///
     /// - Start bit: 15
@@ -217,23 +213,21 @@ impl Bar {
     #[inline(always)]
     pub fn one_raw(&self) -> u8 {
         let signal = u8::unpack_be_bits(&self.raw, (15 - (2 - 1)), 2);
-
+        
         signal
     }
-
+    
     /// Set value of One
     #[inline(always)]
     pub fn set_one(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_u8 || 3_u8 < value {
-            return Err(CanError::ParameterOutOfRange { message_id: 512 });
-        }
+        if value < 0_u8 || 3_u8 < value { return Err(CanError::ParameterOutOfRange{ message_id: 512 }); }
         let start_bit = 15;
         let bits = 2;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-
+    
     /// Two
     ///
     /// - Min: 0
@@ -244,7 +238,7 @@ impl Bar {
     pub fn two(&self) -> f32 {
         self.two_raw()
     }
-
+    
     /// Get raw value of Two
     ///
     /// - Start bit: 7
@@ -256,29 +250,27 @@ impl Bar {
     #[inline(always)]
     pub fn two_raw(&self) -> f32 {
         let signal = u8::unpack_be_bits(&self.raw, (7 - (8 - 1)), 8);
-
+        
         let factor = 0.39_f32;
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-
+    
     /// Set value of Two
     #[inline(always)]
     pub fn set_two(&mut self, value: f32) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_f32 || 100_f32 < value {
-            return Err(CanError::ParameterOutOfRange { message_id: 512 });
-        }
+        if value < 0_f32 || 100_f32 < value { return Err(CanError::ParameterOutOfRange{ message_id: 512 }); }
         let factor = 0.39_f32;
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u8;
-
+        
         let start_bit = 7;
         let bits = 8;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-
+    
     /// Three
     ///
     /// - Min: 0
@@ -295,7 +287,7 @@ impl Bar {
             x => BarThree::Other(x),
         }
     }
-
+    
     /// Get raw value of Three
     ///
     /// - Start bit: 13
@@ -307,23 +299,21 @@ impl Bar {
     #[inline(always)]
     pub fn three_raw(&self) -> u8 {
         let signal = u8::unpack_be_bits(&self.raw, (13 - (3 - 1)), 3);
-
+        
         signal
     }
-
+    
     /// Set value of Three
     #[inline(always)]
     pub fn set_three(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_u8 || 7_u8 < value {
-            return Err(CanError::ParameterOutOfRange { message_id: 512 });
-        }
+        if value < 0_u8 || 7_u8 < value { return Err(CanError::ParameterOutOfRange{ message_id: 512 }); }
         let start_bit = 13;
         let bits = 3;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-
+    
     /// Four
     ///
     /// - Min: 0
@@ -340,7 +330,7 @@ impl Bar {
             x => BarFour::Other(x),
         }
     }
-
+    
     /// Get raw value of Four
     ///
     /// - Start bit: 10
@@ -352,23 +342,21 @@ impl Bar {
     #[inline(always)]
     pub fn four_raw(&self) -> u8 {
         let signal = u8::unpack_be_bits(&self.raw, (10 - (2 - 1)), 2);
-
+        
         signal
     }
-
+    
     /// Set value of Four
     #[inline(always)]
     pub fn set_four(&mut self, value: u8) -> Result<(), CanError> {
         #[cfg(feature = "range_checked")]
-        if value < 0_u8 || 3_u8 < value {
-            return Err(CanError::ParameterOutOfRange { message_id: 512 });
-        }
+        if value < 0_u8 || 3_u8 < value { return Err(CanError::ParameterOutOfRange{ message_id: 512 }); }
         let start_bit = 10;
         let bits = 2;
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
-
+    
     /// Five
     ///
     /// - Min: 0
@@ -376,10 +364,16 @@ impl Bar {
     /// - Unit: "boolean"
     /// - Receivers: Dolor
     #[inline(always)]
-    pub fn five(&self) -> bool {
-        self.five_raw()
+    pub fn five(&self) -> BarFive {
+        match self.five_raw() {
+            false => BarFive::X0off,
+            true => BarFive::X1on,
+            false => BarFive::X2oner,
+            false => BarFive::X3onest,
+            x => BarFive::Other(x),
+        }
     }
-
+    
     /// Get raw value of Five
     ///
     /// - Start bit: 30
@@ -391,10 +385,10 @@ impl Bar {
     #[inline(always)]
     pub fn five_raw(&self) -> bool {
         let signal = u8::unpack_be_bits(&self.raw, (30 - (1 - 1)), 1);
-
+        
         signal == 1
     }
-
+    
     /// Set value of Five
     #[inline(always)]
     pub fn set_five(&mut self, value: bool) -> Result<(), CanError> {
@@ -404,16 +398,15 @@ impl Bar {
         value.pack_be_bits(&mut self.raw, start_bit, bits);
         Ok(())
     }
+    
 }
 
 impl core::convert::TryFrom<&[u8]> for Bar {
     type Error = CanError;
-
+    
     #[inline(always)]
     fn try_from(payload: &[u8]) -> Result<Self, Self::Error> {
-        if payload.len() != 8 {
-            return Err(CanError::InvalidPayloadSize);
-        }
+        if payload.len() != 8 { return Err(CanError::InvalidPayloadSize); }
         let mut raw = [0u8; 8];
         raw.copy_from_slice(&payload[..8]);
         Ok(Self { raw })
@@ -440,6 +433,17 @@ pub enum BarFour {
     Onest,
     Other(u8),
 }
+/// Defined values for Five
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub enum BarFive {
+    X0off,
+    X1on,
+    X2oner,
+    X3onest,
+    Other(bool),
+}
+
 
 /// This is just to make testing easier
 fn main() {}
@@ -456,3 +460,4 @@ pub enum CanError {
     },
     InvalidPayloadSize,
 }
+

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -5,7 +5,7 @@ NS_ :
 
 BS_:
 
-BU_: Lorem Ipsum Dolor 
+BU_: Lorem Ipsum Dolor
 
 
 BO_ 256 Foo: 4 Lorem
@@ -29,3 +29,4 @@ BO_ 512 Bar: 8 Ipsum
 
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";
 VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";
+VAL_ 512 Five 0 "0Off" 1 "1On" 2 "2Oner" 3 "3Onest";

--- a/testing/dbc-examples/example.kcd
+++ b/testing/dbc-examples/example.kcd
@@ -3,7 +3,7 @@
   <Node name="Lorem" id="1"/>
   <Node name="Ipsum" id="2"/>
   <Node name="Dolor" id="3"/>
-  <Bus name="Example">
+  <Bus name="testing/dbc-examples/example">
     <Message id="0x100" name="Foo" length="4">
       <Notes></Notes>
       <Producer>
@@ -38,6 +38,12 @@
           <NodeRef id="3"/>
         </Consumer>
         <Value max="7"/>
+        <LabelSet>
+          <Label name="OFF" value="0"/>
+          <Label name="ON" value="1"/>
+          <Label name="ONER" value="2"/>
+          <Label name="ONEST" value="3"/>
+        </LabelSet>
       </Signal>
       <Signal name="Four" offset="13" length="2" endianess="big">
         <Consumer>
@@ -49,6 +55,18 @@
           <Label name="On" value="1"/>
           <Label name="Oner" value="2"/>
           <Label name="Onest" value="3"/>
+        </LabelSet>
+      </Signal>
+      <Signal name="Five" offset="25" endianess="big">
+        <Consumer>
+          <NodeRef id="3"/>
+        </Consumer>
+        <Value unit="boolean"/>
+        <LabelSet>
+          <Label name="0Off" value="0"/>
+          <Label name="1On" value="1"/>
+          <Label name="2Oner" value="2"/>
+          <Label name="3Onest" value="3"/>
         </LabelSet>
       </Signal>
     </Message>


### PR DESCRIPTION
I have a dbc file which contains:
```
VAL_ 1162 TSGN3 0 "none" 1 "speed sign" 2 "0 unlimited" 7 "unlimited" 16 "highway" 17 "no highway" 18 "motorway" 19 "no motorway" 20 "in city" 21 "outside city" 22 "pedestrian area" 23 "no pedestrian area" 65 "no overtaking left" 66 "no overtaking right" 67 "overtaking allowed again" 129 "no entry";
```

Currently it generates:
```rust
#[derive(Clone, Copy, PartialEq)]
#[cfg_attr(feature = "debug", derive(Debug))]
pub enum Rsa2Tsgn3 {
    None,
    SpeedSign,
    0Unlimited,
    Unlimited,
    Highway,
    NoHighway,
...
```
Notice `0Unlimited` which is not allowed in Rust.

This PR prepends `X` to such enum fields. So it becomes:
```rust
#[derive(Clone, Copy, PartialEq)]
#[cfg_attr(feature = "debug", derive(Debug))]
pub enum Rsa2Tsgn3 {
    None,
    SpeedSign,
    X0Unlimited,
    Unlimited,
    Highway,
    NoHighway,
...
```