### PR TITLE
Fix issue with decoding signed values of non-standard length

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -832,7 +832,7 @@ fn signal_from_payload(mut w: impl Write, signal: &Signal, msg: &Message) -> Res
 
             format!(
                 "self.raw.view_bits::<Lsb0>()[{start}..{end}].load_le::<{typ}>()",
-                typ = signal_to_rust_uint(signal),
+                typ = signal_to_rust_int(signal),
                 start = start_bit,
                 end = end_bit,
             )
@@ -842,7 +842,7 @@ fn signal_from_payload(mut w: impl Write, signal: &Signal, msg: &Message) -> Res
 
             format!(
                 "self.raw.view_bits::<Msb0>()[{start}..{end}].load_be::<{typ}>()",
-                typ = signal_to_rust_uint(signal),
+                typ = signal_to_rust_int(signal),
                 start = start_bit,
                 end = end_bit
             )
@@ -851,14 +851,6 @@ fn signal_from_payload(mut w: impl Write, signal: &Signal, msg: &Message) -> Res
 
     writeln!(&mut w, r#"let signal = {};"#, read_fn)?;
     writeln!(&mut w)?;
-
-    if *signal.value_type() == can_dbc::ValueType::Signed {
-        writeln!(
-            &mut w,
-            "let signal  = {}::from_ne_bytes(signal.to_ne_bytes());",
-            signal_to_rust_int(signal)
-        )?;
-    };
 
     if signal.signal_size == 1 {
         writeln!(&mut w, "signal == 1")?;

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -3,6 +3,7 @@
 use can_messages::{
     Amet, Bar, BarThree, CanError, Foo, LargerIntsWithOffsets, MultiplexTest,
     MultiplexTestMultiplexorIndex, MultiplexTestMultiplexorM0, NegativeFactorTest,
+    TruncatedBeSignal, TruncatedLeSignal,
 };
 
 #[test]
@@ -73,6 +74,24 @@ fn pack_unpack_message_containing_multiplexed_signals() {
     } else {
         panic!("Invalid multiplexor value");
     }
+}
+
+#[test]
+fn pack_unpack_signed_truncated_signal() {
+    let result = TruncatedBeSignal::new(42).unwrap();
+    assert_eq!(result.foo_raw(), 42);
+
+    let result = TruncatedLeSignal::new(42).unwrap();
+    assert_eq!(result.foo_raw(), 42);
+}
+
+#[test]
+fn pack_unpack_signed_truncated_signal_negative() {
+    let result = TruncatedBeSignal::new(-42).unwrap();
+    assert_eq!(result.foo_raw(), -42);
+
+    let result = TruncatedLeSignal::new(-42).unwrap();
+    assert_eq!(result.foo_raw(), -42);
 }
 
 #[test]

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -57,6 +57,12 @@ BO_ 1338 LargerIntsWithOffsets: 8 Sit
 
 BO_ 513 MsgWithoutSignals: 8 Ipsum
 
+BO_ 9001 TruncatedBeSignal: 8 Ipsum
+  SG_ Foo : 0|12@0- (1,0) [-100|100] "" Vector__XXX
+
+BO_ 9002 TruncatedLeSignal: 8 Ipsum
+  SG_ Foo : 0|12@1- (1,0) [-100|100] "" Vector__XXX
+
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";
 VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";
 VAL_ 512 Type 0 "0Off" 1 "1On";


### PR DESCRIPTION
I noticed certain signals were getting decoded incorrectly from one of my DBC files. I tracked this down to signed values that have less bits than the corresponding rust type. For instance if I have a signed signal `foo` with 4 bits (corresponding to a rust i8):

If I try to set a value of -3, it correctly gets encoded in `fn set_foo` to the bits `[1, 0, 1, 1]`. Then in `fn foo_raw` it was first loading the data as a `u8`, and since the 4 most significant bits get dropped, the value gets read in as `13` rather than `253`. So when that value gets converted to an `i8` the result is `13` instead of `-3`. It seems like `bitvec::field::BitSlice::load_le<i8>`, on the other hand, works correctly without the intermediate conversion to a `u8`