### PR TITLE
Fix start and end bit of big endian encoding

### DIFF
--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -8,7 +8,7 @@
 
 #[cfg(feature = "arb")]
 use arbitrary::{Arbitrary, Unstructured};
-use bitvec::prelude::{BitField, BitStore, BitView, LocalBits};
+use bitvec::prelude::{BitField, BitStore, BitView, Lsb0, Msb0};
 
 /// All messages
 #[derive(Clone)]
@@ -20,6 +20,8 @@ pub enum Messages {
     Bar(Bar),
     /// Amet
     Amet(Amet),
+    /// Dolor
+    Dolor(Dolor),
 }
 
 impl Messages {
@@ -32,6 +34,7 @@ impl Messages {
             256 => Messages::Foo(Foo::try_from(payload)?),
             512 => Messages::Bar(Bar::try_from(payload)?),
             1024 => Messages::Amet(Amet::try_from(payload)?),
+            1028 => Messages::Dolor(Dolor::try_from(payload)?),
             n => return Err(CanError::UnknownMessageId(n)),
         };
         Ok(res)
@@ -86,7 +89,7 @@ impl Foo {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn voltage_raw(&self) -> f32 {
-        let signal = self.raw.view_bits::<LocalBits>()[16..32].load_le::<u16>();
+        let signal = self.raw.view_bits::<Lsb0>()[16..32].load_le::<u16>();
 
         let factor = 0.000976562_f32;
         let offset = 0_f32;
@@ -104,7 +107,7 @@ impl Foo {
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u16;
 
-        self.raw.view_bits_mut::<LocalBits>()[16..32].store_le(value);
+        self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
 
@@ -129,7 +132,7 @@ impl Foo {
     /// - Value type: Signed
     #[inline(always)]
     pub fn current_raw(&self) -> f32 {
-        let signal = self.raw.view_bits::<LocalBits>()[0..16].load_le::<u16>();
+        let signal = self.raw.view_bits::<Lsb0>()[0..16].load_le::<u16>();
 
         let signal = i16::from_ne_bytes(signal.to_ne_bytes());
         let factor = 0.0625_f32;
@@ -149,7 +152,7 @@ impl Foo {
         let value = ((value - offset) / factor) as i16;
 
         let value = u16::from_ne_bytes(value.to_ne_bytes());
-        self.raw.view_bits_mut::<LocalBits>()[0..16].store_le(value);
+        self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
         Ok(())
     }
 }
@@ -228,7 +231,7 @@ impl Bar {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn one_raw(&self) -> u8 {
-        let signal = self.raw.view_bits::<LocalBits>()[14..16].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[8..10].load_be::<u8>();
 
         signal
     }
@@ -240,7 +243,7 @@ impl Bar {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange { message_id: 512 });
         }
-        self.raw.view_bits_mut::<LocalBits>()[14..16].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[8..10].store_be(value);
         Ok(())
     }
 
@@ -265,7 +268,7 @@ impl Bar {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn two_raw(&self) -> f32 {
-        let signal = self.raw.view_bits::<LocalBits>()[0..8].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[0..8].load_be::<u8>();
 
         let factor = 0.39_f32;
         let offset = 0_f32;
@@ -283,7 +286,7 @@ impl Bar {
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u8;
 
-        self.raw.view_bits_mut::<LocalBits>()[0..8].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[0..8].store_be(value);
         Ok(())
     }
 
@@ -314,7 +317,7 @@ impl Bar {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn three_raw(&self) -> u8 {
-        let signal = self.raw.view_bits::<LocalBits>()[11..14].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[10..13].load_be::<u8>();
 
         signal
     }
@@ -326,7 +329,7 @@ impl Bar {
         if value < 0_u8 || 7_u8 < value {
             return Err(CanError::ParameterOutOfRange { message_id: 512 });
         }
-        self.raw.view_bits_mut::<LocalBits>()[11..14].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[10..13].store_be(value);
         Ok(())
     }
 
@@ -357,7 +360,7 @@ impl Bar {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn four_raw(&self) -> u8 {
-        let signal = self.raw.view_bits::<LocalBits>()[9..11].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[13..15].load_be::<u8>();
 
         signal
     }
@@ -369,7 +372,7 @@ impl Bar {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange { message_id: 512 });
         }
-        self.raw.view_bits_mut::<LocalBits>()[9..11].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[13..15].store_be(value);
         Ok(())
     }
 
@@ -398,7 +401,7 @@ impl Bar {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn xtype_raw(&self) -> bool {
-        let signal = self.raw.view_bits::<LocalBits>()[30..31].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[25..26].load_be::<u8>();
 
         signal == 1
     }
@@ -407,7 +410,7 @@ impl Bar {
     #[inline(always)]
     pub fn set_xtype(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
-        self.raw.view_bits_mut::<LocalBits>()[30..31].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[25..26].store_be(value);
         Ok(())
     }
 }
@@ -517,7 +520,7 @@ impl Amet {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn one_raw(&self) -> u8 {
-        let signal = self.raw.view_bits::<LocalBits>()[14..16].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[8..10].load_be::<u8>();
 
         signal
     }
@@ -529,7 +532,7 @@ impl Amet {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange { message_id: 1024 });
         }
-        self.raw.view_bits_mut::<LocalBits>()[14..16].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[8..10].store_be(value);
         Ok(())
     }
 
@@ -554,7 +557,7 @@ impl Amet {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn two_raw(&self) -> f32 {
-        let signal = self.raw.view_bits::<LocalBits>()[0..8].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[0..8].load_be::<u8>();
 
         let factor = 0.39_f32;
         let offset = 0_f32;
@@ -572,7 +575,7 @@ impl Amet {
         let offset = 0_f32;
         let value = ((value - offset) / factor) as u8;
 
-        self.raw.view_bits_mut::<LocalBits>()[0..8].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[0..8].store_be(value);
         Ok(())
     }
 
@@ -597,7 +600,7 @@ impl Amet {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn three_raw(&self) -> u8 {
-        let signal = self.raw.view_bits::<LocalBits>()[18..21].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[19..22].load_be::<u8>();
 
         signal
     }
@@ -609,7 +612,7 @@ impl Amet {
         if value < 0_u8 || 7_u8 < value {
             return Err(CanError::ParameterOutOfRange { message_id: 1024 });
         }
-        self.raw.view_bits_mut::<LocalBits>()[18..21].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[19..22].store_be(value);
         Ok(())
     }
 
@@ -634,7 +637,7 @@ impl Amet {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn four_raw(&self) -> u8 {
-        let signal = self.raw.view_bits::<LocalBits>()[29..31].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[25..27].load_be::<u8>();
 
         signal
     }
@@ -646,7 +649,7 @@ impl Amet {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange { message_id: 1024 });
         }
-        self.raw.view_bits_mut::<LocalBits>()[29..31].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[25..27].store_be(value);
         Ok(())
     }
 
@@ -671,7 +674,7 @@ impl Amet {
     /// - Value type: Unsigned
     #[inline(always)]
     pub fn five_raw(&self) -> bool {
-        let signal = self.raw.view_bits::<LocalBits>()[40..41].load_be::<u8>();
+        let signal = self.raw.view_bits::<Msb0>()[47..48].load_be::<u8>();
 
         signal == 1
     }
@@ -680,7 +683,7 @@ impl Amet {
     #[inline(always)]
     pub fn set_five(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
-        self.raw.view_bits_mut::<LocalBits>()[40..41].store_be(value);
+        self.raw.view_bits_mut::<Msb0>()[47..48].store_be(value);
         Ok(())
     }
 }
@@ -708,6 +711,92 @@ impl<'a> Arbitrary<'a> for Amet {
         let four = u.int_in_range(0..=3)?;
         let five = u.int_in_range(0..=1)? == 1;
         Amet::new(one, two, three, four, five).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
+/// Dolor
+///
+/// - ID: 1028 (0x404)
+/// - Size: 8 bytes
+/// - Transmitter: Sit
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct Dolor {
+    raw: [u8; 8],
+}
+
+impl Dolor {
+    pub const MESSAGE_ID: u32 = 1028;
+
+    /// Construct new Dolor from values
+    pub fn new(one_float: u16) -> Result<Self, CanError> {
+        let mut res = Self { raw: [0u8; 8] };
+        res.set_one_float(one_float)?;
+        Ok(res)
+    }
+
+    /// Access message payload raw value
+    pub fn raw(&self) -> &[u8] {
+        &self.raw
+    }
+
+    /// OneFloat
+    ///
+    /// - Min: 0
+    /// - Max: 130
+    /// - Unit: ""
+    /// - Receivers: Vector__XXX
+    #[inline(always)]
+    pub fn one_float(&self) -> u16 {
+        self.one_float_raw()
+    }
+
+    /// Get raw value of OneFloat
+    ///
+    /// - Start bit: 0
+    /// - Signal size: 12 bits
+    /// - Factor: 1
+    /// - Offset: 0
+    /// - Byte order: BigEndian
+    /// - Value type: Unsigned
+    #[inline(always)]
+    pub fn one_float_raw(&self) -> u16 {
+        let signal = self.raw.view_bits::<Msb0>()[7..19].load_be::<u16>();
+
+        signal
+    }
+
+    /// Set value of OneFloat
+    #[inline(always)]
+    pub fn set_one_float(&mut self, value: u16) -> Result<(), CanError> {
+        #[cfg(feature = "range_checked")]
+        if value < 0_u16 || 130_u16 < value {
+            return Err(CanError::ParameterOutOfRange { message_id: 1028 });
+        }
+        self.raw.view_bits_mut::<Msb0>()[7..19].store_be(value);
+        Ok(())
+    }
+}
+
+impl core::convert::TryFrom<&[u8]> for Dolor {
+    type Error = CanError;
+
+    #[inline(always)]
+    fn try_from(payload: &[u8]) -> Result<Self, Self::Error> {
+        if payload.len() != 8 {
+            return Err(CanError::InvalidPayloadSize);
+        }
+        let mut raw = [0u8; 8];
+        raw.copy_from_slice(&payload[..8]);
+        Ok(Self { raw })
+    }
+}
+
+#[cfg(feature = "arb")]
+impl<'a> Arbitrary<'a> for Dolor {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
+        let one_float = u.int_in_range(0..=130)?;
+        Dolor::new(one_float).map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 

--- a/testing/cantools-messages/example.c
+++ b/testing/cantools-messages/example.c
@@ -385,3 +385,52 @@ bool example_amet_five_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
+
+int example_dolor_pack(
+    uint8_t *dst_p,
+    const struct example_dolor_t *src_p,
+    size_t size)
+{
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    memset(&dst_p[0], 0, 8);
+
+    dst_p[0] |= pack_right_shift_u16(src_p->one_float, 11u, 0x01u);
+    dst_p[1] |= pack_right_shift_u16(src_p->one_float, 3u, 0xffu);
+    dst_p[2] |= pack_left_shift_u16(src_p->one_float, 5u, 0xe0u);
+
+    return (8);
+}
+
+int example_dolor_unpack(
+    struct example_dolor_t *dst_p,
+    const uint8_t *src_p,
+    size_t size)
+{
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    dst_p->one_float = unpack_left_shift_u16(src_p[0], 11u, 0x01u);
+    dst_p->one_float |= unpack_left_shift_u16(src_p[1], 3u, 0xffu);
+    dst_p->one_float |= unpack_right_shift_u16(src_p[2], 5u, 0xe0u);
+
+    return (0);
+}
+
+uint16_t example_dolor_one_float_encode(double value)
+{
+    return (uint16_t)(value);
+}
+
+double example_dolor_one_float_decode(uint16_t value)
+{
+    return ((double)value);
+}
+
+bool example_dolor_one_float_is_in_range(uint16_t value)
+{
+    return (value <= 130u);
+}

--- a/testing/cantools-messages/example.h
+++ b/testing/cantools-messages/example.h
@@ -47,16 +47,19 @@ extern "C" {
 #define EXAMPLE_FOO_FRAME_ID (0x100u)
 #define EXAMPLE_BAR_FRAME_ID (0x200u)
 #define EXAMPLE_AMET_FRAME_ID (0x400u)
+#define EXAMPLE_DOLOR_FRAME_ID (0x404u)
 
 /* Frame lengths in bytes. */
 #define EXAMPLE_FOO_LENGTH (4u)
 #define EXAMPLE_BAR_LENGTH (8u)
 #define EXAMPLE_AMET_LENGTH (8u)
+#define EXAMPLE_DOLOR_LENGTH (8u)
 
 /* Extended or standard frame types. */
 #define EXAMPLE_FOO_IS_EXTENDED (0)
 #define EXAMPLE_BAR_IS_EXTENDED (0)
 #define EXAMPLE_AMET_IS_EXTENDED (0)
+#define EXAMPLE_DOLOR_IS_EXTENDED (0)
 
 /* Frame cycle times in milliseconds. */
 
@@ -178,6 +181,20 @@ struct example_amet_t {
      * Offset: 0
      */
     uint8_t five;
+};
+
+/**
+ * Signals in message Dolor.
+ *
+ * All signal values are as on the CAN bus.
+ */
+struct example_dolor_t {
+    /**
+     * Range: 0..130 (0.00..130.00 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint16_t one_float;
 };
 
 /**
@@ -587,6 +604,61 @@ double example_amet_five_decode(uint8_t value);
  * @return true if in range, false otherwise.
  */
 bool example_amet_five_is_in_range(uint8_t value);
+
+/**
+ * Pack message Dolor.
+ *
+ * @param[out] dst_p Buffer to pack the message into.
+ * @param[in] src_p Data to pack.
+ * @param[in] size Size of dst_p.
+ *
+ * @return Size of packed data, or negative error code.
+ */
+int example_dolor_pack(
+    uint8_t *dst_p,
+    const struct example_dolor_t *src_p,
+    size_t size);
+
+/**
+ * Unpack message Dolor.
+ *
+ * @param[out] dst_p Object to unpack the message into.
+ * @param[in] src_p Message to unpack.
+ * @param[in] size Size of src_p.
+ *
+ * @return zero(0) or negative error code.
+ */
+int example_dolor_unpack(
+    struct example_dolor_t *dst_p,
+    const uint8_t *src_p,
+    size_t size);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint16_t example_dolor_one_float_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double example_dolor_one_float_decode(uint16_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool example_dolor_one_float_is_in_range(uint16_t value);
 
 
 #ifdef __cplusplus

--- a/testing/cantools-messages/src/lib.rs
+++ b/testing/cantools-messages/src/lib.rs
@@ -48,3 +48,14 @@ fn pack_message_signed_positive() {
     unsafe { example_foo_pack(buffer.as_mut_ptr(), &foo, buffer.len() as u64) };
     assert_eq!(dbc_codegen_foo.raw(), buffer);
 }
+
+#[test]
+fn pack_big_endian_signal_with_start_bit_zero() {
+    let dbc_codegen_bar = can_messages::Dolor::new(1).unwrap();
+    let one_float = unsafe { example_dolor_one_float_encode(1.0) };
+
+    let dolor = example_dolor_t { one_float };
+    let mut buffer: [u8; 8] = [0; 8];
+    unsafe { example_dolor_pack(buffer.as_mut_ptr(), &dolor, buffer.len() as u64) };
+    assert_eq!(dbc_codegen_bar.raw(), buffer);
+}

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -26,12 +26,8 @@ BO_ 1024 Amet: 8 Sit
  SG_ Four : 30|2@0+ (1,0) [0|3] "" Dolor
  SG_ Five : 40|1@0+ (1,0) [0|1] "boolean" Dolor
 
-
-
-
-
-
-
+BO_ 1028 Dolor: 8 Sit
+ SG_ OneFloat : 0|12@0+ (1,0) [0.00|130.00] "" Vector__XXX
 
 
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";


### PR DESCRIPTION
So currently there is a bug where signals such as the following will panic with a subtraction overflow (signal size is greater than signal start). So I have looked into cantools again and found [this](https://github.com/eerimoq/cantools/blob/2456630adcf7f4277f9fb47d4e3ee03a7138be66/cantools/database/can/formats/sym.py#L421). I actually thought I had understood how it works but apparently I don't.  Looks like it was basically a coincidence that the previous tests worked when comparing the packing results between dbc-codegen and cantools. I have added a new message/signal that would otherwise fail without the fix.

I assume @bitbleep can judge best on this fix.

```
SG_ OneFloat : 0|12@0+ (1,0) [0.00|130.00] "" Vector__XXX
```