### PR TITLE
Prepend x to rust keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ pub fn xtype(&self) -> BarType {
     match self.xtype_raw() {
         false => BarType::X0off,
         true => BarType::X1on,
-        false => BarType::X2oner,
-        false => BarType::Type,
         x => BarType::Other(x),
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,14 +4,48 @@ Generates Rust messages from a `dbc` file.
 
 ⚠️ This is experimental - use with caution. Breaking changes will happen when you least expect it. ⚠️
 
-# Usage
+## Usage
 
 Generate `messages.rs` from `example.dbc`.
 ```bash
 cargo run -- testing/dbc-examples/example.dbc dir/where/messages_rs/file/is/written
 ```
 
-# Development
+If some field name starts with a non-alphabetic character or is a Rust keyword then it is prepended with `x`.
+
+For example:
+```
+VAL_ 512 Five 0 "0Off" 1 "1On" 2 "2Oner" 3 "3Onest";
+```
+..is generated to:
+```rust
+pub enum BarFive {
+    X0off,
+    X1on,
+    X2oner,
+    X3onest,
+    Other(bool),
+}
+```
+
+`Type` here:
+```
+SG_ Type : 30|1@0+ (1,0) [0|1] "boolean" Dolor
+```
+..would become Rust keyword `type` therefore it is prepended with `x`:
+```rust
+pub fn xtype(&self) -> BarType {
+    match self.xtype_raw() {
+        false => BarType::X0off,
+        true => BarType::X1on,
+        false => BarType::X2oner,
+        false => BarType::Type,
+        x => BarType::Other(x),
+    }
+}
+```
+
+## Development
 
 ```bash
 # generate messages.rs
@@ -27,7 +61,7 @@ cargo test --all
 cargo fmt --all
 ```
 
-## Generate .kdc from .dbc
+### Generate .kdc from .dbc
 
 Use [canmatrix](https://github.com/ebroecker/canmatrix) if you need to generate a new `.kcd` file from a `.dbc`.
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1,0 +1,23 @@
+// https://doc.rust-lang.org/stable/reference/keywords.html
+const KEYWORDS: [&str; 52] = [
+    "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
+    "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
+    "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe", "use", "where",
+    "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
+    "override", "priv", "typeof", "unsized", "virtual", "yield", "try", "union",
+];
+
+pub fn is_keyword(x: &str) -> bool {
+    KEYWORDS.contains(&x.to_lowercase().as_str())
+}
+
+#[test]
+fn value_is_a_keyword() {
+    assert!(is_keyword("type"));
+    assert!(is_keyword("TYPE"));
+}
+
+#[test]
+fn value_is_not_a_keyword() {
+    assert!(!is_keyword("rpms"));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::{fs::File, io::BufWriter, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
 mod includes;
+mod keywords;
 mod pad;
 
 #[derive(Debug, StructOpt)]
@@ -522,7 +523,11 @@ fn type_name(x: &str) -> String {
 }
 
 fn field_name(x: &str) -> String {
-    x.to_snake_case()
+    if keywords::is_keyword(x) {
+        format!("x{}", x.to_snake_case())
+    } else {
+        x.to_snake_case()
+    }
 }
 
 fn enum_name(msg: &Message, signal: &Signal) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -523,7 +523,7 @@ fn type_name(x: &str) -> String {
 }
 
 fn field_name(x: &str) -> String {
-    if keywords::is_keyword(x) {
+    if keywords::is_keyword(x) || !x.starts_with(|c: char| c.is_ascii_alphabetic()) {
         format!("x{}", x.to_snake_case())
     } else {
         x.to_snake_case()

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -180,13 +180,13 @@ impl Bar {
     pub const MESSAGE_ID: u32 = 512;
 
     /// Construct new Bar from values
-    pub fn new(one: u8, two: f32, three: u8, four: u8, five: bool) -> Result<Self, CanError> {
+    pub fn new(one: u8, two: f32, three: u8, four: u8, xtype: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 8] };
         res.set_one(one)?;
         res.set_two(two)?;
         res.set_three(three)?;
         res.set_four(four)?;
-        res.set_five(five)?;
+        res.set_xtype(xtype)?;
         Ok(res)
     }
 
@@ -369,24 +369,24 @@ impl Bar {
         Ok(())
     }
 
-    /// Five
+    /// Type
     ///
     /// - Min: 0
     /// - Max: 1
     /// - Unit: "boolean"
     /// - Receivers: Dolor
     #[inline(always)]
-    pub fn five(&self) -> BarFive {
-        match self.five_raw() {
-            false => BarFive::X0off,
-            true => BarFive::X1on,
-            false => BarFive::X2oner,
-            false => BarFive::X3onest,
-            x => BarFive::Other(x),
+    pub fn xtype(&self) -> BarType {
+        match self.xtype_raw() {
+            false => BarType::X0off,
+            true => BarType::X1on,
+            false => BarType::X2oner,
+            false => BarType::Type,
+            x => BarType::Other(x),
         }
     }
 
-    /// Get raw value of Five
+    /// Get raw value of Type
     ///
     /// - Start bit: 30
     /// - Signal size: 1 bits
@@ -395,15 +395,15 @@ impl Bar {
     /// - Byte order: BigEndian
     /// - Value type: Unsigned
     #[inline(always)]
-    pub fn five_raw(&self) -> bool {
+    pub fn xtype_raw(&self) -> bool {
         let signal = u8::unpack_be_bits(&self.raw, (30 - (1 - 1)), 1);
 
         signal == 1
     }
 
-    /// Set value of Five
+    /// Set value of Type
     #[inline(always)]
-    pub fn set_five(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_xtype(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         let start_bit = 30;
         let bits = 1;
@@ -446,14 +446,14 @@ pub enum BarFour {
     Onest,
     Other(u8),
 }
-/// Defined values for Five
+/// Defined values for Type
 #[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
-pub enum BarFive {
+pub enum BarType {
     X0off,
     X1on,
     X2oner,
-    X3onest,
+    Type,
     Other(bool),
 }
 

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -380,8 +380,6 @@ impl Bar {
         match self.xtype_raw() {
             false => BarType::X0off,
             true => BarType::X1on,
-            false => BarType::X2oner,
-            false => BarType::Type,
             x => BarType::Other(x),
         }
     }
@@ -452,8 +450,6 @@ pub enum BarFour {
 pub enum BarType {
     X0off,
     X1on,
-    X2oner,
-    Type,
     Other(bool),
 }
 

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -17,7 +17,7 @@ BO_ 512 Bar: 8 Ipsum
  SG_ Two : 7|8@0+ (0.39,0) [0.00|100] "%" Dolor
  SG_ Three : 13|3@0+ (1,0) [0|7] "" Dolor
  SG_ Four : 10|2@0+ (1,0) [0|3] "" Dolor
- SG_ Five : 30|1@0+ (1,0) [0|1] "boolean" Dolor
+ SG_ Type : 30|1@0+ (1,0) [0|1] "boolean" Dolor
 
 
 
@@ -29,4 +29,4 @@ BO_ 512 Bar: 8 Ipsum
 
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";
 VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";
-VAL_ 512 Five 0 "0Off" 1 "1On" 2 "2Oner" 3 "3Onest";
+VAL_ 512 Type 0 "0Off" 1 "1On" 2 "2Oner" 3 "TYPE";

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -29,4 +29,4 @@ BO_ 512 Bar: 8 Ipsum
 
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";
 VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";
-VAL_ 512 Type 0 "0Off" 1 "1On" 2 "2Oner" 3 "TYPE";
+VAL_ 512 Type 0 "0Off" 1 "1On";

--- a/testing/dbc-examples/example.kcd
+++ b/testing/dbc-examples/example.kcd
@@ -57,7 +57,7 @@
           <Label name="Onest" value="3"/>
         </LabelSet>
       </Signal>
-      <Signal name="Five" offset="25" endianess="big">
+      <Signal name="Type" offset="25" endianess="big">
         <Consumer>
           <NodeRef id="3"/>
         </Consumer>
@@ -66,7 +66,7 @@
           <Label name="0Off" value="0"/>
           <Label name="1On" value="1"/>
           <Label name="2Oner" value="2"/>
-          <Label name="3Onest" value="3"/>
+          <Label name="TYPE" value="3"/>
         </LabelSet>
       </Signal>
     </Message>

--- a/testing/dbc-examples/example.kcd
+++ b/testing/dbc-examples/example.kcd
@@ -65,8 +65,6 @@
         <LabelSet>
           <Label name="0Off" value="0"/>
           <Label name="1On" value="1"/>
-          <Label name="2Oner" value="2"/>
-          <Label name="TYPE" value="3"/>
         </LabelSet>
       </Signal>
     </Message>


### PR DESCRIPTION
There are cases where some fields in in `dbc` can be Rust keywords. This PR prepends `x` to such fields. So `type` would become `xtype` etc.