### PR TITLE
Allow specifying signal enmum default variant name

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1,10 +1,10 @@
 // https://doc.rust-lang.org/stable/reference/keywords.html
-const KEYWORDS: [&str; 52] = [
+const KEYWORDS: [&str; 53] = [
     "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for",
-    "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
-    "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe", "use", "where",
-    "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final", "macro",
-    "override", "priv", "typeof", "unsized", "virtual", "yield", "try", "union",
+    "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "other", "pub", "ref",
+    "return", "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe",
+    "use", "where", "while", "async", "await", "dyn", "abstract", "become", "box", "do", "final",
+    "macro", "override", "priv", "typeof", "unsized", "virtual", "yield", "try", "union",
 ];
 
 pub fn is_keyword(x: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,7 @@ fn write_enum(
         for variant in variants {
             writeln!(w, "{},", enum_variant_name(variant.b()))?;
         }
-        writeln!(w, "Other({}),", signal_rust_type)?;
+        writeln!(w, "XOther({}),", signal_rust_type)?;
     }
     writeln!(w, "}}")?;
     writeln!(w)?;
@@ -586,7 +586,7 @@ fn write_enum(
                         enum_variant_name(variant.b())
                     )?;
                 }
-                writeln!(&mut w, "x => {}::Other(x),", type_name,)?;
+                writeln!(&mut w, "x => {}::XOther(x),", type_name,)?;
             }
             writeln!(w, "}}")?;
         }
@@ -621,7 +621,7 @@ fn write_enum(
                         literal,
                     )?;
                 }
-                writeln!(&mut w, "{}::Other(x) => x,", type_name,)?;
+                writeln!(&mut w, "{}::XOther(x) => x,", type_name,)?;
             }
             writeln!(w, "}}")?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,7 @@ fn write_enum(
         for variant in variants {
             writeln!(w, "{},", enum_variant_name(variant.b()))?;
         }
-        writeln!(w, "XOther({}),", signal_rust_type)?;
+        writeln!(w, "Other({}),", signal_rust_type)?;
     }
     writeln!(w, "}}")?;
     writeln!(w)?;
@@ -586,7 +586,7 @@ fn write_enum(
                         enum_variant_name(variant.b())
                     )?;
                 }
-                writeln!(&mut w, "x => {}::XOther(x),", type_name,)?;
+                writeln!(&mut w, "x => {}::Other(x),", type_name,)?;
             }
             writeln!(w, "}}")?;
         }
@@ -621,7 +621,7 @@ fn write_enum(
                         literal,
                     )?;
                 }
-                writeln!(&mut w, "{}::XOther(x) => x,", type_name,)?;
+                writeln!(&mut w, "{}::Other(x) => x,", type_name,)?;
             }
             writeln!(w, "}}")?;
         }
@@ -696,7 +696,7 @@ fn enum_name(msg: &Message, signal: &Signal) -> String {
 }
 
 fn enum_variant_name(x: &str) -> String {
-    if !x.starts_with(|c: char| c.is_ascii_alphabetic()) {
+    if keywords::is_keyword(x) || !x.starts_with(|c: char| c.is_ascii_alphabetic()) {
         format!("X{}", x.to_camel_case())
     } else {
         x.to_camel_case()

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -468,7 +468,7 @@ pub enum BarThree {
     On,
     Oner,
     Onest,
-    Other(u8),
+    XOther(u8),
 }
 
 impl From<u8> for BarThree {
@@ -478,7 +478,7 @@ impl From<u8> for BarThree {
             1 => BarThree::On,
             2 => BarThree::Oner,
             3 => BarThree::Onest,
-            x => BarThree::Other(x),
+            x => BarThree::XOther(x),
         }
     }
 }
@@ -490,7 +490,7 @@ impl Into<u8> for BarThree {
             BarThree::On => 1,
             BarThree::Oner => 2,
             BarThree::Onest => 3,
-            BarThree::Other(x) => x,
+            BarThree::XOther(x) => x,
         }
     }
 }
@@ -503,7 +503,7 @@ pub enum BarFour {
     On,
     Oner,
     Onest,
-    Other(u8),
+    XOther(u8),
 }
 
 impl From<u8> for BarFour {
@@ -513,7 +513,7 @@ impl From<u8> for BarFour {
             1 => BarFour::On,
             2 => BarFour::Oner,
             3 => BarFour::Onest,
-            x => BarFour::Other(x),
+            x => BarFour::XOther(x),
         }
     }
 }
@@ -525,7 +525,7 @@ impl Into<u8> for BarFour {
             BarFour::On => 1,
             BarFour::Oner => 2,
             BarFour::Onest => 3,
-            BarFour::Other(x) => x,
+            BarFour::XOther(x) => x,
         }
     }
 }
@@ -536,7 +536,7 @@ impl Into<u8> for BarFour {
 pub enum BarType {
     X0off,
     X1on,
-    Other(bool),
+    XOther(bool),
 }
 
 impl From<bool> for BarType {
@@ -544,7 +544,7 @@ impl From<bool> for BarType {
         match raw {
             false => BarType::X0off,
             true => BarType::X1on,
-            x => BarType::Other(x),
+            x => BarType::XOther(x),
         }
     }
 }
@@ -554,7 +554,7 @@ impl Into<bool> for BarType {
         match self {
             BarType::X0off => false,
             BarType::X1on => true,
-            BarType::Other(x) => x,
+            BarType::XOther(x) => x,
         }
     }
 }
@@ -928,14 +928,14 @@ impl<'a> Arbitrary<'a> for Dolor {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum DolorOneFloat {
     Dolor,
-    Other(f32),
+    XOther(f32),
 }
 
 impl From<f32> for DolorOneFloat {
     fn from(raw: f32) -> Self {
         match raw {
             x if approx_eq!(f32, x, 3_f32, ulps = 2) => DolorOneFloat::Dolor,
-            x => DolorOneFloat::Other(x),
+            x => DolorOneFloat::XOther(x),
         }
     }
 }
@@ -944,7 +944,7 @@ impl Into<f32> for DolorOneFloat {
     fn into(self) -> f32 {
         match self {
             DolorOneFloat::Dolor => 3_f32,
-            DolorOneFloat::Other(x) => x,
+            DolorOneFloat::XOther(x) => x,
         }
     }
 }

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -468,7 +468,7 @@ pub enum BarThree {
     On,
     Oner,
     Onest,
-    XOther(u8),
+    Other(u8),
 }
 
 impl From<u8> for BarThree {
@@ -478,7 +478,7 @@ impl From<u8> for BarThree {
             1 => BarThree::On,
             2 => BarThree::Oner,
             3 => BarThree::Onest,
-            x => BarThree::XOther(x),
+            x => BarThree::Other(x),
         }
     }
 }
@@ -490,7 +490,7 @@ impl Into<u8> for BarThree {
             BarThree::On => 1,
             BarThree::Oner => 2,
             BarThree::Onest => 3,
-            BarThree::XOther(x) => x,
+            BarThree::Other(x) => x,
         }
     }
 }
@@ -503,7 +503,7 @@ pub enum BarFour {
     On,
     Oner,
     Onest,
-    XOther(u8),
+    Other(u8),
 }
 
 impl From<u8> for BarFour {
@@ -513,7 +513,7 @@ impl From<u8> for BarFour {
             1 => BarFour::On,
             2 => BarFour::Oner,
             3 => BarFour::Onest,
-            x => BarFour::XOther(x),
+            x => BarFour::Other(x),
         }
     }
 }
@@ -525,7 +525,7 @@ impl Into<u8> for BarFour {
             BarFour::On => 1,
             BarFour::Oner => 2,
             BarFour::Onest => 3,
-            BarFour::XOther(x) => x,
+            BarFour::Other(x) => x,
         }
     }
 }
@@ -536,7 +536,7 @@ impl Into<u8> for BarFour {
 pub enum BarType {
     X0off,
     X1on,
-    XOther(bool),
+    Other(bool),
 }
 
 impl From<bool> for BarType {
@@ -544,7 +544,7 @@ impl From<bool> for BarType {
         match raw {
             false => BarType::X0off,
             true => BarType::X1on,
-            x => BarType::XOther(x),
+            x => BarType::Other(x),
         }
     }
 }
@@ -554,7 +554,7 @@ impl Into<bool> for BarType {
         match self {
             BarType::X0off => false,
             BarType::X1on => true,
-            BarType::XOther(x) => x,
+            BarType::Other(x) => x,
         }
     }
 }
@@ -928,14 +928,16 @@ impl<'a> Arbitrary<'a> for Dolor {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum DolorOneFloat {
     Dolor,
-    XOther(f32),
+    XOther,
+    Other(f32),
 }
 
 impl From<f32> for DolorOneFloat {
     fn from(raw: f32) -> Self {
         match raw {
             x if approx_eq!(f32, x, 3_f32, ulps = 2) => DolorOneFloat::Dolor,
-            x => DolorOneFloat::XOther(x),
+            x if approx_eq!(f32, x, 5_f32, ulps = 2) => DolorOneFloat::XOther,
+            x => DolorOneFloat::Other(x),
         }
     }
 }
@@ -944,7 +946,8 @@ impl Into<f32> for DolorOneFloat {
     fn into(self) -> f32 {
         match self {
             DolorOneFloat::Dolor => 3_f32,
-            DolorOneFloat::XOther(x) => x,
+            DolorOneFloat::XOther => 5_f32,
+            DolorOneFloat::Other(x) => x,
         }
     }
 }

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -33,4 +33,4 @@ BO_ 1028 Dolor: 8 Sit
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";
 VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";
 VAL_ 512 Type 0 "0Off" 1 "1On";
-VAL_ 1028 OneFloat 3 "Dolor";
+VAL_ 1028 OneFloat 3 "Dolor" 5 "Other";


### PR DESCRIPTION
I noticed it seems to occur quite frequently that there are naming collisions with existing value descriptions. I assume it would be actually better to also have some other default string but I don't really have a good idea here for a new name that may not collide.
E.g. ["Other" - Variant](https://github.com/marcelbuesing/dbcc/blob/7e3e6b7e608563aa52c1ace143c1194d63b0c183/examples/j1939.dbc#L11533)