### PR TITLE
Support extended IDs and generate impls for embedded_can::Frame trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "can-dbc"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2d32f0a7f3754502f84cb68e493a6765ce0978348a59efcb1bccf2ee19c255"
+checksum = "cbe0d033ec316c3bb50e2e53d7ef3d8805e65c5f976d49daea65a12f7e0f9ce8"
 dependencies = [
  "derive-getters",
  "nom",
@@ -144,6 +144,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "can-messages",
+ "embedded-can",
 ]
 
 [[package]]
@@ -154,6 +155,7 @@ dependencies = [
  "arbitrary",
  "bitvec",
  "dbc-codegen",
+ "embedded-can",
 ]
 
 [[package]]
@@ -249,6 +251,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "can-dbc",
+ "embedded-can",
  "heck 0.4.1",
  "typed-builder",
 ]
@@ -265,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0122f262bf9c9a367829da84f808d9fb128c10ef283bbe7b0922a77cf07b2747"
+checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -279,6 +282,15 @@ name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "embedded-can"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
+dependencies = [
+ "nb",
+]
 
 [[package]]
 name = "errno"
@@ -397,6 +409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +479,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "can-messages",
+ "embedded-can",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ rust-version = "1.78.0"
 std = []
 
 [dependencies]
-can-dbc = "5.0.0"
+can-dbc = "6.0.0"
 anyhow = "1.0.68"
 heck = "0.4.0"
 typed-builder = "0.18.0"
+embedded-can = "0.4.1"
 
 [workspace]
 members = [

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "can-dbc"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2d32f0a7f3754502f84cb68e493a6765ce0978348a59efcb1bccf2ee19c255"
+checksum = "cbe0d033ec316c3bb50e2e53d7ef3d8805e65c5f976d49daea65a12f7e0f9ce8"
 dependencies = [
  "derive-getters",
  "nom",
@@ -73,6 +73,7 @@ dependencies = [
  "arbitrary",
  "bitvec",
  "dbc-codegen",
+ "embedded-can",
 ]
 
 [[package]]
@@ -122,6 +123,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "can-dbc",
+ "embedded-can",
  "heck",
  "typed-builder",
 ]
@@ -137,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0122f262bf9c9a367829da84f808d9fb128c10ef283bbe7b0922a77cf07b2747"
+checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -151,6 +153,15 @@ name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "embedded-can"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
+dependencies = [
+ "nb",
+]
 
 [[package]]
 name = "errno"
@@ -263,6 +274,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "nom"

--- a/src/includes/errors.rs
+++ b/src/includes/errors.rs
@@ -1,17 +1,17 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
-    UnknownMessageId(u32),
+    UnknownMessageId(embedded_can::Id),
     /// Signal parameter is not within the range
     /// defined in the dbc
     ParameterOutOfRange {
         /// dbc message id
-        message_id: u32,
+        message_id: embedded_can::Id,
     },
     InvalidPayloadSize,
     /// Multiplexor value not defined in the dbc
     InvalidMultiplexor {
         /// dbc message id
-        message_id: u32,
+        message_id: embedded_can::Id,
         /// Multiplexor value not defined in the dbc
         multiplexor: u16,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ pub fn codegen(config: Config<'_>, out: impl Write) -> Result<()> {
     writeln!(&mut w)?;
     writeln!(&mut w, "use core::ops::BitOr;")?;
     writeln!(&mut w, "use bitvec::prelude::*;")?;
+    writeln!(&mut w, "use embedded_can::{{Id, StandardId, ExtendedId}};")?;
 
     writeln!(w, r##"#[cfg(feature = "arb")]"##)?;
     writeln!(&mut w, "use arbitrary::{{Arbitrary, Unstructured}};")?;
@@ -210,7 +211,7 @@ fn render_root_enum(mut w: impl Write, dbc: &DBC, config: &Config<'_>) -> Result
         writeln!(w, "#[inline(never)]")?;
         writeln!(
             &mut w,
-            "pub fn from_can_message(id: u32, payload: &[u8]) -> Result<Self, CanError> {{",
+            "pub fn from_can_message(id: Id, payload: &[u8]) -> Result<Self, CanError> {{",
         )?;
         {
             let mut w = PadAdapter::wrap(&mut w);
@@ -221,12 +222,11 @@ fn render_root_enum(mut w: impl Write, dbc: &DBC, config: &Config<'_>) -> Result
                 for msg in get_relevant_messages(dbc) {
                     writeln!(
                         w,
-                        "{} => Messages::{1}({1}::try_from(payload)?),",
-                        msg.message_id().0,
+                        "{0}::MESSAGE_ID => Messages::{0}({0}::try_from(payload)?),",
                         type_name(msg.message_name())
                     )?;
                 }
-                writeln!(w, r#"n => return Err(CanError::UnknownMessageId(n)),"#)?;
+                writeln!(w, r#"id => return Err(CanError::UnknownMessageId(id)),"#)?;
             }
             writeln!(&mut w, "}};")?;
             writeln!(&mut w, "Ok(res)")?;
@@ -243,7 +243,10 @@ fn render_root_enum(mut w: impl Write, dbc: &DBC, config: &Config<'_>) -> Result
 fn render_message(mut w: impl Write, config: &Config<'_>, msg: &Message, dbc: &DBC) -> Result<()> {
     writeln!(w, "/// {}", msg.message_name())?;
     writeln!(w, "///")?;
-    writeln!(w, "/// - ID: {0} (0x{0:x})", msg.message_id().0)?;
+    match msg.message_id() {
+        can_dbc::MessageId::Standard(id) => writeln!(w, "/// - Standard ID: {0} (0x{0:x})", id),
+        can_dbc::MessageId::Extended(id) => writeln!(w, "/// - Extended ID: {0} (0x{0:x})", id),
+    }?;
     writeln!(w, "/// - Size: {} bytes", msg.message_size())?;
     if let can_dbc::Transmitter::NodeName(transmitter) = msg.transmitter() {
         writeln!(w, "/// - Transmitter: {}", transmitter)?;
@@ -274,8 +277,18 @@ fn render_message(mut w: impl Write, config: &Config<'_>, msg: &Message, dbc: &D
 
         writeln!(
             &mut w,
-            "pub const MESSAGE_ID: u32 = {};",
-            msg.message_id().0
+            "pub const MESSAGE_ID: embedded_can::Id = {};",
+            match msg.message_id() {
+                // use StandardId::new().unwrap() once const_option is stable
+                can_dbc::MessageId::Standard(id) => format!(
+                    "Id::Standard(unsafe {{ StandardId::new_unchecked({0:#x})}})",
+                    id
+                ),
+                can_dbc::MessageId::Extended(id) => format!(
+                    "Id::Extended(unsafe {{ ExtendedId::new_unchecked({0:#x})}})",
+                    id
+                ),
+            }
         )?;
         writeln!(w)?;
 
@@ -623,8 +636,8 @@ fn render_set_signal(
                     let mut w = PadAdapter::wrap(&mut w);
                     writeln!(
                         w,
-                        r##"return Err(CanError::ParameterOutOfRange {{ message_id: {message_id} }});"##,
-                        message_id = msg.message_id().0,
+                        r##"return Err(CanError::ParameterOutOfRange {{ message_id: {}::MESSAGE_ID }});"##,
+                        type_name(msg.message_name())
                     )?;
                 }
                 writeln!(w, r"}}")?;
@@ -742,8 +755,8 @@ fn render_multiplexor_signal(
             }
             writeln!(
                 &mut w,
-                "multiplexor => Err(CanError::InvalidMultiplexor {{ message_id: {}, multiplexor: multiplexor.into() }}),",
-                msg.message_id().0
+                "multiplexor => Err(CanError::InvalidMultiplexor {{ message_id: {}::MESSAGE_ID, multiplexor: multiplexor.into() }}),",
+                type_name(msg.message_name())
             )?;
         }
 
@@ -914,8 +927,7 @@ fn signal_to_payload(mut w: impl Write, signal: &Signal, msg: &Message) -> Resul
         }
         writeln!(
             &mut w,
-            "    .ok_or(CanError::ParameterOutOfRange {{ message_id: {} }})?;",
-            msg.message_id().0,
+            "    .ok_or(CanError::ParameterOutOfRange {{ message_id: Self::MESSAGE_ID }})?;",
         )?;
         writeln!(
             &mut w,

--- a/testing/can-embedded/Cargo.toml
+++ b/testing/can-embedded/Cargo.toml
@@ -10,6 +10,7 @@ build-messages = ["dep:can-messages"]
 
 [dependencies]
 bitvec = { version = "1.0", default-features = false }
+embedded-can = "0.4.1"
 
 
 # This is optional and default so we can turn it off for the embedded target.

--- a/testing/can-messages/Cargo.toml
+++ b/testing/can-messages/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 bitvec = { version = "1.0", default-features = false }
 arbitrary = { version = "1.0", optional = true }
+embedded-can = "0.4.1"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/testing/can-messages/src/messages.rs
+++ b/testing/can-messages/src/messages.rs
@@ -223,6 +223,42 @@ impl core::convert::TryFrom<&[u8]> for Foo {
     }
 }
 
+impl embedded_can::Frame for Foo {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for Foo {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -534,6 +570,42 @@ impl core::convert::TryFrom<&[u8]> for Bar {
     }
 }
 
+impl embedded_can::Frame for Bar {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for Bar {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -720,6 +792,42 @@ impl core::convert::TryFrom<&[u8]> for X4wd {
     }
 }
 
+impl embedded_can::Frame for X4wd {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for X4wd {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -1028,6 +1136,42 @@ impl core::convert::TryFrom<&[u8]> for Amet {
     }
 }
 
+impl embedded_can::Frame for Amet {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for Amet {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -1150,6 +1294,42 @@ impl core::convert::TryFrom<&[u8]> for Dolor {
     }
 }
 
+impl embedded_can::Frame for Dolor {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for Dolor {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -1355,6 +1535,42 @@ impl core::convert::TryFrom<&[u8]> for MultiplexTest {
     }
 }
 
+impl embedded_can::Frame for MultiplexTest {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for MultiplexTest {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -1866,6 +2082,42 @@ impl core::convert::TryFrom<&[u8]> for IntegerFactorOffset {
     }
 }
 
+impl embedded_can::Frame for IntegerFactorOffset {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for IntegerFactorOffset {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -2048,6 +2300,42 @@ impl core::convert::TryFrom<&[u8]> for NegativeFactorTest {
     }
 }
 
+impl embedded_can::Frame for NegativeFactorTest {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for NegativeFactorTest {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -2222,6 +2510,42 @@ impl core::convert::TryFrom<&[u8]> for LargerIntsWithOffsets {
     }
 }
 
+impl embedded_can::Frame for LargerIntsWithOffsets {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for LargerIntsWithOffsets {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -2286,6 +2610,42 @@ impl core::convert::TryFrom<&[u8]> for MsgWithoutSignals {
     }
 }
 
+impl embedded_can::Frame for MsgWithoutSignals {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for MsgWithoutSignals {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -2394,6 +2754,42 @@ impl core::convert::TryFrom<&[u8]> for TruncatedBeSignal {
     }
 }
 
+impl embedded_can::Frame for TruncatedBeSignal {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for TruncatedBeSignal {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -2505,6 +2901,42 @@ impl core::convert::TryFrom<&[u8]> for TruncatedLeSignal {
     }
 }
 
+impl embedded_can::Frame for TruncatedLeSignal {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for TruncatedLeSignal {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
@@ -2614,6 +3046,42 @@ impl core::convert::TryFrom<&[u8]> for MsgExtendedId {
     }
 }
 
+impl embedded_can::Frame for MsgExtendedId {
+    fn new(id: impl Into<Id>, data: &[u8]) -> Option<Self> {
+        if id.into() != Self::MESSAGE_ID {
+            None
+        } else {
+            data.try_into().ok()
+        }
+    }
+
+    fn new_remote(_id: impl Into<Id>, _dlc: usize) -> Option<Self> {
+        unimplemented!()
+    }
+
+    fn is_extended(&self) -> bool {
+        match self.id() {
+            Id::Standard(_) => false,
+            Id::Extended(_) => true,
+        }
+    }
+
+    fn is_remote_frame(&self) -> bool {
+        false
+    }
+
+    fn id(&self) -> Id {
+        Self::MESSAGE_ID
+    }
+
+    fn dlc(&self) -> usize {
+        self.raw.len()
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.raw
+    }
+}
 impl core::fmt::Debug for MsgExtendedId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -1,18 +1,21 @@
 #![allow(clippy::float_cmp)]
 
 use can_messages::{
-    Amet, Bar, BarThree, CanError, Foo, LargerIntsWithOffsets, MultiplexTest,
+    Amet, Bar, BarThree, CanError, Foo, LargerIntsWithOffsets, MsgExtendedId, MultiplexTest,
     MultiplexTestMultiplexorIndex, MultiplexTestMultiplexorM0, NegativeFactorTest,
     TruncatedBeSignal, TruncatedLeSignal,
 };
+use embedded_can::{ExtendedId, Id, StandardId};
 
 #[test]
 fn check_range_value_error() {
     let result = Bar::new(1, 2.0, 3, 4, true);
-    assert!(matches!(
-        result,
-        Err(CanError::ParameterOutOfRange { message_id: 512 })
-    ));
+    assert_eq!(
+        result.unwrap_err(),
+        CanError::ParameterOutOfRange {
+            message_id: Id::Standard(StandardId::new(512).unwrap())
+        }
+    );
 }
 
 #[test]
@@ -118,14 +121,18 @@ fn offset_integers() {
     assert_eq!(m.sixteen(), -1000);
 
     // Setting out of range values
-    assert!(matches!(
+    assert_eq!(
         m.set_twelve(-2000),
-        Err(CanError::ParameterOutOfRange { message_id: 1338 })
-    ));
-    assert!(matches!(
+        Err(CanError::ParameterOutOfRange {
+            message_id: Id::Standard(StandardId::new(1338).unwrap())
+        })
+    );
+    assert_eq!(
         m.set_sixteen(65536),
-        Err(CanError::ParameterOutOfRange { message_id: 1338 })
-    ));
+        Err(CanError::ParameterOutOfRange {
+            message_id: Id::Standard(StandardId::new(1338).unwrap())
+        })
+    );
 }
 
 #[test]
@@ -168,5 +175,21 @@ fn test_min_max_doesnt_confuse_width() {
         NegativeFactorTest::WIDTH_MORE_THAN_MIN_MAX_MAX,
         2_i16,
         "This signal should be i16 even though the min/max only needs i8."
+    )
+}
+
+#[test]
+fn test_standard_id() {
+    assert_eq!(
+        Foo::MESSAGE_ID,
+        Id::Standard(StandardId::new(0x100).unwrap())
+    )
+}
+
+#[test]
+fn test_extended_id() {
+    assert_eq!(
+        MsgExtendedId::MESSAGE_ID,
+        Id::Extended(ExtendedId::new(0x1234).unwrap())
     )
 }

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -63,6 +63,9 @@ BO_ 9001 TruncatedBeSignal: 8 Ipsum
 BO_ 9002 TruncatedLeSignal: 8 Ipsum
   SG_ Foo : 0|12@1- (1,0) [-100|100] "" Vector__XXX
 
+BO_ 2147488308 MsgExtendedId: 8 Sit
+ SG_ Dummy : 15|2@0+ (1,0) [0|3] "" XXX
+
 VAL_ 512 Three 0 "OFF" 1 "ON" 2 "ONER" 3 "ONEST";
 VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";
 VAL_ 512 Type 0 "0Off" 1 "1On";

--- a/testing/rust-integration/Cargo.toml
+++ b/testing/rust-integration/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 [dependencies]
 approx = "0.4"
 can-messages = { path = "../can-messages" }
+embedded-can = "0.4.1"

--- a/testing/rust-integration/src/main.rs
+++ b/testing/rust-integration/src/main.rs
@@ -1,4 +1,5 @@
 use can_messages::Messages;
+use embedded_can::{Id, StandardId};
 
 fn main() {
     let input = std::env::args()
@@ -10,7 +11,7 @@ fn main() {
         let (id, payload) = {
             let mut s = data.split('#');
             let id = s.next().unwrap();
-            let id: u32 = u32::from_str_radix(id, 16).unwrap();
+            let id = Id::Standard(StandardId::new(u16::from_str_radix(id, 16).unwrap()).unwrap());
             let payload = s.next().unwrap();
             let payload = (0..(payload.len() / 2))
                 .map(|i| {


### PR DESCRIPTION
- upgraded `can-dbc` dependency to support parsing extended IDs
- added new dependency on `embedded_can` interface crate
- both standard and extended message IDs are represented by `embedded_can::Id` instead of `u32` (#66)
- generate trait impls `embedded_can::Frame` for each frame, so id or data can be accessed in generic way

Fixes #66
Superceeds #71