### PR TITLE
Remove warnings in generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ fn main() {
     let config = Config::builder()
         .dbc_name("example.dbc")
         .dbc_content(&dbc_file)
+        //.allow_dead_code(true) // Don't emit warnings if not all generated code is used
         //.impl_arbitrary(FeatureConfig::Gated("arbitrary")) // Optional impls.
         //.impl_debug(FeatureConfig::Always)                 // See rustdoc for more,
         //.check_ranges(FeatureConfig::Never)                // or look below for an example.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub fn codegen(config: Config<'_>, out: impl Write) -> Result<()> {
     )?;
     writeln!(
         &mut w,
-        "#![allow(clippy::excessive_precision, clippy::manual_range_contains, clippy::absurd_extreme_comparisons)]"
+        "#![allow(clippy::excessive_precision, clippy::manual_range_contains, clippy::absurd_extreme_comparisons, clippy::too_many_arguments)]"
     )?;
     writeln!(&mut w, "#![deny(clippy::arithmetic_side_effects)]")?;
     writeln!(&mut w)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub fn codegen(config: Config<'_>, out: impl Write) -> Result<()> {
     writeln!(&mut w, "// Generated code!")?;
     writeln!(
         &mut w,
-        "#![allow(unused_comparisons, unreachable_patterns)]"
+        "#![allow(unused_comparisons, unreachable_patterns, unused_imports)]"
     )?;
     writeln!(&mut w, "#![allow(clippy::let_and_return, clippy::eq_op)]")?;
     writeln!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,13 @@ pub struct Config<'a> {
     #[builder(default)]
     pub impl_error: FeatureConfig<'a>,
 
-    /// Optional: Validate min and max values in generated signal setters. Default: `Always`.
+    /// Optional: Validate min and max values in generated signal setters. Default: `Always`
     #[builder(default = FeatureConfig::Always)]
     pub check_ranges: FeatureConfig<'a>,
+
+    /// Optional: Allow dead code in the generated module. Default: `false`.
+    #[builder(default)]
+    pub allow_dead_code: bool,
 }
 
 /// Configuration for including features in the codegenerator.
@@ -110,6 +114,9 @@ pub fn codegen(config: Config<'_>, out: impl Write) -> Result<()> {
         &mut w,
         "#![allow(unused_comparisons, unreachable_patterns, unused_imports)]"
     )?;
+    if config.allow_dead_code {
+        writeln!(&mut w, "#![allow(dead_code)]")?;
+    }
     writeln!(&mut w, "#![allow(clippy::let_and_return, clippy::eq_op)]")?;
     writeln!(
         &mut w,

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -35,6 +35,8 @@ pub enum Messages {
     MultiplexTest(MultiplexTest),
     /// IntegerFactorOffset
     IntegerFactorOffset(IntegerFactorOffset),
+    /// MsgWithoutSignals
+    MsgWithoutSignals(MsgWithoutSignals),
 }
 
 impl Messages {
@@ -49,6 +51,7 @@ impl Messages {
             1028 => Messages::Dolor(Dolor::try_from(payload)?),
             200 => Messages::MultiplexTest(MultiplexTest::try_from(payload)?),
             1337 => Messages::IntegerFactorOffset(IntegerFactorOffset::try_from(payload)?),
+            513 => Messages::MsgWithoutSignals(MsgWithoutSignals::try_from(payload)?),
             n => return Err(CanError::UnknownMessageId(n)),
         };
         Ok(res)
@@ -1819,6 +1822,62 @@ impl<'a> Arbitrary<'a> for IntegerFactorOffset {
             byte_with_negative_min,
         )
         .map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
+/// MsgWithoutSignals
+///
+/// - ID: 513 (0x201)
+/// - Size: 8 bytes
+/// - Transmitter: Ipsum
+#[derive(Clone, Copy)]
+pub struct MsgWithoutSignals {
+    raw: [u8; 8],
+}
+
+impl MsgWithoutSignals {
+    pub const MESSAGE_ID: u32 = 513;
+
+    /// Construct new MsgWithoutSignals from values
+    pub fn new() -> Result<Self, CanError> {
+        let res = Self { raw: [0u8; 8] };
+        Ok(res)
+    }
+
+    /// Access message payload raw value
+    pub fn raw(&self) -> &[u8; 8] {
+        &self.raw
+    }
+}
+
+impl core::convert::TryFrom<&[u8]> for MsgWithoutSignals {
+    type Error = CanError;
+
+    #[inline(always)]
+    fn try_from(payload: &[u8]) -> Result<Self, Self::Error> {
+        if payload.len() != 8 {
+            return Err(CanError::InvalidPayloadSize);
+        }
+        let mut raw = [0u8; 8];
+        raw.copy_from_slice(&payload[..8]);
+        Ok(Self { raw })
+    }
+}
+
+impl core::fmt::Debug for MsgWithoutSignals {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if f.alternate() {
+            f.debug_struct("MsgWithoutSignals").finish()
+        } else {
+            f.debug_tuple("MsgWithoutSignals").field(&self.raw).finish()
+        }
+    }
+}
+
+#[cfg(feature = "arb")]
+impl<'a> Arbitrary<'a> for MsgWithoutSignals {
+    fn arbitrary(_u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
+        MsgWithoutSignals::new().map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -5,7 +5,8 @@
 #![allow(
     clippy::excessive_precision,
     clippy::manual_range_contains,
-    clippy::absurd_extreme_comparisons
+    clippy::absurd_extreme_comparisons,
+    clippy::too_many_arguments
 )]
 #![deny(clippy::arithmetic_side_effects)]
 

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -1,5 +1,5 @@
 // Generated code!
-#![allow(unused_comparisons, unreachable_patterns)]
+#![allow(unused_comparisons, unreachable_patterns, unused_imports)]
 #![allow(clippy::let_and_return, clippy::eq_op)]
 #![allow(clippy::useless_conversion, clippy::unnecessary_cast)]
 #![allow(

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -47,6 +47,8 @@ BO_ 1337 IntegerFactorOffset: 8 Sit
  SG_ ByteWithNegativeOffset : 24|8@1+ (1,-1) [0|255] "" Vector__XXX
  SG_ ByteWithNegativeMin : 32|8@1+ (1,-1) [-127|127] "" Vector__XXX
 
+BO_ 513 MsgWithoutSignals: 8 Ipsum
+
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";
 VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";
 VAL_ 512 Type 0 "0Off" 1 "1On";


### PR DESCRIPTION
Thanks for creating this project, it's exactly what I was looking for!

This PR is a small collection of individual commits to remove warnings in the generated Rust code. It shouldn't change any actual functionality:

* Disable unused imports warnings (fixes #53)
* Avoid warnings in code generated for messages that contain no signals (not common, but possible especially when reverse engineering.)
* Add a config option for `#!allow(dead_code)` in the generated source file, useful if you're generating from a large DBC file but don't intend to use all of it in your project.
* Disable the clippy `too_many_arguments` warning. Constructors for messages with a lot of signals *are* impractical, but hard to see an easy way to introduce an alternative constructor.