### PR TITLE
Generate min/max consts for signals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,25 +169,27 @@ fn render_message(mut w: impl Write, msg: &Message, dbc: &DBC) -> Result<()> {
         )?;
         writeln!(w)?;
 
-        for signal in msg.signals().iter() {
+        for signal in msg
+            .signals()
+            .iter()
+            .filter(|sig| signal_to_rust_type(&sig) != "bool")
+        {
             let typ = signal_to_rust_type(&signal);
-            if typ != "bool" {
-                writeln!(
-                    &mut w,
-                    "pub const {sig}_MIN: {typ} = {min}_{typ};",
-                    sig = signal.name().to_snake_case().to_uppercase(),
-                    typ = typ,
-                    min = signal.min,
-                )?;
+            writeln!(
+                &mut w,
+                "pub const {sig}_MIN: {typ} = {min}_{typ};",
+                sig = signal.name().to_snake_case().to_uppercase(),
+                typ = typ,
+                min = signal.min,
+            )?;
 
-                writeln!(
-                    &mut w,
-                    "pub const {sig}_MAX: {typ} = {max}_{typ};",
-                    sig = signal.name().to_snake_case().to_uppercase(),
-                    typ = typ,
-                    max = signal.max,
-                )?;
-            }
+            writeln!(
+                &mut w,
+                "pub const {sig}_MAX: {typ} = {max}_{typ};",
+                sig = signal.name().to_snake_case().to_uppercase(),
+                typ = typ,
+                max = signal.max,
+            )?;
         }
         writeln!(w)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,28 @@ fn render_message(mut w: impl Write, msg: &Message, dbc: &DBC) -> Result<()> {
         )?;
         writeln!(w)?;
 
+        for signal in msg.signals().iter() {
+            let typ = signal_to_rust_type(&signal);
+            if typ != "bool" {
+                writeln!(
+                    &mut w,
+                    "pub const {sig}_MIN: {typ} = {min}_{typ};",
+                    sig = signal.name().to_snake_case().to_uppercase(),
+                    typ = typ,
+                    min = signal.min,
+                )?;
+
+                writeln!(
+                    &mut w,
+                    "pub const {sig}_MAX: {typ} = {max}_{typ};",
+                    sig = signal.name().to_snake_case().to_uppercase(),
+                    typ = typ,
+                    max = signal.max,
+                )?;
+            }
+        }
+        writeln!(w)?;
+
         writeln!(
             &mut w,
             "/// Construct new {} from values",

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -61,6 +61,11 @@ pub struct Foo {
 impl Foo {
     pub const MESSAGE_ID: u32 = 256;
 
+    pub const VOLTAGE_MIN: f32 = 0_f32;
+    pub const VOLTAGE_MAX: f32 = 63.9990234375_f32;
+    pub const CURRENT_MIN: f32 = -2048_f32;
+    pub const CURRENT_MAX: f32 = 2047.9375_f32;
+
     /// Construct new Foo from values
     pub fn new(voltage: f32, current: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 4] };
@@ -212,6 +217,15 @@ pub struct Bar {
 
 impl Bar {
     pub const MESSAGE_ID: u32 = 512;
+
+    pub const ONE_MIN: u8 = 0_u8;
+    pub const ONE_MAX: u8 = 3_u8;
+    pub const TWO_MIN: f32 = 0_f32;
+    pub const TWO_MAX: f32 = 100_f32;
+    pub const THREE_MIN: u8 = 0_u8;
+    pub const THREE_MAX: u8 = 7_u8;
+    pub const FOUR_MIN: u8 = 0_u8;
+    pub const FOUR_MAX: u8 = 3_u8;
 
     /// Construct new Bar from values
     pub fn new(one: u8, two: f32, three: u8, four: u8, xtype: bool) -> Result<Self, CanError> {
@@ -572,6 +586,15 @@ pub struct Amet {
 impl Amet {
     pub const MESSAGE_ID: u32 = 1024;
 
+    pub const ONE_MIN: u8 = 0_u8;
+    pub const ONE_MAX: u8 = 3_u8;
+    pub const TWO_MIN: f32 = 0_f32;
+    pub const TWO_MAX: f32 = 100_f32;
+    pub const THREE_MIN: u8 = 0_u8;
+    pub const THREE_MAX: u8 = 7_u8;
+    pub const FOUR_MIN: u8 = 0_u8;
+    pub const FOUR_MAX: u8 = 3_u8;
+
     /// Construct new Amet from values
     pub fn new(one: u8, two: f32, three: u8, four: u8, five: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 8] };
@@ -832,6 +855,9 @@ pub struct Dolor {
 
 impl Dolor {
     pub const MESSAGE_ID: u32 = 1028;
+
+    pub const ONE_FLOAT_MIN: f32 = 0_f32;
+    pub const ONE_FLOAT_MAX: f32 = 130_f32;
 
     /// Construct new Dolor from values
     pub fn new(one_float: f32) -> Result<Self, CanError> {

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -20,6 +20,18 @@ fn check_range_value_valid() {
 }
 
 #[test]
+fn check_min_max_values() {
+    // min/max copy-pasted from example.dbc:
+    // BO_ 256 Foo: 4 Lorem
+    //    SG_ Voltage : 16|16@1+ (0.000976562,0) [0E-009|63.9990234375] "V" Vector__XXX
+    //    SG_ Current : 0|16@1- (0.0625,0) [-2048|2047.9375] "A" Vector__XXX
+    assert_eq!(Foo::VOLTAGE_MIN, 0.0);
+    assert_eq!(Foo::VOLTAGE_MAX, 63.9990234375);
+    assert_eq!(Foo::CURRENT_MIN, -2048.0);
+    assert_eq!(Foo::CURRENT_MAX, 2047.9375);
+}
+
+#[test]
 fn pack_unpack_message() {
     let result = Foo::new(63.9990234375, 10.0).unwrap();
     assert_eq!(result.voltage_raw(), 63.99899);


### PR DESCRIPTION
This PR adds consts for signal min/max values.

```rust
impl Amet {
    pub const MESSAGE_ID: u32 = 1024;

    pub const ONE_MIN: u8 = 0_u8;
    pub const ONE_MAX: u8 = 3_u8;
    pub const TWO_MIN: f32 = 0_f32;
    pub const TWO_MAX: f32 = 100_f32;
    pub const THREE_MIN: u8 = 0_u8;
    pub const THREE_MAX: u8 = 7_u8;
    pub const FOUR_MIN: u8 = 0_u8;
    pub const FOUR_MAX: u8 = 3_u8;
...
}
```