### PR TITLE
Fix bug with unsigned types and negative factors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Rust targets we use for embedded
         run: rustup target install thumbv7em-none-eabihf
       - name: Build for embedded
-        run: cargo build -p can-embedded --target=thumbv7em-none-eabihf
+        run: cargo build -p can-embedded --target=thumbv7em-none-eabihf --no-default-features
 
       - name: Install clippy
         run: rustup component add clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ name = "can-embedded"
 version = "0.1.0"
 dependencies = [
  "bitvec",
+ "can-messages",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ members = [
     ".",
     "dbc-codegen-cli",
     "testing/rust-integration",
-    "testing/can-messages",
     "testing/can-embedded",
+    "testing/can-messages",
     "testing/cantools-messages",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ members = [
     ".",
     "dbc-codegen-cli",
     "testing/rust-integration",
-    "testing/can-embedded",
     "testing/can-messages",
+    "testing/can-embedded",
     "testing/cantools-messages",
 ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,15 +1031,9 @@ fn write_enum(
 }
 
 /// Determine the smallest rust integer that can fit the actual signal values,
-/// i.e. accounting for factor and offset.
-///
-/// NOTE: Factor and offset must be whole integers.
+/// using the min/max information of the signal.
 fn scaled_signal_to_rust_int(signal: &Signal) -> String {
-    let sign = match signal.value_type() {
-        can_dbc::ValueType::Signed => "i",
-        can_dbc::ValueType::Unsigned => "u",
-    };
-
+    // Check the factor and offset to convince ourselves that this is supposed to be an integer
     assert!(
         signal.factor.fract().abs() <= f64::EPSILON,
         "Signal Factor ({}) should be an integer",
@@ -1047,7 +1041,7 @@ fn scaled_signal_to_rust_int(signal: &Signal) -> String {
     );
     assert!(
         signal.offset.fract().abs() <= f64::EPSILON,
-        "Signal Factor ({}) should be an integer",
+        "Signal Offset ({}) should be an integer",
         signal.offset,
     );
 
@@ -1540,5 +1534,3 @@ mod tests {
         assert_eq!(signal_params_to_rust_int(-129.0, -127.0), "i16");
     }
 }
-
-// TODO: test getting values from the signal with negative factor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,9 @@ use std::{
     fmt::Display,
     io::{self, BufWriter, Write},
 };
+use std::cmp::max;
 use typed_builder::TypedBuilder;
+
 
 mod includes;
 mod keywords;
@@ -261,7 +263,7 @@ fn render_message(mut w: impl Write, config: &Config<'_>, msg: &Message, dbc: &D
         let mut w = PadAdapter::wrap(&mut w);
         config
             .impl_serde
-            .fmt_attr(&mut w, "serde(with = \"serde_bytes\")");
+            .fmt_attr(&mut w, "serde(with = \"serde_bytes\")")?;
         writeln!(w, "raw: [u8; {}],", msg.message_size())?;
     }
     writeln!(w, "}}")?;
@@ -1049,44 +1051,54 @@ fn scaled_signal_to_rust_int(signal: &Signal) -> String {
         signal.offset,
     );
 
-    // calculate the maximum possible signal value, accounting for factor and offset
-
-    if signal.min >= 0.0 {
-        let factor = signal.factor as u64;
-        let offset = signal.offset as u64;
-        let max_value = 1u64
-            .checked_shl(*signal.signal_size() as u32)
-            .map(|n| n.saturating_sub(1))
-            .and_then(|n| n.checked_mul(factor))
-            .and_then(|n| n.checked_add(offset))
-            .unwrap_or(u64::MAX);
-
-        let size = match max_value {
-            n if n <= u8::MAX.into() => "8",
-            n if n <= u16::MAX.into() => "16",
-            n if n <= u32::MAX.into() => "32",
-            _ => "64",
-        };
-        format!("{sign}{size}")
-    } else {
-        let factor = signal.factor as i64;
-        let offset = signal.offset as i64;
-        let max_value = 1i64
-            .checked_shl(*signal.signal_size() as u32)
-            .map(|n| n.saturating_sub(1))
-            .and_then(|n| n.checked_mul(factor))
-            .and_then(|n| n.checked_add(offset))
-            .unwrap_or(i64::MAX);
-
-        let size = match max_value {
-            n if n <= i8::MAX.into() => "8",
-            n if n <= i16::MAX.into() => "16",
-            n if n <= i32::MAX.into() => "32",
-            _ => "64",
-        };
-        format!("i{size}")
-    }
+    signal_params_to_rust_int(*signal.min(), *signal.max())
 }
+
+
+
+/// Determine the smallest Rust integer type that can fit the range of values
+fn signal_params_to_rust_int(
+    low: f64,
+    high: f64
+) -> String {
+
+    // Two cases:
+    // Min is negative, in which case lower and upper bounds are signed
+    // Min is positive so lower/upper bounds are unsigned
+    let lower_bound: u8;
+    let upper_bound: u8;
+    let sign: &str;
+
+    if low < 0.0 {
+        // signed case
+        sign = "i";
+        lower_bound = match low {
+            n if n >= i8::MIN.into() => 8,
+            n if n >= i16::MIN.into() => 16,
+            n if n >= i32::MIN.into() => 32,
+            _ => 64
+        };
+        upper_bound = match high {
+            n if n <= i8::MAX.into() => 8,
+            n if n <= i16::MAX.into() => 16,
+            n if n <= i32::MAX.into() => 32,
+            _ => 64
+        };
+    } else{
+        sign = "u";
+        lower_bound = 8;
+        upper_bound = match high {
+            n if n <= u8::MAX.into() => 8,
+            n if n <= u16::MAX.into() => 16,
+            n if n <= u32::MAX.into() => 32,
+            _ => 64
+        };
+    }
+
+    let size = max(lower_bound, upper_bound);
+    format!("{sign}{size}")
+}
+
 
 /// Determine the smallest rust integer that can fit the raw signal values.
 fn signal_to_rust_int(signal: &Signal) -> String {
@@ -1116,6 +1128,7 @@ fn signal_to_rust_uint(signal: &Signal) -> String {
 
     format!("u{}", size)
 }
+
 
 #[allow(clippy::float_cmp)]
 fn signal_is_float_in_rust(signal: &Signal) -> bool {
@@ -1507,3 +1520,27 @@ impl FeatureConfig<'_> {
         f(&mut w)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{signal_params_to_rust_int};
+
+    #[test]
+    fn test_something() {
+        assert_eq!(1, 1);
+    }
+
+    #[test]
+    fn test_signal_params_to_rust_int() {
+        assert_eq!(signal_params_to_rust_int(0.0, 255.0), "u8");
+        assert_eq!(signal_params_to_rust_int(-1.0, 127.0), "i8");
+        assert_eq!(signal_params_to_rust_int(-1.0, 128.0), "i16");
+        assert_eq!(signal_params_to_rust_int(-1.0, 255.0), "i16");
+        assert_eq!(signal_params_to_rust_int(-65535.0, 0.0), "i32");
+    }
+}
+
+// TODO: both min and max are negative?
+// TODO: bulletproof it against errors? min and max are 0, min/max reversed
+// TODO: test getting values from the signal with negative factor
+// TODO: consolidate all the signal range functions?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1101,7 +1101,6 @@ fn get_range_of_values(
             high = 1i128
                 .checked_shl(signal_size)
                 .and_then(|n| n.checked_sub(1));
-
         }
     }
     let range1 = apply_factor_and_offset(low, factor, offset);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1058,8 +1058,7 @@ fn scaled_signal_to_rust_int(signal: &Signal) -> String {
     .expect(&err)
 }
 
-/// Convert the relevant parameters of a signal into a Rust type.
-/// This is easiest to unit-test than taking the whole `can_dbc::Signal`
+/// Convert the relevant parameters of a `can_dbc::Signal` into a Rust type.
 fn signal_params_to_rust_int(
     sign: can_dbc::ValueType,
     signal_size: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,17 +27,13 @@
 #![deny(clippy::arithmetic_side_effects)]
 
 use anyhow::{anyhow, ensure, Context, Result};
-use can_dbc::ValueType::Signed;
-use can_dbc::{
-    Message, MultiplexIndicator, Signal, ValDescription, ValueDescription, ValueType, DBC,
-};
+use can_dbc::{Message, MultiplexIndicator, Signal, ValDescription, ValueDescription, DBC};
 use heck::{ToPascalCase, ToSnakeCase};
 use pad::PadAdapter;
 use std::cmp::{max, min};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Display,
-    i128, i64,
     io::{self, BufWriter, Write},
 };
 use typed_builder::TypedBuilder;
@@ -1063,7 +1059,7 @@ fn scaled_signal_to_rust_int(signal: &Signal) -> String {
 }
 
 fn signal_params_to_rust_int(
-    sign: ValueType,
+    sign: can_dbc::ValueType,
     signal_size: u32,
     factor: i64,
     offset: i64,
@@ -1080,7 +1076,7 @@ fn signal_params_to_rust_int(
 
 /// Using the signal's parameters, find the range of values that it spans
 fn get_range_of_values(
-    sign: ValueType,
+    sign: can_dbc::ValueType,
     signal_size: u32,
     factor: i64,
     offset: i64,
@@ -1088,7 +1084,7 @@ fn get_range_of_values(
     let low;
     let high;
     match sign {
-        Signed => {
+        can_dbc::ValueType::Signed => {
             low = 1i128
                 .checked_shl(signal_size - 1)
                 .and_then(|n| n.checked_mul(-1));
@@ -1096,7 +1092,7 @@ fn get_range_of_values(
                 .checked_shl(signal_size - 1)
                 .and_then(|n| n.checked_sub(1));
         }
-        ValueType::Unsigned => {
+        can_dbc::ValueType::Unsigned => {
             low = Some(0);
             high = 1i128
                 .checked_shl(signal_size)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1537,10 +1537,8 @@ mod tests {
         assert_eq!(signal_params_to_rust_int(-1.0, 128.0), "i16");
         assert_eq!(signal_params_to_rust_int(-1.0, 255.0), "i16");
         assert_eq!(signal_params_to_rust_int(-65535.0, 0.0), "i32");
+        assert_eq!(signal_params_to_rust_int(-129.0, -127.0), "i16");
     }
 }
 
-// TODO: both min and max are negative?
-// TODO: bulletproof it against errors? min and max are 0, min/max reversed
 // TODO: test getting values from the signal with negative factor
-// TODO: consolidate all the signal range functions?

--- a/testing/can-embedded/Cargo.toml
+++ b/testing/can-embedded/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 
 [dependencies]
 bitvec = { version = "1.0", default-features = false }
+can-messages = { path = "../can-messages" }

--- a/testing/can-embedded/Cargo.toml
+++ b/testing/can-embedded/Cargo.toml
@@ -4,6 +4,16 @@ version = "0.1.0"
 authors = ["Pascal Hertleif <pascal@technocreatives.com>"]
 edition = "2021"
 
+[features]
+default = ["build-messages"]
+build-messages = ["dep:can-messages"]
+
 [dependencies]
 bitvec = { version = "1.0", default-features = false }
-can-messages = { path = "../can-messages" }
+
+
+# This is optional and default so we can turn it off for the embedded target.
+# Then it doesn't pull in std.
+[dependencies.can-messages]
+path = "../can-messages"
+optional = true

--- a/testing/can-embedded/src/messages.rs
+++ b/testing/can-embedded/src/messages.rs
@@ -1,0 +1,1 @@
+// This stub will be replaced by testing/can-messages/build.rs

--- a/testing/can-embedded/src/messages.rs
+++ b/testing/can-embedded/src/messages.rs
@@ -1,1 +1,0 @@
-// This stub will get replaced by testing/can-messages/build.rs upon a build

--- a/testing/can-embedded/src/messages.rs
+++ b/testing/can-embedded/src/messages.rs
@@ -1,0 +1,1 @@
+// This stub will get replaced by testing/can-messages/build.rs upon a build

--- a/testing/can-embedded/src/messages.rs
+++ b/testing/can-embedded/src/messages.rs
@@ -1,1 +1,0 @@
-../../can-messages/src/messages.rs

--- a/testing/can-messages/build.rs
+++ b/testing/can-messages/build.rs
@@ -34,5 +34,7 @@ fn main() -> Result<()> {
         .output()
         .expect("failed to execute rustfmt");
 
+    fs::copy("src/messages.rs", "../can-embedded/src/messages.rs")?;
+
     Ok(())
 }

--- a/testing/can-messages/build.rs
+++ b/testing/can-messages/build.rs
@@ -12,6 +12,7 @@ fn main() -> Result<()> {
     let mut out = BufWriter::new(File::create(out_file)?);
     println!("cargo:rerun-if-changed=../dbc-examples/example.dbc");
     println!("cargo:rerun-if-changed=../../src");
+    println!("cargo:rerun-if-changed=../can-embedded/src");
 
     let config = Config::builder()
         .dbc_name("example.dbc")

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -1846,13 +1846,13 @@ pub struct NegativeFactor {
 impl NegativeFactor {
     pub const MESSAGE_ID: u32 = 1344;
 
-    pub const NEGATIVE_FACTOR_SIGNAL_MIN: i32 = -65535_i32;
-    pub const NEGATIVE_FACTOR_SIGNAL_MAX: i32 = 0_i32;
+    pub const UNSIGNED_NEGATIVE_FACTOR_SIGNAL_MIN: i32 = -65535_i32;
+    pub const UNSIGNED_NEGATIVE_FACTOR_SIGNAL_MAX: i32 = 0_i32;
 
     /// Construct new NegativeFactor from values
-    pub fn new(negative_factor_signal: i32) -> Result<Self, CanError> {
+    pub fn new(unsigned_negative_factor_signal: i32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 2] };
-        res.set_negative_factor_signal(negative_factor_signal)?;
+        res.set_unsigned_negative_factor_signal(unsigned_negative_factor_signal)?;
         Ok(res)
     }
 
@@ -1861,18 +1861,18 @@ impl NegativeFactor {
         &self.raw
     }
 
-    /// NegativeFactorSignal
+    /// UnsignedNegativeFactorSignal
     ///
     /// - Min: -65535
     /// - Max: 0
     /// - Unit: ""
     /// - Receivers: Vector__XXX
     #[inline(always)]
-    pub fn negative_factor_signal(&self) -> i32 {
-        self.negative_factor_signal_raw()
+    pub fn unsigned_negative_factor_signal(&self) -> i32 {
+        self.unsigned_negative_factor_signal_raw()
     }
 
-    /// Get raw value of NegativeFactorSignal
+    /// Get raw value of UnsignedNegativeFactorSignal
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -1881,16 +1881,16 @@ impl NegativeFactor {
     /// - Byte order: LittleEndian
     /// - Value type: Unsigned
     #[inline(always)]
-    pub fn negative_factor_signal_raw(&self) -> i32 {
+    pub fn unsigned_negative_factor_signal_raw(&self) -> i32 {
         let signal = self.raw.view_bits::<Lsb0>()[0..16].load_le::<u16>();
 
         let factor = -1;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
 
-    /// Set value of NegativeFactorSignal
+    /// Set value of UnsignedNegativeFactorSignal
     #[inline(always)]
-    pub fn set_negative_factor_signal(&mut self, value: i32) -> Result<(), CanError> {
+    pub fn set_unsigned_negative_factor_signal(&mut self, value: i32) -> Result<(), CanError> {
         if value < -65535_i32 || 0_i32 < value {
             return Err(CanError::ParameterOutOfRange { message_id: 1344 });
         }
@@ -1923,7 +1923,10 @@ impl core::fmt::Debug for NegativeFactor {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
             f.debug_struct("NegativeFactor")
-                .field("negative_factor_signal", &self.negative_factor_signal())
+                .field(
+                    "unsigned_negative_factor_signal",
+                    &self.unsigned_negative_factor_signal(),
+                )
                 .finish()
         } else {
             f.debug_tuple("NegativeFactor").field(&self.raw).finish()
@@ -1934,8 +1937,9 @@ impl core::fmt::Debug for NegativeFactor {
 #[cfg(feature = "arb")]
 impl<'a> Arbitrary<'a> for NegativeFactor {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
-        let negative_factor_signal = u.int_in_range(-65535..=0)?;
-        NegativeFactor::new(negative_factor_signal).map_err(|_| arbitrary::Error::IncorrectFormat)
+        let unsigned_negative_factor_signal = u.int_in_range(-65535..=0)?;
+        NegativeFactor::new(unsigned_negative_factor_signal)
+            .map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -1535,18 +1535,18 @@ impl IntegerFactorOffset {
     pub const BYTE_WITH_FACTOR_MAX: u16 = 1020_u16;
     pub const BYTE_WITH_BOTH_MIN: u16 = 16_u16;
     pub const BYTE_WITH_BOTH_MAX: u16 = 526_u16;
-    pub const BYTE_WITH_NEGATIVE_OFFSET_MIN: u8 = 0_u8;
-    pub const BYTE_WITH_NEGATIVE_OFFSET_MAX: u8 = 255_u8;
-    pub const BYTE_WITH_NEGATIVE_MIN_MIN: i8 = -127_i8;
-    pub const BYTE_WITH_NEGATIVE_MIN_MAX: i8 = 127_i8;
+    pub const BYTE_WITH_NEGATIVE_OFFSET_MIN: i16 = 0_i16;
+    pub const BYTE_WITH_NEGATIVE_OFFSET_MAX: i16 = 255_i16;
+    pub const BYTE_WITH_NEGATIVE_MIN_MIN: i16 = -127_i16;
+    pub const BYTE_WITH_NEGATIVE_MIN_MAX: i16 = 127_i16;
 
     /// Construct new IntegerFactorOffset from values
     pub fn new(
         byte_with_offset: u16,
         byte_with_factor: u16,
         byte_with_both: u16,
-        byte_with_negative_offset: u8,
-        byte_with_negative_min: i8,
+        byte_with_negative_offset: i16,
+        byte_with_negative_min: i16,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 8] };
         res.set_byte_with_offset(byte_with_offset)?;
@@ -1698,7 +1698,7 @@ impl IntegerFactorOffset {
     /// - Unit: ""
     /// - Receivers: Vector__XXX
     #[inline(always)]
-    pub fn byte_with_negative_offset(&self) -> u8 {
+    pub fn byte_with_negative_offset(&self) -> i16 {
         self.byte_with_negative_offset_raw()
     }
 
@@ -1711,17 +1711,17 @@ impl IntegerFactorOffset {
     /// - Byte order: LittleEndian
     /// - Value type: Unsigned
     #[inline(always)]
-    pub fn byte_with_negative_offset_raw(&self) -> u8 {
+    pub fn byte_with_negative_offset_raw(&self) -> i16 {
         let signal = self.raw.view_bits::<Lsb0>()[24..32].load_le::<u8>();
 
         let factor = 1;
-        u8::from(signal).saturating_mul(factor).saturating_sub(1)
+        i16::from(signal).saturating_mul(factor).saturating_sub(1)
     }
 
     /// Set value of ByteWithNegativeOffset
     #[inline(always)]
-    pub fn set_byte_with_negative_offset(&mut self, value: u8) -> Result<(), CanError> {
-        if value < 0_u8 || 255_u8 < value {
+    pub fn set_byte_with_negative_offset(&mut self, value: i16) -> Result<(), CanError> {
+        if value < 0_i16 || 255_i16 < value {
             return Err(CanError::ParameterOutOfRange { message_id: 1337 });
         }
         let factor = 1;
@@ -1741,7 +1741,7 @@ impl IntegerFactorOffset {
     /// - Unit: ""
     /// - Receivers: Vector__XXX
     #[inline(always)]
-    pub fn byte_with_negative_min(&self) -> i8 {
+    pub fn byte_with_negative_min(&self) -> i16 {
         self.byte_with_negative_min_raw()
     }
 
@@ -1754,18 +1754,17 @@ impl IntegerFactorOffset {
     /// - Byte order: LittleEndian
     /// - Value type: Unsigned
     #[inline(always)]
-    pub fn byte_with_negative_min_raw(&self) -> i8 {
+    pub fn byte_with_negative_min_raw(&self) -> i16 {
         let signal = self.raw.view_bits::<Lsb0>()[32..40].load_le::<u8>();
 
         let factor = 1;
-        let signal = signal as i8;
-        i8::from(signal).saturating_mul(factor).saturating_sub(1)
+        i16::from(signal).saturating_mul(factor).saturating_sub(1)
     }
 
     /// Set value of ByteWithNegativeMin
     #[inline(always)]
-    pub fn set_byte_with_negative_min(&mut self, value: i8) -> Result<(), CanError> {
-        if value < -127_i8 || 127_i8 < value {
+    pub fn set_byte_with_negative_min(&mut self, value: i16) -> Result<(), CanError> {
+        if value < -127_i16 || 127_i16 < value {
             return Err(CanError::ParameterOutOfRange { message_id: 1337 });
         }
         let factor = 1;
@@ -1846,70 +1845,25 @@ pub struct NegativeFactorTest {
 impl NegativeFactorTest {
     pub const MESSAGE_ID: u32 = 1344;
 
-    pub const WIDTH_MORE_THAN_MIN_MAX_MIN: i8 = -2_i8;
-    pub const WIDTH_MORE_THAN_MIN_MAX_MAX: i8 = 2_i8;
     pub const UNSIGNED_NEGATIVE_FACTOR_SIGNAL_MIN: i32 = -65535_i32;
     pub const UNSIGNED_NEGATIVE_FACTOR_SIGNAL_MAX: i32 = 0_i32;
+    pub const WIDTH_MORE_THAN_MIN_MAX_MIN: i16 = -2_i16;
+    pub const WIDTH_MORE_THAN_MIN_MAX_MAX: i16 = 2_i16;
 
     /// Construct new NegativeFactorTest from values
     pub fn new(
-        width_more_than_min_max: i8,
         unsigned_negative_factor_signal: i32,
+        width_more_than_min_max: i16,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 4] };
-        res.set_width_more_than_min_max(width_more_than_min_max)?;
         res.set_unsigned_negative_factor_signal(unsigned_negative_factor_signal)?;
+        res.set_width_more_than_min_max(width_more_than_min_max)?;
         Ok(res)
     }
 
     /// Access message payload raw value
     pub fn raw(&self) -> &[u8; 4] {
         &self.raw
-    }
-
-    /// WidthMoreThanMinMax
-    ///
-    /// - Min: -2
-    /// - Max: 2
-    /// - Unit: ""
-    /// - Receivers: Vector__XXX
-    #[inline(always)]
-    pub fn width_more_than_min_max(&self) -> i8 {
-        self.width_more_than_min_max_raw()
-    }
-
-    /// Get raw value of WidthMoreThanMinMax
-    ///
-    /// - Start bit: 16
-    /// - Signal size: 10 bits
-    /// - Factor: 1
-    /// - Offset: 0
-    /// - Byte order: LittleEndian
-    /// - Value type: Signed
-    #[inline(always)]
-    pub fn width_more_than_min_max_raw(&self) -> i8 {
-        let signal = self.raw.view_bits::<Lsb0>()[16..26].load_le::<u16>();
-
-        let signal = i16::from_ne_bytes(signal.to_ne_bytes());
-        let factor = 1;
-        i8::from(signal).saturating_mul(factor).saturating_add(0)
-    }
-
-    /// Set value of WidthMoreThanMinMax
-    #[inline(always)]
-    pub fn set_width_more_than_min_max(&mut self, value: i8) -> Result<(), CanError> {
-        if value < -2_i8 || 2_i8 < value {
-            return Err(CanError::ParameterOutOfRange { message_id: 1344 });
-        }
-        let factor = 1;
-        let value = value
-            .checked_sub(0)
-            .ok_or(CanError::ParameterOutOfRange { message_id: 1344 })?;
-        let value = (value / factor) as i16;
-
-        let value = u16::from_ne_bytes(value.to_ne_bytes());
-        self.raw.view_bits_mut::<Lsb0>()[16..26].store_le(value);
-        Ok(())
     }
 
     /// UnsignedNegativeFactorSignal
@@ -1954,6 +1908,52 @@ impl NegativeFactorTest {
         self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
         Ok(())
     }
+
+    /// WidthMoreThanMinMax
+    ///
+    /// - Min: -2
+    /// - Max: 2
+    /// - Unit: ""
+    /// - Receivers: Vector__XXX
+    #[inline(always)]
+    pub fn width_more_than_min_max(&self) -> i16 {
+        self.width_more_than_min_max_raw()
+    }
+
+    /// Get raw value of WidthMoreThanMinMax
+    ///
+    /// - Start bit: 16
+    /// - Signal size: 10 bits
+    /// - Factor: 1
+    /// - Offset: 0
+    /// - Byte order: LittleEndian
+    /// - Value type: Signed
+    #[inline(always)]
+    pub fn width_more_than_min_max_raw(&self) -> i16 {
+        let signal = self.raw.view_bits::<Lsb0>()[16..26].load_le::<u16>();
+
+        let signal = i16::from_ne_bytes(signal.to_ne_bytes());
+        let factor = 1;
+        let signal = signal as i16;
+        i16::from(signal).saturating_mul(factor).saturating_add(0)
+    }
+
+    /// Set value of WidthMoreThanMinMax
+    #[inline(always)]
+    pub fn set_width_more_than_min_max(&mut self, value: i16) -> Result<(), CanError> {
+        if value < -2_i16 || 2_i16 < value {
+            return Err(CanError::ParameterOutOfRange { message_id: 1344 });
+        }
+        let factor = 1;
+        let value = value
+            .checked_sub(0)
+            .ok_or(CanError::ParameterOutOfRange { message_id: 1344 })?;
+        let value = (value / factor) as i16;
+
+        let value = u16::from_ne_bytes(value.to_ne_bytes());
+        self.raw.view_bits_mut::<Lsb0>()[16..26].store_le(value);
+        Ok(())
+    }
 }
 
 impl core::convert::TryFrom<&[u8]> for NegativeFactorTest {
@@ -1974,11 +1974,11 @@ impl core::fmt::Debug for NegativeFactorTest {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
             f.debug_struct("NegativeFactorTest")
-                .field("width_more_than_min_max", &self.width_more_than_min_max())
                 .field(
                     "unsigned_negative_factor_signal",
                     &self.unsigned_negative_factor_signal(),
                 )
+                .field("width_more_than_min_max", &self.width_more_than_min_max())
                 .finish()
         } else {
             f.debug_tuple("NegativeFactorTest")
@@ -1991,9 +1991,9 @@ impl core::fmt::Debug for NegativeFactorTest {
 #[cfg(feature = "arb")]
 impl<'a> Arbitrary<'a> for NegativeFactorTest {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
-        let width_more_than_min_max = u.int_in_range(-2..=2)?;
         let unsigned_negative_factor_signal = u.int_in_range(-65535..=0)?;
-        NegativeFactorTest::new(width_more_than_min_max, unsigned_negative_factor_signal)
+        let width_more_than_min_max = u.int_in_range(-2..=2)?;
+        NegativeFactorTest::new(unsigned_negative_factor_signal, width_more_than_min_max)
             .map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -6,7 +6,6 @@ use can_messages::{
 };
 
 #[test]
-#[cfg(feature = "range_checked")]
 fn check_range_value_error() {
     let result = Bar::new(1, 2.0, 3, 4, true);
     assert!(matches!(
@@ -16,7 +15,6 @@ fn check_range_value_error() {
 }
 
 #[test]
-#[cfg(feature = "range_checked")]
 fn check_range_value_valid() {
     let result = Bar::new(1, 2.0, 3, 3, true);
     assert!(result.is_ok());

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -2,7 +2,7 @@
 
 use can_messages::{
     Amet, Bar, BarThree, CanError, Foo, LargerIntsWithOffsets, MultiplexTest,
-    MultiplexTestMultiplexorIndex, MultiplexTestMultiplexorM0, NegativeFactor
+    MultiplexTestMultiplexorIndex, MultiplexTestMultiplexorM0, NegativeFactorTest,
 };
 
 #[test]
@@ -138,7 +138,19 @@ fn from_enum_into_raw() {
 
 #[test]
 fn negative_factor() {
-    assert_eq!(NegativeFactor::UNSIGNED_NEGATIVE_FACTOR_SIGNAL_MIN, -65535_i32,
-               "Rust type should expand to i32 to hold the negated u16");
+    assert_eq!(
+        NegativeFactorTest::UNSIGNED_NEGATIVE_FACTOR_SIGNAL_MIN,
+        -65535_i32,
+        "Rust type should expand to i32 to hold the negated u16"
+    );
 }
 
+
+#[test]
+fn test_min_max_doesnt_confuse_width() {
+    assert_eq!(
+        NegativeFactorTest::WIDTH_MORE_THAN_MIN_MAX_MAX,
+        2_i16,
+        "This signal should be a Rust i16 because the underlying signal is 10 bits."
+    )
+}

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -143,7 +143,6 @@ fn negative_factor() {
     );
 }
 
-
 #[test]
 fn test_min_max_doesnt_confuse_width() {
     assert_eq!(

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -148,6 +148,6 @@ fn test_min_max_doesnt_confuse_width() {
     assert_eq!(
         NegativeFactorTest::WIDTH_MORE_THAN_MIN_MAX_MAX,
         2_i16,
-        "This signal should be a Rust i16 because the underlying signal is 10 bits."
+        "This signal should be i16 even though the min/max only needs i8."
     )
 }

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -2,7 +2,7 @@
 
 use can_messages::{
     Amet, Bar, BarThree, CanError, Foo, LargerIntsWithOffsets, MultiplexTest,
-    MultiplexTestMultiplexorIndex, MultiplexTestMultiplexorM0,
+    MultiplexTestMultiplexorIndex, MultiplexTestMultiplexorM0, NegativeFactor
 };
 
 #[test]
@@ -135,3 +135,10 @@ fn from_enum_into_raw() {
     let raw: u8 = BarThree::Onest.into();
     assert_eq!(raw, 3);
 }
+
+#[test]
+fn negative_factor() {
+    assert_eq!(NegativeFactor::UNSIGNED_NEGATIVE_FACTOR_SIGNAL_MIN, -65535_i32,
+               "Rust type should expand to i32 to hold the negated u16");
+}
+

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -48,7 +48,7 @@ BO_ 1337 IntegerFactorOffset: 8 Sit
  SG_ ByteWithNegativeMin : 32|8@1+ (1,-1) [-127|127] "" Vector__XXX
 
 BO_ 1344 NegativeFactor: 2 Sit
- SG_ NegativeFactorSignal : 0|16@1+ (-1,0) [-65535|0] "" Vector__XXX
+ SG_ UnsignedNegativeFactorSignal : 0|16@1+ (-1,0) [-65535|0] "" Vector__XXX
 
 BO_ 1338 LargerIntsWithOffsets: 8 Sit
  SG_ Twelve : 0|12@1+ (1,-1000) [-1000|3000] "" XXX

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -48,8 +48,8 @@ BO_ 1337 IntegerFactorOffset: 8 Sit
  SG_ ByteWithNegativeMin : 32|8@1+ (1,-1) [-127|127] "" Vector__XXX
 
 BO_ 1344 NegativeFactorTest: 4 Sit
- SG_ WidthMoreThanMinMax : 16|10@1- (1,0) [-2|2] "" Vector__XXX
  SG_ UnsignedNegativeFactorSignal : 0|16@1+ (-1,0) [-65535|0] "" Vector__XXX
+ SG_ WidthMoreThanMinMax : 16|10@1- (1,0) [-2|2] "" Vector__XXX
 
 BO_ 1338 LargerIntsWithOffsets: 8 Sit
  SG_ Twelve : 0|12@1+ (1,-1000) [-1000|3000] "" XXX

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -47,6 +47,9 @@ BO_ 1337 IntegerFactorOffset: 8 Sit
  SG_ ByteWithNegativeOffset : 24|8@1+ (1,-1) [0|255] "" Vector__XXX
  SG_ ByteWithNegativeMin : 32|8@1+ (1,-1) [-127|127] "" Vector__XXX
 
+BO_ 1344 NegativeFactor: 2 Sit
+ SG_ NegativeFactorSignal : 0|16@1+ (-1,0) [-65535|0] "" Vector__XXX
+
 BO_ 1338 LargerIntsWithOffsets: 8 Sit
  SG_ Twelve : 0|12@1+ (1,-1000) [-1000|3000] "" XXX
  SG_ Sixteen : 12|16@1+ (1,-1000) [-1000|64535] "" XXX

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -47,7 +47,8 @@ BO_ 1337 IntegerFactorOffset: 8 Sit
  SG_ ByteWithNegativeOffset : 24|8@1+ (1,-1) [0|255] "" Vector__XXX
  SG_ ByteWithNegativeMin : 32|8@1+ (1,-1) [-127|127] "" Vector__XXX
 
-BO_ 1344 NegativeFactor: 2 Sit
+BO_ 1344 NegativeFactorTest: 4 Sit
+ SG_ WidthMoreThanMinMax : 16|10@1- (1,0) [-2|2] "" Vector__XXX
  SG_ UnsignedNegativeFactorSignal : 0|16@1+ (-1,0) [-65535|0] "" Vector__XXX
 
 BO_ 1338 LargerIntsWithOffsets: 8 Sit


### PR DESCRIPTION
This PR fixes a bug in how the library chooses Rust types to represent signals. 

We tried a DBC with a 16 bit unsigned signal with a factor of -1. This means the range of valid values is `[-65535, 0]`. But this confused the function `scaled_signal_to_rust_int` which chose `i8` when it should have picked `i32`. 

This PR will: 
* Change `scaled_signal_to_rust_int` to look at the whole range of values for a signal and pick the smallest Rust type. 
* Ignore `min` and `max` values when deciding Rust types for a signal because `Config.check_ranges` can disable range checking. To be on the safe side, this picks types assuming the worst-case values for a signal. 
* Drop the symlink in `testing/can-messages/src/messages.rs` because it doesn't work on Windows. Now `testing/can-messages/build.rs` copies the file from `can-messages` to `can-embedded`. 
* Fix build order so `can-messages` goes before `can-embedded`. 
* Add unit and integration tests. `UnsignedNegativeFactorSignal` in `example.dbc` will reproduce the bug.

Happy to address any comments or change requests. 