### PR TITLE
Manually implement debug to support `:#?` 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub fn codegen(dbc_name: &str, dbc_content: &[u8], out: impl Write, debug: bool)
     writeln!(&mut w, "#![allow(clippy::let_and_return, clippy::eq_op)]")?;
     writeln!(
         &mut w,
-        "#![allow(clippy::excessive_precision, clippy::manual_range_contains, absurd_extreme_comparisons)]"
+        "#![allow(clippy::excessive_precision, clippy::manual_range_contains, clippy::absurd_extreme_comparisons)]"
     )?;
     writeln!(&mut w, "#![deny(clippy::integer_arithmetic)]")?;
     writeln!(&mut w)?;

--- a/testing/can-messages/Cargo.toml
+++ b/testing/can-messages/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 dbc-codegen = { path = "../../" }
 
 [features]
-default = ["debug", "arb"]
+default = ["debug", "arb", "range_checked"]
 arb = ["arbitrary"]
 debug = []
 range_checked = []

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -1,6 +1,11 @@
 // Generated code!
-#![no_std]
-#![allow(unused, clippy::let_and_return, clippy::eq_op)]
+#![allow(unused_comparisons, unreachable_patterns)]
+#![allow(clippy::let_and_return, clippy::eq_op)]
+#![allow(
+    clippy::excessive_precision,
+    clippy::manual_range_contains,
+    clippy::absurd_extreme_comparisons
+)]
 #![deny(clippy::integer_arithmetic)]
 
 //! Message definitions from file `"example.dbc"`
@@ -9,7 +14,7 @@
 
 #[cfg(feature = "arb")]
 use arbitrary::{Arbitrary, Unstructured};
-use bitvec::prelude::{BitField, BitStore, BitView, Lsb0, Msb0};
+use bitvec::prelude::{BitField, BitView, Lsb0, Msb0};
 
 /// All messages
 #[derive(Clone)]
@@ -48,7 +53,6 @@ impl Messages {
 /// - Size: 4 bytes
 /// - Transmitter: Lorem
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Foo {
     raw: [u8; 4],
 }
@@ -172,6 +176,20 @@ impl core::convert::TryFrom<&[u8]> for Foo {
     }
 }
 
+#[cfg(feature = "debug")]
+impl core::fmt::Debug for Foo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if f.alternate() {
+            f.debug_struct("Foo")
+                .field("voltage", &self.voltage())
+                .field("current", &self.current())
+                .finish()
+        } else {
+            f.debug_tuple("Foo").field(&self.raw).finish()
+        }
+    }
+}
+
 #[cfg(feature = "arb")]
 impl<'a> Arbitrary<'a> for Foo {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
@@ -187,7 +205,6 @@ impl<'a> Arbitrary<'a> for Foo {
 /// - Size: 8 bytes
 /// - Transmitter: Ipsum
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Bar {
     raw: [u8; 8],
 }
@@ -430,6 +447,23 @@ impl core::convert::TryFrom<&[u8]> for Bar {
     }
 }
 
+#[cfg(feature = "debug")]
+impl core::fmt::Debug for Bar {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if f.alternate() {
+            f.debug_struct("Bar")
+                .field("one", &self.one())
+                .field("two", &self.two())
+                .field("three", &self.three())
+                .field("four", &self.four())
+                .field("xtype", &self.xtype())
+                .finish()
+        } else {
+            f.debug_tuple("Bar").field(&self.raw).finish()
+        }
+    }
+}
+
 #[cfg(feature = "arb")]
 impl<'a> Arbitrary<'a> for Bar {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
@@ -476,7 +510,6 @@ pub enum BarType {
 /// - Size: 8 bytes
 /// - Transmitter: Sit
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Amet {
     raw: [u8; 8],
 }
@@ -703,6 +736,23 @@ impl core::convert::TryFrom<&[u8]> for Amet {
     }
 }
 
+#[cfg(feature = "debug")]
+impl core::fmt::Debug for Amet {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if f.alternate() {
+            f.debug_struct("Amet")
+                .field("one", &self.one())
+                .field("two", &self.two())
+                .field("three", &self.three())
+                .field("four", &self.four())
+                .field("five", &self.five())
+                .finish()
+        } else {
+            f.debug_tuple("Amet").field(&self.raw).finish()
+        }
+    }
+}
+
 #[cfg(feature = "arb")]
 impl<'a> Arbitrary<'a> for Amet {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
@@ -721,7 +771,6 @@ impl<'a> Arbitrary<'a> for Amet {
 /// - Size: 8 bytes
 /// - Transmitter: Sit
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Dolor {
     raw: [u8; 8],
 }
@@ -793,6 +842,19 @@ impl core::convert::TryFrom<&[u8]> for Dolor {
     }
 }
 
+#[cfg(feature = "debug")]
+impl core::fmt::Debug for Dolor {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if f.alternate() {
+            f.debug_struct("Dolor")
+                .field("one_float", &self.one_float())
+                .finish()
+        } else {
+            f.debug_tuple("Dolor").field(&self.raw).finish()
+        }
+    }
+}
+
 #[cfg(feature = "arb")]
 impl<'a> Arbitrary<'a> for Dolor {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
@@ -802,6 +864,7 @@ impl<'a> Arbitrary<'a> for Dolor {
 }
 
 /// This is just to make testing easier
+#[allow(dead_code)]
 fn main() {}
 
 #[derive(Clone, Copy, PartialEq)]

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::float_cmp)]
 
-use can_messages as messages;
+use can_messages::{Amet, Bar, CanError, Foo};
 
 #[test]
 #[cfg(feature = "range_checked")]
 fn check_range_value_error() {
-    let result = messages::Bar::new(1, 2.0, 3, 4);
+    let result = Bar::new(1, 2.0, 3, 4, true);
     assert!(matches!(
         result,
         Err(CanError::ParameterOutOfRange { message_id: 512 })
@@ -15,30 +15,49 @@ fn check_range_value_error() {
 #[test]
 #[cfg(feature = "range_checked")]
 fn check_range_value_valid() {
-    let result = messages::Bar::new(1, 2.0, 3, 3);
+    let result = Bar::new(1, 2.0, 3, 3, true);
     assert!(result.is_ok());
 }
 
 #[test]
 fn pack_unpack_message() {
-    let result = messages::Foo::new(63.99899, 10.0).unwrap();
+    let result = Foo::new(63.9990234375, 10.0).unwrap();
     assert_eq!(result.voltage_raw(), 63.99899);
     assert_eq!(result.current_raw(), 10.0);
 }
 
 #[test]
 fn pack_unpack_message_negative() {
-    let result = messages::Foo::new(0.000976562, -3.0 * 0.0625).unwrap();
+    let result = Foo::new(0.000976562, -3.0 * 0.0625).unwrap();
     assert_eq!(result.voltage_raw(), 0.000976562);
     assert_eq!(result.current_raw(), -3.0 * 0.0625);
 }
 
 #[test]
 fn pack_unpack_message2() {
-    let result = messages::Amet::new(1, 0.39, 3, 3, true).unwrap();
+    let result = Amet::new(1, 0.39, 3, 3, true).unwrap();
     assert_eq!(result.one_raw(), 1);
     assert_eq!(result.two_raw(), 0.39);
     assert_eq!(result.three_raw(), 3);
     assert_eq!(result.four_raw(), 3);
     assert_eq!(result.five_raw(), true);
+}
+
+#[test]
+#[cfg(feature = "debug")]
+fn debug_impl() {
+    let result = Bar::new(1, 2.0, 3, 3, true).unwrap();
+    let dbg = format!("{:?}", result);
+    assert_eq!(&dbg, "Bar([5, 94, 0, 64, 0, 0, 0, 0])");
+}
+
+#[test]
+#[cfg(feature = "debug")]
+fn debug_alternative_impl() {
+    let result = Bar::new(1, 2.0, 3, 3, true).unwrap();
+    let dbg = format!("{:#?}", result);
+    assert_eq!(
+        &dbg,
+        "Bar {\n    one: 1,\n    two: 1.9499999,\n    three: Onest,\n    four: Onest,\n    xtype: X1on,\n}"
+    );
 }

--- a/testing/cantools-messages/src/lib.rs
+++ b/testing/cantools-messages/src/lib.rs
@@ -6,11 +6,11 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[test]
 fn pack_message() {
-    let dbc_codegen_bar = can_messages::Bar::new(3, 2.0, 4, 5, false).unwrap();
+    let dbc_codegen_bar = can_messages::Bar::new(3, 2.0, 4, 2, false).unwrap();
     let one = unsafe { example_bar_one_encode(3.0) };
     let two = unsafe { example_bar_two_encode(2.0) };
     let three = unsafe { example_bar_three_encode(4.0) };
-    let four = unsafe { example_bar_four_encode(5.0) };
+    let four = unsafe { example_bar_four_encode(2.0) };
     let type_ = unsafe { example_bar_type_encode(0.0) };
 
     let bar = example_bar_t {


### PR DESCRIPTION
The usual debug now print like a tuple, while the alternative form prints the decoded fields.

Along the way, I also enabled range checks in tests and fixed the fallout from that.

This also adds a couple lint settings, that happen to fix #28.