### PR TITLE
fix duplicate enum names on multiplex messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1145,7 +1145,7 @@ fn multiplex_enum_name(msg: &Message, multiplexor: &Signal) -> Result<String> {
         multiplexor
     );
     Ok(format!(
-        "{}{}",
+        "{}{}Index",
         msg.message_name().to_pascal_case(),
         multiplexor.name().to_pascal_case()
     ))

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -1182,14 +1182,14 @@ impl MultiplexTest {
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
 
-    pub fn multiplexor(&mut self) -> Result<MultiplexTestMultiplexor, CanError> {
+    pub fn multiplexor(&mut self) -> Result<MultiplexTestMultiplexorIndex, CanError> {
         match self.multiplexor_raw() {
-            0 => Ok(MultiplexTestMultiplexor::M0(MultiplexTestMultiplexorM0 {
-                raw: self.raw,
-            })),
-            1 => Ok(MultiplexTestMultiplexor::M1(MultiplexTestMultiplexorM1 {
-                raw: self.raw,
-            })),
+            0 => Ok(MultiplexTestMultiplexorIndex::M0(
+                MultiplexTestMultiplexorM0 { raw: self.raw },
+            )),
+            1 => Ok(MultiplexTestMultiplexorIndex::M1(
+                MultiplexTestMultiplexorM1 { raw: self.raw },
+            )),
             multiplexor => Err(CanError::InvalidMultiplexor {
                 message_id: 200,
                 multiplexor: multiplexor.into(),
@@ -1313,7 +1313,7 @@ impl<'a> Arbitrary<'a> for MultiplexTest {
 }
 /// Defined values for multiplexed signal MultiplexTest
 #[derive(Debug)]
-pub enum MultiplexTestMultiplexor {
+pub enum MultiplexTestMultiplexorIndex {
     M0(MultiplexTestMultiplexorM0),
     M1(MultiplexTestMultiplexorM1),
 }

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::float_cmp)]
 
 use can_messages::{
-    Amet, Bar, BarThree, CanError, Foo, MultiplexTest, MultiplexTestMultiplexor,
+    Amet, Bar, BarThree, CanError, Foo, MultiplexTest, MultiplexTestMultiplexorIndex,
     MultiplexTestMultiplexorM0,
 };
 
@@ -69,7 +69,7 @@ fn pack_unpack_message_containing_multiplexed_signals() {
     assert_eq!(result.unmultiplexed_signal(), 2);
     assert_eq!(result.multiplexor_raw(), 0);
     let multiplexor = result.multiplexor().unwrap();
-    if let MultiplexTestMultiplexor::M0(m0) = multiplexor {
+    if let MultiplexTestMultiplexorIndex::M0(m0) = multiplexor {
         assert_eq!(m0.multiplexed_signal_zero_a(), 1.2);
         assert_eq!(m0.multiplexed_signal_zero_b(), 2.0);
     } else {


### PR DESCRIPTION
Two enums would render with the same name, example below

```
BO_ 2365539326 Example: 8 SCC
 SG_ message2 m2 : 32|1@0+ (1,0) [0|1] ""  TCU
 SG_ message1 m1 : 39|16@0+ (0.01,0) [0|655.35] ""  TCU
 SG_ Multiplexor M : 23|16@0+ (1,0) [0|0] ""  TCU
 
VAL_ 2365539326 Multiplexor 1 "Message 1" 2 "Message 2" ;
```
Would render as:
 
```
pub enum ExampleMultiplexor {
        M1(ExampleMultiplexorM1),
        M2(ExampleMultiplexorM2),
}

pub enum ExampleMultiplexor {
        Message1,
        Message2,
} 
```
This fix will render as: 

```
pub enum ExampleMultiplexorIndex {
        M1(ExampleMultiplexorM1),
        M2(ExampleMultiplexorM2),
}

pub enum ExampleMultiplexor {
        Message1,
        Message2,
} 
```