### PR TITLE
Round f32 when used as integers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,7 @@ name = "can-messages"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "approx 0.5.0",
  "arbitrary",
  "bitvec",
  "dbc-codegen",
@@ -397,7 +407,7 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 name = "read_candump"
 version = "0.1.0"
 dependencies = [
- "approx",
+ "approx 0.4.0",
  "can-messages",
 ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -744,7 +744,7 @@ fn signal_to_payload(mut w: impl Write, signal: &Signal, msg: &Message) -> Resul
         writeln!(&mut w, "let offset = {}_f32;", signal.offset)?;
         writeln!(
             &mut w,
-            "let value = ((value - offset) / factor) as {};",
+            "let value = ((value - offset) / factor).round() as {};",
             signal_to_rust_int(signal)
         )?;
         writeln!(&mut w)?;

--- a/testing/can-messages/Cargo.toml
+++ b/testing/can-messages/Cargo.toml
@@ -12,6 +12,9 @@ arbitrary = { version = "1.0", optional = true }
 anyhow = "1.0"
 dbc-codegen = { path = "../../" }
 
+[dev-dependencies]
+approx = "0.5.0"
+
 [features]
 default = ["debug", "arb", "range_checked"]
 arb = ["arbitrary"]

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -121,7 +121,7 @@ impl Foo {
         }
         let factor = 0.000976562_f32;
         let offset = 0_f32;
-        let value = ((value - offset) / factor) as u16;
+        let value = ((value - offset) / factor).round() as u16;
         
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
@@ -165,7 +165,7 @@ impl Foo {
         }
         let factor = 0.0625_f32;
         let offset = 0_f32;
-        let value = ((value - offset) / factor) as i16;
+        let value = ((value - offset) / factor).round() as i16;
         
         let value = u16::from_ne_bytes(value.to_ne_bytes());
         self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
@@ -277,7 +277,7 @@ impl FooInexact {
         }
         let factor = 0.001_f32;
         let offset = 0_f32;
-        let value = ((value - offset) / factor) as u16;
+        let value = ((value - offset) / factor).round() as u16;
         
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
@@ -321,7 +321,7 @@ impl FooInexact {
         }
         let factor = 0.001_f32;
         let offset = 0_f32;
-        let value = ((value - offset) / factor) as i16;
+        let value = ((value - offset) / factor).round() as i16;
         
         let value = u16::from_ne_bytes(value.to_ne_bytes());
         self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
@@ -477,7 +477,7 @@ impl Bar {
         }
         let factor = 0.39_f32;
         let offset = 0_f32;
-        let value = ((value - offset) / factor) as u8;
+        let value = ((value - offset) / factor).round() as u8;
         
         self.raw.view_bits_mut::<Msb0>()[0..8].store_be(value);
         Ok(())
@@ -964,7 +964,7 @@ impl Amet {
         }
         let factor = 0.39_f32;
         let offset = 0_f32;
-        let value = ((value - offset) / factor) as u8;
+        let value = ((value - offset) / factor).round() as u8;
         
         self.raw.view_bits_mut::<Msb0>()[0..8].store_be(value);
         Ok(())
@@ -1192,7 +1192,7 @@ impl Dolor {
         }
         let factor = 0.5_f32;
         let offset = 0_f32;
-        let value = ((value - offset) / factor) as u16;
+        let value = ((value - offset) / factor).round() as u16;
         
         self.raw.view_bits_mut::<Msb0>()[7..19].store_be(value);
         Ok(())
@@ -1466,7 +1466,7 @@ pub fn set_multiplexed_signal_zero_a(&mut self, value: f32) -> Result<(), CanErr
     }
     let factor = 0.1_f32;
     let offset = 0_f32;
-    let value = ((value - offset) / factor) as u8;
+    let value = ((value - offset) / factor).round() as u8;
     
     self.raw.view_bits_mut::<Lsb0>()[12..20].store_le(value);
     Ok(())
@@ -1509,7 +1509,7 @@ pub fn set_multiplexed_signal_zero_b(&mut self, value: f32) -> Result<(), CanErr
     }
     let factor = 0.1_f32;
     let offset = 0_f32;
-    let value = ((value - offset) / factor) as u8;
+    let value = ((value - offset) / factor).round() as u8;
     
     self.raw.view_bits_mut::<Lsb0>()[20..28].store_le(value);
     Ok(())
@@ -1560,7 +1560,7 @@ pub fn set_multiplexed_signal_one_a(&mut self, value: f32) -> Result<(), CanErro
     }
     let factor = 0.1_f32;
     let offset = 0_f32;
-    let value = ((value - offset) / factor) as u8;
+    let value = ((value - offset) / factor).round() as u8;
     
     self.raw.view_bits_mut::<Lsb0>()[12..20].store_le(value);
     Ok(())
@@ -1603,7 +1603,7 @@ pub fn set_multiplexed_signal_one_b(&mut self, value: f32) -> Result<(), CanErro
     }
     let factor = 0.1_f32;
     let offset = 0_f32;
-    let value = ((value - offset) / factor) as u8;
+    let value = ((value - offset) / factor).round() as u8;
     
     self.raw.view_bits_mut::<Lsb0>()[20..28].store_le(value);
     Ok(())

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::float_cmp)]
 
+use approx::assert_ulps_eq;
 use can_messages::{
-    Amet, Bar, BarThree, CanError, Foo, MultiplexTest, MultiplexTestMultiplexor,
+    Amet, Bar, BarThree, CanError, Foo, FooInexact, MultiplexTest, MultiplexTestMultiplexor,
     MultiplexTestMultiplexorM0,
 };
 
@@ -39,6 +40,13 @@ fn pack_unpack_message() {
     let result = Foo::new(63.9990234375, 10.0).unwrap();
     assert_eq!(result.voltage_raw(), 63.99899);
     assert_eq!(result.current_raw(), 10.0);
+}
+
+#[test]
+fn pack_unpack_message_inexact_scale() {
+    let result = FooInexact::new(0.08, -0.035).unwrap();
+    assert_ulps_eq!(result.voltage_raw(), 0.08);
+    assert_eq!(result.current_raw(), -0.035);
 }
 
 #[test]

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -12,6 +12,10 @@ BO_ 256 Foo: 4 Lorem
  SG_ Voltage : 16|16@1+ (0.000976562,0) [0E-009|63.9990234375] "V" Vector__XXX
  SG_ Current : 0|16@1- (0.0625,0) [-2048|2047.9375] "A" Vector__XXX
 
+BO_ 256 FooInexact: 4 Test
+ SG_ Voltage : 16|16@1+ (0.001,0) [0|655.35] "V" Vector__XXX
+ SG_ Current : 0|16@1- (0.001,0) [-327.68|327.67] "A" Vector__XXX
+
 BO_ 512 Bar: 8 Ipsum
  SG_ One : 15|2@0+ (1,0) [0|3] "" Dolor
  SG_ Two : 7|8@0+ (0.39,0) [0.00|100] "%" Dolor


### PR DESCRIPTION
I was finding problems with values that after scaling were not exact, such as 79.99999 being truncated to 79 instead of rounded to 80. I have added a test and the fix for this use case.

Let me know if this was a design choice because of performance and I have misunderstood it to be a bug.