### PR TITLE
feat: float32 signal generation

### DIFF
--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::float_cmp)]
 
 use can_messages::{
-    Amet, Bar, BarThree, CanError, Foo, LargerIntsWithOffsets, MsgExtendedId, MultiplexTest,
+    Amet, Bar, BarThree, CanError, Float32Test, Foo, LargerIntsWithOffsets, MsgExtendedId, MultiplexTest,
     MultiplexTestMultiplexorIndex, MultiplexTestMultiplexorM0, NegativeFactorTest,
     TruncatedBeSignal, TruncatedLeSignal,
 };
@@ -133,6 +133,16 @@ fn offset_integers() {
             message_id: Id::Standard(StandardId::new(1338).unwrap())
         })
     );
+}
+
+#[test]
+fn floats() {
+    let m = Float32Test::new(42.0, 42.0).unwrap();
+
+    dbg!(m.raw());
+    assert_eq!(m.raw(), b"\x42\x28\x00\x00\x00\x00\x28\x42");
+    assert_eq!(m.float32_big_endian_raw(), 42.0);
+    assert_eq!(m.float32_little_endian_raw(), 42.0);
 }
 
 #[test]

--- a/testing/dbc-examples/example.dbc
+++ b/testing/dbc-examples/example.dbc
@@ -47,6 +47,10 @@ BO_ 1337 IntegerFactorOffset: 8 Sit
  SG_ ByteWithNegativeOffset : 24|8@1+ (1,-1) [0|255] "" Vector__XXX
  SG_ ByteWithNegativeMin : 32|8@1+ (1,-1) [-127|127] "" Vector__XXX
 
+BO_ 600 Float32Test: 8 Ipsum
+ SG_ Float32BigEndian : 7|32@0- (1,0) [-100|100] "" DBG
+ SG_ Float32LittleEndian : 32|32@1- (1,0) [-100|100] "" DBG
+
 BO_ 1344 NegativeFactorTest: 4 Sit
  SG_ UnsignedNegativeFactorSignal : 0|16@1+ (-1,0) [-65535|0] "" Vector__XXX
  SG_ WidthMoreThanMinMax : 16|10@1- (1,0) [-2|2] "" Vector__XXX
@@ -71,3 +75,6 @@ VAL_ 512 Four 0 "Off" 1 "On" 2 "Oner" 3 "Onest";
 VAL_ 512 Type 0 "0Off" 1 "1On";
 VAL_ 768 _4DRIVE 0 "OFF" 1 "2WD" 2 "4WD" 3 "ALL";
 VAL_ 1028 OneFloat 3 "Dolor" 5 "Other";
+
+SIG_VALTYPE_ 600 Float32BigEndian : 1;
+SIG_VALTYPE_ 600 Float32LittleEndian : 1;


### PR DESCRIPTION
Add handling of the float32 extended signal type to the generator. This type of signal are passed as float32 bits packed into bytes based of endianness of the signal.

Corresponding tests are provided.

Right now it's implemented in not so pleasant way. If you have some ideas on how to implement it more canonically to the crate style, I'll be glad to adjust code.