### PR TITLE
Put codegen output into `OUT_DIR` rather than `src/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,18 @@ fn main() {
         //.check_ranges(FeatureConfig::Never)                // or look below for an example.
         .build();
 
-    let mut out = std::io::BufWriter::new(std::fs::File::create("src/messages.rs").unwrap());
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let dest_path = std::path::Path::new(&out_dir).join("messages.rs");
+    let mut out = std::io::BufWriter::new(std::fs::File::create(&dest_path).unwrap());
     dbc_codegen::codegen(config, &mut out).expect("dbc-codegen failed");
+}
+```
+
+and including the following snippet in your `main.rs` or `lib.rs`:
+
+```rust
+pub mod messages {
+    include!(concat!(env!("OUT_DIR"), "/messages.rs"));
 }
 ```
 

--- a/dbc-codegen-cli/src/main.rs
+++ b/dbc-codegen-cli/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
         .dbc_name(&dbc_file_name)
         .dbc_content(&dbc_file)
         .debug_prints(true)
+        .clippy_attributes(true)
         .build();
 
     dbc_codegen::codegen(config, &mut messages_code).unwrap_or_else(|e| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,10 @@ pub struct Config<'a> {
     /// Optional: Allow dead code in the generated module. Default: `false`.
     #[builder(default)]
     pub allow_dead_code: bool,
+
+    /// Optional: Include clippy lint attributes in generated output. Default: `false`.
+    #[builder(default)]
+    pub clippy_attributes: bool,
 }
 
 /// Configuration for including features in the codegenerator.
@@ -114,32 +118,36 @@ pub fn codegen(config: Config<'_>, out: impl Write) -> Result<()> {
     let mut w = BufWriter::new(out);
 
     writeln!(&mut w, "// Generated code!")?;
-    writeln!(
-        &mut w,
-        "#![allow(unused_comparisons, unreachable_patterns, unused_imports)]"
-    )?;
-    if config.allow_dead_code {
-        writeln!(&mut w, "#![allow(dead_code)]")?;
+
+    if config.clippy_attributes {
+        writeln!(
+            &mut w,
+            "#![allow(unused_comparisons, unreachable_patterns, unused_imports)]"
+        )?;
+        if config.allow_dead_code {
+            writeln!(&mut w, "#![allow(dead_code)]")?;
+        }
+        writeln!(&mut w, "#![allow(clippy::let_and_return, clippy::eq_op)]")?;
+        writeln!(
+            &mut w,
+            "#![allow(clippy::useless_conversion, clippy::unnecessary_cast)]"
+        )?;
+        writeln!(
+            &mut w,
+            "#![allow(clippy::excessive_precision, clippy::manual_range_contains, clippy::absurd_extreme_comparisons, clippy::too_many_arguments)]"
+        )?;
+        writeln!(&mut w, "#![deny(clippy::arithmetic_side_effects)]")?;
+        writeln!(&mut w)?;
+        writeln!(
+            &mut w,
+            "//! Message definitions from file `{:?}`",
+            config.dbc_name
+        )?;
+        writeln!(&mut w, "//!")?;
+        writeln!(&mut w, "//! - Version: `{:?}`", dbc.version())?;
+        writeln!(&mut w)?;
     }
-    writeln!(&mut w, "#![allow(clippy::let_and_return, clippy::eq_op)]")?;
-    writeln!(
-        &mut w,
-        "#![allow(clippy::useless_conversion, clippy::unnecessary_cast)]"
-    )?;
-    writeln!(
-        &mut w,
-        "#![allow(clippy::excessive_precision, clippy::manual_range_contains, clippy::absurd_extreme_comparisons, clippy::too_many_arguments)]"
-    )?;
-    writeln!(&mut w, "#![deny(clippy::arithmetic_side_effects)]")?;
-    writeln!(&mut w)?;
-    writeln!(
-        &mut w,
-        "//! Message definitions from file `{:?}`",
-        config.dbc_name
-    )?;
-    writeln!(&mut w, "//!")?;
-    writeln!(&mut w, "//! - Version: `{:?}`", dbc.version())?;
-    writeln!(&mut w)?;
+
     writeln!(&mut w, "use core::ops::BitOr;")?;
     writeln!(&mut w, "use bitvec::prelude::*;")?;
 

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -1,19 +1,4 @@
 // Generated code!
-#![allow(unused_comparisons, unreachable_patterns, unused_imports)]
-#![allow(clippy::let_and_return, clippy::eq_op)]
-#![allow(clippy::useless_conversion, clippy::unnecessary_cast)]
-#![allow(
-    clippy::excessive_precision,
-    clippy::manual_range_contains,
-    clippy::absurd_extreme_comparisons,
-    clippy::too_many_arguments
-)]
-#![deny(clippy::arithmetic_side_effects)]
-
-//! Message definitions from file `"example.dbc"`
-//!
-//! - Version: `Version("43")`
-
 #[cfg(feature = "arb")]
 use arbitrary::{Arbitrary, Unstructured};
 use bitvec::prelude::*;


### PR DESCRIPTION
The current guidance of putting code generated by a `build.rs` script into `src/` is generally not a good idea (see [here](https://doc.rust-lang.org/cargo/reference/build-script-examples.html)). It leads to it being checked into source control and people trying to make edits to it.

Trying to put the current output of `codegen` into `OUT_DIR` causes errors to do with inner attributes not being permitted.  This PR implements a config parameter `clippy_attributes` which turns off generating these attributes by default. They are turned back on for the CLI as it is assumed the user _will_ be placing the output into `src/` in that case.

Also see [`prost_build`](https://docs.rs/prost-build/latest/prost_build/) for a good template for how code generation from an interface format should work.