### PR TITLE
Fix signed offset integers where scaled int size equals raw size.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -868,18 +868,25 @@ fn signal_from_payload(mut w: impl Write, signal: &Signal, msg: &Message) -> Res
         writeln!(&mut w, "(signal as f32) * factor + offset")?;
     } else {
         writeln!(&mut w, "let factor = {};", signal.factor)?;
+        let scaled_type = scaled_signal_to_rust_int(signal);
+
+        if scaled_type == signal_to_rust_uint(signal).replace('u', "i") {
+            // Can't do iNN::from(uNN) if they both fit in the same integer type,
+            // so cast first
+            writeln!(&mut w, "let signal = signal as {};", scaled_type)?;
+        }
+
         if signal.offset >= 0.0 {
             writeln!(
                 &mut w,
                 "{}::from(signal).saturating_mul(factor).saturating_add({})",
-                scaled_signal_to_rust_int(signal),
-                signal.offset,
+                scaled_type, signal.offset,
             )?;
         } else {
             writeln!(
                 &mut w,
                 "{}::from(signal).saturating_mul(factor).saturating_sub({})",
-                scaled_signal_to_rust_int(signal),
+                scaled_type,
                 signal.offset.abs(),
             )?;
         }

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -47,6 +47,10 @@ BO_ 1337 IntegerFactorOffset: 8 Sit
  SG_ ByteWithNegativeOffset : 24|8@1+ (1,-1) [0|255] "" Vector__XXX
  SG_ ByteWithNegativeMin : 32|8@1+ (1,-1) [-127|127] "" Vector__XXX
 
+BO_ 1338 LargerIntsWithOffsets: 8 Sit
+ SG_ Twelve : 0|12@1+ (1,-1000) [-1000|3000] "" XXX
+ SG_ Sixteen : 12|16@1+ (1,-1000) [-1000|64535] "" XXX
+
 BO_ 513 MsgWithoutSignals: 8 Ipsum
 
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";


### PR DESCRIPTION
For signals where a signed integer is generated using an offset, the generated code wouldn't compile if the raw unsigned value and the signed result fit in the same size.

For example, without this fix a signal such as this (included in this PR as new test case):

```
 SG_ WithOffset : 32|12@1+ (1,-1000) [-1000|3000] "" XXX
```

Generates this function:

```rust
    pub fn with_offset_raw(&self) -> i16 {
        let signal = self.raw.view_bits::<Lsb0>()[32..44].load_le::<u16>();

        let factor = 1;
        i16::from(signal)
            .saturating_mul(factor)
            .saturating_sub(1000)
    }
```

Which fails to compile, because u16 won't convert to i16 without a cast:

```
error[E0277]: the trait bound `i16: From<u16>` is not satisfied
   --> testing/can-messages/src/messages.rs:511:19
    |
511 |         i16::from(signal)
    |         --------- ^^^^^^ the trait `From<u16>` is not implemented for `i16`
    |         |
    |         required by a bound introduced by this call
    |
    = help: the following other types implement trait `From<T>`:
              <i16 as From<bool>>
              <i16 as From<i8>>
              <i16 as From<u8>>
              <i16 as From<NonZeroI16>>
```

This PR fixes the above, and also adds a test case for offset integers that take up a full Rust integer type (these already generated correctly.)
