### PR TITLE
fix issue where signed signals would be rendered as unsigned

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1011,23 +1011,42 @@ fn scaled_signal_to_rust_int(signal: &Signal) -> String {
     );
 
     // calculate the maximum possible signal value, accounting for factor and offset
-    let factor = signal.factor as u64;
-    let offset = signal.offset as u64;
-    let max_value = 1u64
-        .checked_shl(*signal.signal_size() as u32)
-        .map(|n| n.saturating_sub(1))
-        .and_then(|n| n.checked_mul(factor))
-        .and_then(|n| n.checked_add(offset))
-        .unwrap_or(u64::MAX);
 
-    let size = match max_value {
-        n if n <= u8::MAX.into() => "8",
-        n if n <= u16::MAX.into() => "16",
-        n if n <= u32::MAX.into() => "32",
-        _ => "64",
-    };
+    if signal.min >= 0.0 {
+        let factor = signal.factor as u64;
+        let offset = signal.offset as u64;
+        let max_value = 1u64
+            .checked_shl(*signal.signal_size() as u32)
+            .map(|n| n.saturating_sub(1))
+            .and_then(|n| n.checked_mul(factor))
+            .and_then(|n| n.checked_add(offset))
+            .unwrap_or(u64::MAX);
 
-    format!("{sign}{size}")
+        let size = match max_value {
+            n if n <= u8::MAX.into() => "8",
+            n if n <= u16::MAX.into() => "16",
+            n if n <= u32::MAX.into() => "32",
+            _ => "64",
+        };
+        format!("{sign}{size}")
+    } else {
+        let factor = signal.factor as i64;
+        let offset = signal.offset as i64;
+        let max_value = 1i64
+            .checked_shl(*signal.signal_size() as u32)
+            .map(|n| n.saturating_sub(1))
+            .and_then(|n| n.checked_mul(factor))
+            .and_then(|n| n.checked_add(offset))
+            .unwrap_or(i64::MAX);
+
+        let size = match max_value {
+            n if n <= i8::MAX.into() => "8",
+            n if n <= i16::MAX.into() => "16",
+            n if n <= i32::MAX.into() => "32",
+            _ => "64",
+        };
+        format!("i{size}")
+    }
 }
 
 /// Determine the smallest rust integer that can fit the raw signal values.

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -45,6 +45,7 @@ BO_ 1337 IntegerFactorOffset: 8 Sit
  SG_ ByteWithFactor : 8|8@1+ (4,0) [0|1020] "" Vector__XXX
  SG_ ByteWithBoth : 16|8@1+ (2,16) [16|526] "" Vector__XXX
  SG_ ByteWithNegativeOffset : 24|8@1+ (1,-1) [0|255] "" Vector__XXX
+ SG_ ByteWithNegativeMin : 32|8@1+ (1,-1) [-127|127] "" Vector__XXX
 
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";
 VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";


### PR DESCRIPTION
The title pretty much sums it up, some signals with a negative minimum value would end up as unsigned integers when generated 