### PR TITLE
Use message name instead of self

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,7 +933,8 @@ fn signal_to_payload(mut w: impl Write, signal: &Signal, msg: &Message) -> Resul
         }
         writeln!(
             &mut w,
-            "    .ok_or(CanError::ParameterOutOfRange {{ message_id: Self::MESSAGE_ID }})?;",
+            "    .ok_or(CanError::ParameterOutOfRange {{ message_id: {}::MESSAGE_ID }})?;",
+            type_name(msg.message_name())
         )?;
         writeln!(
             &mut w,


### PR DESCRIPTION
The generated code for multiplexed messages is currently invalid because `Self` doesn't point to the message type in those cases and doesn't have a `MESSAGE_ID`