### PR TITLE
chore!: remove main fn from generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,14 +144,7 @@ impl Config<'_> {
         })?;
 
         writeln!(w)?;
-
-        self.render_dbc(&mut w, &dbc)
-            .context("could not generate Rust code")?;
-
-        writeln!(w)?;
-        writeln!(w, "/// This is just to make testing easier")?;
-        writeln!(w, "#[allow(dead_code)]")?;
-        writeln!(w, "fn main() {{}}")?;
+        self.render_dbc(&mut w, &dbc)?;
         writeln!(w)?;
         self.render_error(&mut w)?;
         self.render_arbitrary_helpers(&mut w)?;
@@ -1328,7 +1321,8 @@ impl Config<'_> {
     /// Generate Rust structs matching DBC input description and return as String
     pub fn generate(self) -> Result<String> {
         let mut out = Vec::new();
-        self.codegen(&mut out)?;
+        self.codegen(&mut out)
+            .context("could not generate Rust code")?;
         // Parse and re-format the generated code to allow for future
         // syn/quote codegen migration. Note that this is inefficient at the moment,
         // but this shouldn't be significantly noticeable.

--- a/tests-snapshots/canpy/DBC_template.snap.rs
+++ b/tests-snapshots/canpy/DBC_template.snap.rs
@@ -596,9 +596,6 @@ impl embedded_can::Frame for CanMessage {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -623,3 +620,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
@@ -187,9 +187,6 @@ impl From<ControlState> for u8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -214,3 +211,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
@@ -187,9 +187,6 @@ impl From<Message1Signal1> for u8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -214,3 +211,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/CamelCaseEmpty.snap.rs
+++ b/tests-snapshots/dbc-cantools/CamelCaseEmpty.snap.rs
@@ -115,9 +115,6 @@ impl embedded_can::Frame for Message1 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -142,3 +139,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/abs.snap.rs
+++ b/tests-snapshots/dbc-cantools/abs.snap.rs
@@ -5797,9 +5797,6 @@ impl From<Bremse53AbsFaultInfo> for u8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -5824,3 +5821,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/add_two_dbc_files_1.snap.rs
+++ b/tests-snapshots/dbc-cantools/add_two_dbc_files_1.snap.rs
@@ -188,9 +188,6 @@ impl embedded_can::Frame for M2 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -215,3 +212,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/add_two_dbc_files_2.snap.rs
+++ b/tests-snapshots/dbc-cantools/add_two_dbc_files_2.snap.rs
@@ -115,9 +115,6 @@ impl embedded_can::Frame for M1 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -142,3 +139,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
+++ b/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
@@ -164,9 +164,6 @@ impl embedded_can::Frame for Inv2EventMsg1 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -191,3 +188,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/attributes.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes.snap.rs
@@ -284,9 +284,6 @@ impl embedded_can::Frame for TheOtherMessage {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -311,3 +308,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
@@ -282,9 +282,6 @@ impl embedded_can::Frame for Message1 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -309,3 +306,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/big_numbers.snap.rs
+++ b/tests-snapshots/dbc-cantools/big_numbers.snap.rs
@@ -284,9 +284,6 @@ impl embedded_can::Frame for TheOtherMessage {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -311,3 +308,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/bus_comment.snap.rs
+++ b/tests-snapshots/dbc-cantools/bus_comment.snap.rs
@@ -589,9 +589,6 @@ impl Message1MultiplexorM24 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -616,3 +613,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/bus_comment_bare.snap.rs
+++ b/tests-snapshots/dbc-cantools/bus_comment_bare.snap.rs
@@ -38,9 +38,6 @@ impl Messages {
         Err(CanError::UnknownMessageId(id))
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -65,3 +62,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/bus_comment_bare_out.snap.rs
+++ b/tests-snapshots/dbc-cantools/bus_comment_bare_out.snap.rs
@@ -38,9 +38,6 @@ impl Messages {
         Err(CanError::UnknownMessageId(id))
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -65,3 +62,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices.snap.rs
@@ -205,9 +205,6 @@ impl From<FooFoo> for i8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -232,3 +229,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
@@ -177,9 +177,6 @@ impl From<TestMessageSignalWithChoices> for bool {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -204,3 +201,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
+++ b/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
@@ -820,9 +820,6 @@ impl From<Msg2Test7> for u8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -847,3 +844,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/cp1252.snap.rs
+++ b/tests-snapshots/dbc-cantools/cp1252.snap.rs
@@ -38,9 +38,6 @@ impl Messages {
         Err(CanError::UnknownMessageId(id))
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -65,3 +62,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
@@ -289,9 +289,6 @@ impl From<Message0BarSignal> for u8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -316,3 +313,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/emc32.snap.rs
+++ b/tests-snapshots/dbc-cantools/emc32.snap.rs
@@ -276,9 +276,6 @@ impl embedded_can::Frame for EmvStati {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -303,3 +300,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/empty_choice.snap.rs
+++ b/tests-snapshots/dbc-cantools/empty_choice.snap.rs
@@ -316,9 +316,6 @@ impl From<ExampleMessageNonEmptyChoice> for i8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -343,3 +340,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/empty_ns.snap.rs
+++ b/tests-snapshots/dbc-cantools/empty_ns.snap.rs
@@ -38,9 +38,6 @@ impl Messages {
         Err(CanError::UnknownMessageId(id))
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -65,3 +62,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/fd_test.snap.rs
+++ b/tests-snapshots/dbc-cantools/fd_test.snap.rs
@@ -524,9 +524,6 @@ impl embedded_can::Frame for TestMsgFdEx {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -551,3 +548,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/floating_point.snap.rs
+++ b/tests-snapshots/dbc-cantools/floating_point.snap.rs
@@ -329,9 +329,6 @@ impl embedded_can::Frame for Message2 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -356,3 +353,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/floating_point_use_float.snap.rs
+++ b/tests-snapshots/dbc-cantools/floating_point_use_float.snap.rs
@@ -443,9 +443,6 @@ impl embedded_can::Frame for Message3 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -470,3 +467,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/foobar.snap.rs
+++ b/tests-snapshots/dbc-cantools/foobar.snap.rs
@@ -805,9 +805,6 @@ impl embedded_can::Frame for Foobar {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -832,3 +829,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_163_newline.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_163_newline.snap.rs
@@ -115,9 +115,6 @@ impl embedded_can::Frame for DummyMsg {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -142,3 +139,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_168.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_168.snap.rs
@@ -805,9 +805,6 @@ impl embedded_can::Frame for Foobar {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -832,3 +829,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded.snap.rs
@@ -403,9 +403,6 @@ impl ExtMuxCascadedMuxAM1 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -430,3 +427,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs
@@ -488,9 +488,6 @@ impl ExtMuxCascadedMuxedA2MuxBM1 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -515,3 +512,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs
@@ -606,9 +606,6 @@ impl ExtMuxIndepMultiplexorsMuxBM2 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -633,3 +630,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs
@@ -606,9 +606,6 @@ impl ExtMuxIndepMultiplexorsMuxBM2 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -633,3 +630,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values.snap.rs
@@ -445,9 +445,6 @@ impl ExtMuxMultipleValuesMuxM2 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -472,3 +469,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values_dumped.snap.rs
@@ -445,9 +445,6 @@ impl ExtMuxMultipleValuesMuxM2 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -472,3 +469,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_199.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.rs
@@ -2279,9 +2279,6 @@ impl From<CruiseButtons2LkaGapButton> for u8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -2306,3 +2303,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
@@ -2179,9 +2179,6 @@ impl From<CruiseButtons2LkaGapButton> for u8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -2206,3 +2203,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_207_sig_plus.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_207_sig_plus.snap.rs
@@ -209,9 +209,6 @@ impl embedded_can::Frame for MyMsg {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -236,3 +233,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_228.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_228.snap.rs
@@ -421,9 +421,6 @@ impl embedded_can::Frame for NormalMsg {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -448,3 +445,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_62.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_62.snap.rs
@@ -38,9 +38,6 @@ impl Messages {
         Err(CanError::UnknownMessageId(id))
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -65,3 +62,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_63.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_63.snap.rs
@@ -385,9 +385,6 @@ impl embedded_can::Frame for Aft1psi2 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -412,3 +409,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
@@ -191,9 +191,6 @@ impl From<ExampleMessageTemperature> for f32 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -218,3 +215,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/issue_725.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_725.snap.rs
@@ -162,9 +162,6 @@ impl embedded_can::Frame for TestMessage {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -189,3 +186,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/j1939.snap.rs
+++ b/tests-snapshots/dbc-cantools/j1939.snap.rs
@@ -282,9 +282,6 @@ impl embedded_can::Frame for Message2 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -309,3 +306,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/long_names.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names.snap.rs
@@ -1468,9 +1468,6 @@ impl embedded_can::Frame for Mm123456789012345678901234567890 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1495,3 +1492,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
@@ -1445,9 +1445,6 @@ impl embedded_can::Frame for MsgLongName5678912345670001 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1472,3 +1469,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
@@ -1445,9 +1445,6 @@ impl embedded_can::Frame for MsgLongName5678912345670001 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1472,3 +1469,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/message-dlc-zero.snap.rs
+++ b/tests-snapshots/dbc-cantools/message-dlc-zero.snap.rs
@@ -115,9 +115,6 @@ impl embedded_can::Frame for Message1 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -142,3 +139,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/mod_name_len_dest.snap.rs
+++ b/tests-snapshots/dbc-cantools/mod_name_len_dest.snap.rs
@@ -162,9 +162,6 @@ impl embedded_can::Frame for MsgNowShort {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -189,3 +186,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/mod_name_len_src.snap.rs
+++ b/tests-snapshots/dbc-cantools/mod_name_len_src.snap.rs
@@ -167,9 +167,6 @@ impl embedded_can::Frame for MsgWillBeShortened345678912 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -194,3 +191,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/motohawk.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk.snap.rs
@@ -269,9 +269,6 @@ impl From<ExampleMessageEnable> for bool {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -296,3 +293,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
@@ -269,9 +269,6 @@ impl From<ExampleMessageEnable> for bool {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -296,3 +293,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
@@ -269,9 +269,6 @@ impl From<ExampleMessageEnable> for bool {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -296,3 +293,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
@@ -275,9 +275,6 @@ impl From<ExampleMessageEnable> for bool {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -302,3 +299,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/msxii_system_can.snap.rs
+++ b/tests-snapshots/dbc-cantools/msxii_system_can.snap.rs
@@ -5004,9 +5004,6 @@ impl BatteryVtBatteryVtIndexM35 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -5031,3 +5028,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/multiple_senders.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiple_senders.snap.rs
@@ -162,9 +162,6 @@ impl embedded_can::Frame for Bar {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -189,3 +186,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/multiplex.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex.snap.rs
@@ -589,9 +589,6 @@ impl Message1MultiplexorM24 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -616,3 +613,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.rs
@@ -1555,9 +1555,6 @@ impl ExtendedTypesS11M5 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1582,3 +1579,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs
@@ -1695,9 +1695,6 @@ impl ExtendedTypesS0M5 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1722,3 +1719,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
@@ -1515,9 +1515,6 @@ impl Message3MultiplexorM8 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1542,3 +1539,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
@@ -1515,9 +1515,6 @@ impl Message3MultiplexorM8 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1542,3 +1539,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/multiplex_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_dumped.snap.rs
@@ -589,9 +589,6 @@ impl Message1MultiplexorM24 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -616,3 +613,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/no_sender.snap.rs
+++ b/tests-snapshots/dbc-cantools/no_sender.snap.rs
@@ -163,9 +163,6 @@ impl embedded_can::Frame for Foo {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -190,3 +187,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/no_signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/no_signals.snap.rs
@@ -188,9 +188,6 @@ impl embedded_can::Frame for Message2 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -215,3 +212,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/open_actuator.snap.rs
+++ b/tests-snapshots/dbc-cantools/open_actuator.snap.rs
@@ -1427,9 +1427,6 @@ impl embedded_can::Frame for TorqueSensorData {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1454,3 +1451,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/padding_bit_order.snap.rs
+++ b/tests-snapshots/dbc-cantools/padding_bit_order.snap.rs
@@ -936,9 +936,6 @@ impl embedded_can::Frame for Msg4 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -963,3 +960,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/sig_groups.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups.snap.rs
@@ -806,9 +806,6 @@ impl embedded_can::Frame for NormalMsg {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -833,3 +830,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/sig_groups_del.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups_del.snap.rs
@@ -806,9 +806,6 @@ impl embedded_can::Frame for NormalMsg {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -833,3 +830,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/sig_groups_out.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups_out.snap.rs
@@ -806,9 +806,6 @@ impl embedded_can::Frame for NormalMsg {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -833,3 +830,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/signed.snap.rs
+++ b/tests-snapshots/dbc-cantools/signed.snap.rs
@@ -1703,9 +1703,6 @@ impl embedded_can::Frame for Message32 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1730,3 +1727,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
@@ -1420,9 +1420,6 @@ impl SensorSonarsSensorSonarsMuxM1 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1447,3 +1444,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
@@ -1420,9 +1420,6 @@ impl SensorSonarsSensorSonarsMuxM1 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1447,3 +1444,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
@@ -1420,9 +1420,6 @@ impl SensorSonarsSensorSonarsMuxM1 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1447,3 +1444,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/socialledge.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge.snap.rs
@@ -1420,9 +1420,6 @@ impl SensorSonarsSensorSonarsMuxM1 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1447,3 +1444,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/test_extended_id_dump.snap.rs
+++ b/tests-snapshots/dbc-cantools/test_extended_id_dump.snap.rs
@@ -282,9 +282,6 @@ impl embedded_can::Frame for SomeExtFrame {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -309,3 +306,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/test_multiplex_dump.snap.rs
+++ b/tests-snapshots/dbc-cantools/test_multiplex_dump.snap.rs
@@ -315,9 +315,6 @@ impl MuxedFrameMultiplexorSigM42 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -342,3 +339,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/timing.snap.rs
+++ b/tests-snapshots/dbc-cantools/timing.snap.rs
@@ -274,9 +274,6 @@ impl embedded_can::Frame for Bar {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -301,3 +298,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/val_table.snap.rs
+++ b/tests-snapshots/dbc-cantools/val_table.snap.rs
@@ -191,9 +191,6 @@ impl From<Message1Signal1> for i8 {
         }
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -218,3 +215,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/variable_dlc.snap.rs
+++ b/tests-snapshots/dbc-cantools/variable_dlc.snap.rs
@@ -558,9 +558,6 @@ impl embedded_can::Frame for TestMessage2 {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -585,3 +582,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/dbc-cantools/vehicle.snap.rs
+++ b/tests-snapshots/dbc-cantools/vehicle.snap.rs
@@ -36339,9 +36339,6 @@ impl embedded_can::Frame for RtSbGyroRates {
         &self.raw
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -36366,3 +36363,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}

--- a/tests-snapshots/oxibus/bug_dbc-codegen_98.snap.rs
+++ b/tests-snapshots/oxibus/bug_dbc-codegen_98.snap.rs
@@ -1064,9 +1064,6 @@ impl TestOutputTestOutputMuxM3 {
         Ok(())
     }
 }
-/// This is just to make testing easier
-#[allow(dead_code)]
-fn main() {}
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CanError {
@@ -1091,3 +1088,7 @@ impl core::fmt::Display for CanError {
         write!(f, "{self:?}")
     }
 }
+
+
+#[allow(dead_code)]
+fn main() {}


### PR DESCRIPTION
there is no need to generate fn main, unless we are doing testing. The main fn is now added to the snapshot at the end, but is no longer part of the generator.

Additionally, move `could not generate Rust code` error context to the top level for consistency.