### PR TITLE
chore: use `quote` crate to handle str escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "heck",
  "insta",
  "prettyplease",
+ "quote",
  "syn",
  "test_each_file",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ can-dbc = "8.0.1"
 embedded-can = "0.4.1"
 heck = "0.5.0"
 prettyplease = "0.2.37"
+quote = "1.0"
 syn = "2.0.114"
 typed-builder = "0.23.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use can_dbc::MultiplexIndicator::{
 use can_dbc::ValueType::Signed;
 use can_dbc::{Dbc, Message, MessageId, Signal, Transmitter, ValDescription, ValueDescription};
 use heck::{ToPascalCase, ToSnakeCase};
+use quote::ToTokens;
 use typed_builder::TypedBuilder;
 
 pub use crate::feature_config::FeatureConfig;
@@ -109,20 +110,20 @@ fn codegen(config: &Config<'_>, out: impl Write) -> Result<()> {
     }
     let mut w = BufWriter::new(out);
 
-    let dbc_name = config.dbc_name.escape_default();
     writeln!(
         w,
         "/// The name of the DBC file this code was generated from"
     )?;
     writeln!(w, "#[allow(dead_code)]")?;
-    writeln!(w, r#"pub const DBC_FILE_NAME: &str = "{dbc_name}";"#)?;
-    let dbc_version = dbc.version.0.escape_default();
+    let dbc_name = config.dbc_name.to_token_stream();
+    writeln!(w, "pub const DBC_FILE_NAME: &str = {dbc_name};")?;
     writeln!(
         w,
         "/// The version of the DBC file this code was generated from"
     )?;
     writeln!(w, "#[allow(dead_code)]")?;
-    writeln!(w, r#"pub const DBC_FILE_VERSION: &str = "{dbc_version}";"#)?;
+    let dbc_version = dbc.version.0.to_token_stream();
+    writeln!(w, "pub const DBC_FILE_VERSION: &str = {dbc_version};")?;
 
     writeln!(w, "#[allow(unused_imports)]")?;
     writeln!(w, "use core::ops::BitOr;")?;

--- a/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
@@ -3,7 +3,7 @@
 pub const DBC_FILE_NAME: &str = "dump_signal_choices";
 /// The version of the DBC file this code was generated from
 #[allow(dead_code)]
-pub const DBC_FILE_VERSION: &str = "HIPBNYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY/4/%%%/4/\'%**4YYY///";
+pub const DBC_FILE_VERSION: &str = "HIPBNYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY/4/%%%/4/'%**4YYY///";
 #[allow(unused_imports)]
 use core::ops::BitOr;
 #[allow(unused_imports)]

--- a/tests-snapshots/dbc-cantools/emc32.snap.rs
+++ b/tests-snapshots/dbc-cantools/emc32.snap.rs
@@ -3,7 +3,7 @@
 pub const DBC_FILE_NAME: &str = "emc32";
 /// The version of the DBC file this code was generated from
 #[allow(dead_code)]
-pub const DBC_FILE_VERSION: &str = "HINBNYYYYYYYYYYYYYYYYYYYYYYYYYYYNNNNNNNNNN/4/%%%/4/\'%**4NNN///";
+pub const DBC_FILE_VERSION: &str = "HINBNYYYYYYYYYYYYYYYYYYYYYYYYYYYNNNNNNNNNN/4/%%%/4/'%**4NNN///";
 #[allow(unused_imports)]
 use core::ops::BitOr;
 #[allow(unused_imports)]

--- a/tests-snapshots/dbc-cantools/floating_point.snap.rs
+++ b/tests-snapshots/dbc-cantools/floating_point.snap.rs
@@ -3,7 +3,7 @@
 pub const DBC_FILE_NAME: &str = "floating_point";
 /// The version of the DBC file this code was generated from
 #[allow(dead_code)]
-pub const DBC_FILE_VERSION: &str = "HIPBNYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY/4/%%%/4/\'%**4YYY///";
+pub const DBC_FILE_VERSION: &str = "HIPBNYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY/4/%%%/4/'%**4YYY///";
 #[allow(unused_imports)]
 use core::ops::BitOr;
 #[allow(unused_imports)]

--- a/tests-snapshots/dbc-cantools/no_signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/no_signals.snap.rs
@@ -3,7 +3,7 @@
 pub const DBC_FILE_NAME: &str = "no_signals";
 /// The version of the DBC file this code was generated from
 #[allow(dead_code)]
-pub const DBC_FILE_VERSION: &str = "HIPBNYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY/4/%%%/4/\'%**4YYY///";
+pub const DBC_FILE_VERSION: &str = "HIPBNYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY/4/%%%/4/'%**4YYY///";
 #[allow(unused_imports)]
 use core::ops::BitOr;
 #[allow(unused_imports)]


### PR DESCRIPTION
while the previous method was accurate, it created some mismatches with the future quote/syn method of code generation. The new one avoids escaping characters that do not need to be escaped.

Note that quote is not a new dependency - it was already used as a sub-dependency.  We just declare it explicitly.