### PR TITLE
Generate message size and cycle time consts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Config::builder()
     // this will generate Debug implementations
     .impl_debug(FeatureConfig::Always)
 
-    // this will generate Error implementations behind `#[cfg(feature = "std")]` guards
+    // this will generate Error implementations behind a `#[cfg(feature = "std")]` guard
     .impl_error(FeatureConfig::Gated("std"))
 
     // this will disable range checks
@@ -155,7 +155,7 @@ impl SomeMessage {
 
 ### `no_std`
 
-The generated code is `no_std` compatible, unless you enable `impl_error`.
+The generated code is `no_std` compatible.
 
 ### Field/variant rename rules
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,7 @@ pub struct Config<'a> {
     #[builder(default)]
     pub impl_serde: FeatureConfig<'a>,
 
-    /// Optional: `impl Error` for generated error type. Default: `Never`.
-    ///
-    /// Note: this feature depends on `std`.
+    /// Optional: `impl core::error::Error` for the generated `CanError` type. Default: `Never`.
     #[builder(default)]
     pub impl_error: FeatureConfig<'a>,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1591,17 +1591,14 @@ fn resolve_field_source(
     signal: Option<&Signal>,
 ) -> Option<String> {
     match source {
-        FieldSource::Attr(name) => {
-            let value = match signal {
-                Some(s) => dbc.resolved_signal_attribute(msg.id, &s.name, name),
-                None => dbc.resolved_message_attribute(msg.id, name),
-            }?;
-            Some(attr_value_literal(value))
+        FieldSource::Attr(name) => match signal {
+            Some(s) => dbc.resolved_signal_attribute(msg.id, &s.name, name),
+            None => dbc.resolved_message_attribute(msg.id, name),
         }
-        FieldSource::MessageAttr(name) => {
-            let value = dbc.resolved_message_attribute(msg.id, name)?;
-            Some(attr_value_literal(value))
-        }
+        .map(attr_value_literal),
+        FieldSource::MessageAttr(name) => dbc
+            .resolved_message_attribute(msg.id, name)
+            .map(attr_value_literal),
         FieldSource::StartBit => signal.map(|s| s.start_bit.to_string()),
         FieldSource::StartByte => signal.map(|s| signal_start_byte(s).to_string()),
         FieldSource::BitWidth => signal.map(|s| s.size.to_string()),
@@ -1626,8 +1623,8 @@ fn attr_value_literal(value: &AttributeValue) -> String {
     }
 }
 
-/// Cycle time in milliseconds from an assigned `GenMsgCycleTime` (`BA_`)
-/// attribute, if present and non-negative.
+/// Cycle time in milliseconds from an assigned and valid
+// `GenMsgCycleTime` (`BA_`) attribute.
 fn message_cycle_time_ms(dbc: &Dbc, id: MessageId) -> Option<u64> {
     match dbc.message_attribute(id, "GenMsgCycleTime")? {
         AttributeValue::Uint(v) => Some(*v),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,11 @@ impl Config<'_> {
             )?;
             writeln!(w)?;
 
+            writeln!(w, "pub const MESSAGE_SIZE: usize = {};", msg.size)?;
+            writeln!(w)?;
+
+            Self::render_cycle_time(&mut w, msg, dbc)?;
+
             for signal in &msg.signals {
                 let typ = ValType::from_signal(signal);
                 if typ != ValType::Bool {
@@ -650,6 +655,19 @@ impl Config<'_> {
         }
         writeln!(w, "}};")?;
         writeln!(w)?;
+        Ok(())
+    }
+
+    /// Emit the cycle time as a constant for messages that have an assigned
+    /// `GenMsgCycleTime` (`BA_`) attribute.
+    fn render_cycle_time(w: &mut impl Write, msg: &Message, dbc: &Dbc) -> Result<()> {
+        let Some(ms) = message_cycle_time_ms(dbc, msg.id) else {
+            return Ok(());
+        };
+        writeln!(
+            w,
+            "pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis({ms});"
+        )?;
         Ok(())
     }
 
@@ -1604,6 +1622,16 @@ fn attr_value_literal(value: &AttributeValue) -> String {
         AttributeValue::Int(v) => v.to_string(),
         AttributeValue::Double(v) => format!("{v:?}"),
         AttributeValue::String(v) => format!("{v:?}"),
+    }
+}
+
+/// Cycle time in milliseconds from an assigned `GenMsgCycleTime` (`BA_`)
+/// attribute, if present and non-negative.
+fn message_cycle_time_ms(dbc: &Dbc, id: MessageId) -> Option<u64> {
+    match dbc.message_attribute(id, "GenMsgCycleTime")? {
+        AttributeValue::Uint(v) => Some(*v),
+        AttributeValue::Int(v) => u64::try_from(*v).ok(),
+        AttributeValue::Double(_) | AttributeValue::String(_) => None,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,9 @@ impl Config<'_> {
         writeln!(w, "use bitvec::prelude::*;")?;
         writeln!(w, "#[allow(unused_imports)]")?;
         writeln!(w, "use embedded_can::{{Id, StandardId, ExtendedId}};")?;
+        if get_relevant_messages(&dbc).any(|m| message_cycle_time_ms(&dbc, m.id).is_some()) {
+            writeln!(w, "use core::time::Duration;")?;
+        }
 
         self.impl_arbitrary.fmt_cfg(&mut w, |w| {
             writeln!(w, "use arbitrary::{{Arbitrary, Unstructured}};")

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -195,3 +195,12 @@ fn test_extended_id() {
         Id::Extended(ExtendedId::new(0x1234).unwrap())
     );
 }
+
+#[test]
+fn test_message_size() {
+    assert_eq!(Foo::MESSAGE_SIZE, 4);
+    assert_eq!(MsgExtendedId::MESSAGE_SIZE, 8);
+
+    let m = Foo::new(0.0, 0.0).unwrap();
+    assert_eq!(m.raw().len(), Foo::MESSAGE_SIZE);
+}

--- a/tests-snapshots/canpy/DBC_template.snap.rs
+++ b/tests-snapshots/canpy/DBC_template.snap.rs
@@ -76,6 +76,7 @@ impl CanMultiplexed {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x10e1)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const VALUE1_MIN: u8 = 0_u8;
     pub const VALUE1_MAX: u8 = 0_u8;
     pub const VALUE0_MIN: u8 = 0_u8;
@@ -454,6 +455,7 @@ impl CanMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x4d2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: u64 = 0_u64;
     pub const SIGNAL1_MAX: u64 = 100_u64;
     pub const SIGNAL0_MIN: i32 = 0_i32;

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
@@ -67,6 +67,7 @@ impl Control {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 7;
     pub const STATE_MIN: u8 = 0_u8;
     pub const STATE_MAX: u8 = 100_u8;
     /// Construct new CONTROL from values

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
@@ -67,6 +67,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 7;
     pub const SIGNAL_1_MIN: u8 = 0_u8;
     pub const SIGNAL_1_MAX: u8 = 100_u8;
     /// Construct new message_1 from values

--- a/tests-snapshots/dbc-cantools/CamelCaseEmpty.snap.rs
+++ b/tests-snapshots/dbc-cantools/CamelCaseEmpty.snap.rs
@@ -67,6 +67,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x400)
     });
+    pub const MESSAGE_SIZE: usize = 5;
     /// Construct new Message1 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 5] };

--- a/tests-snapshots/dbc-cantools/abs.snap.rs
+++ b/tests-snapshots/dbc-cantools/abs.snap.rs
@@ -118,6 +118,7 @@ impl Bremse33 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x343)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const WHLSPEED_FL_MIN: f32 = 0_f32;
     pub const WHLSPEED_FL_MAX: f32 = 100_f32;
     pub const WHLSPEED_FR_MIN: f32 = 0_f32;
@@ -369,6 +370,7 @@ impl Bremse10 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x140)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new BREMSE_10 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -439,6 +441,7 @@ impl Bremse11 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x141)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new BREMSE_11 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -509,6 +512,7 @@ impl Bremse12 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x142)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new BREMSE_12 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -579,6 +583,7 @@ impl Bremse13 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x143)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new BREMSE_13 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -649,6 +654,7 @@ impl DrsRxId0 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x75)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new DRS_RX_ID0 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -719,6 +725,7 @@ impl Mm510Tx1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x70)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const YAW_RATE_MIN: f32 = -163.84_f32;
     pub const YAW_RATE_MAX: f32 = 163.83_f32;
     pub const AY1_MIN: f32 = -4.1768_f32;
@@ -877,6 +884,7 @@ impl Mm510Tx2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x80)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const ROLL_RATE_MIN: f32 = -163.84_f32;
     pub const ROLL_RATE_MAX: f32 = 163.835_f32;
     pub const AX1_MIN: f32 = -4.1768_f32;
@@ -1035,6 +1043,7 @@ impl Mm510Tx3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x576)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const AZ_MIN: f32 = -4.1768_f32;
     pub const AZ_MAX: f32 = 4.1765_f32;
     /// Construct new MM5_10_TX3 from values
@@ -1149,6 +1158,7 @@ impl Bremse2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x24a)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const WHLSPEED_FL_BREMSE2_MIN: f32 = 0_f32;
     pub const WHLSPEED_FL_BREMSE2_MAX: f32 = 100_f32;
     pub const WHLSPEED_FR_BREMSE2_MIN: f32 = 0_f32;
@@ -1399,6 +1409,7 @@ impl AbsSwitch {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x24c)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const ABS_SWITCHPOSITION_MIN: u8 = 0_u8;
     pub const ABS_SWITCHPOSITION_MAX: u8 = 11_u8;
     /// Construct new ABS_Switch from values
@@ -1516,6 +1527,7 @@ impl Bremse30 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x340)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new BREMSE_30 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -1586,6 +1598,7 @@ impl Bremse31 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x341)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const IDLE_TIME_MIN: u16 = 0_u16;
     pub const IDLE_TIME_MAX: u16 = 0_u16;
     /// Construct new BREMSE_31 from values
@@ -1701,6 +1714,7 @@ impl Bremse32 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x342)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const ACC_FA_MIN: f32 = 0_f32;
     pub const ACC_FA_MAX: f32 = 10_f32;
     pub const ACC_RA_MIN: f32 = 0_f32;
@@ -2086,6 +2100,7 @@ impl Bremse51 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x541)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const AX1_ABS_INT_MIN: f32 = -4.1768_f32;
     pub const AX1_ABS_INT_MAX: f32 = 4.1736697_f32;
     pub const AY1_ABS_INT_MIN: f32 = -4.1768_f32;
@@ -2391,6 +2406,7 @@ impl Bremse52 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x542)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MPLX_SW_INFO_MIN: u8 = 0_u8;
     pub const MPLX_SW_INFO_MAX: u8 = 255_u8;
     pub const SW_VERSION_HIGH_UPPER_MIN: u8 = 0_u8;
@@ -4522,6 +4538,7 @@ impl Bremse50 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x560)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const BRAKE_BAL_AT50_MIN: f32 = 0_f32;
     pub const BRAKE_BAL_AT50_MAX: f32 = 100_f32;
     pub const BRAKE_BAL_AT50_ADVICE_MIN: u8 = 0_u8;
@@ -4779,6 +4796,7 @@ impl Bremse53 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x5c0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SWITCH_POSITION_MIN: u8 = 1_u8;
     pub const SWITCH_POSITION_MAX: u8 = 12_u8;
     pub const P_FA_MIN: f32 = -42.5_f32;

--- a/tests-snapshots/dbc-cantools/add_two_dbc_files_1.snap.rs
+++ b/tests-snapshots/dbc-cantools/add_two_dbc_files_1.snap.rs
@@ -70,6 +70,7 @@ impl M1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new M1 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -140,6 +141,7 @@ impl M2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new M2 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };

--- a/tests-snapshots/dbc-cantools/add_two_dbc_files_2.snap.rs
+++ b/tests-snapshots/dbc-cantools/add_two_dbc_files_2.snap.rs
@@ -67,6 +67,7 @@ impl M1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new M1 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };

--- a/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
+++ b/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
@@ -69,6 +69,8 @@ impl Inv2EventMsg1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x4d2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(0);
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
     /// Construct new INV2EventMsg1 from values

--- a/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
+++ b/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/attributes.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes.snap.rs
@@ -73,6 +73,8 @@ impl TheMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x39)
     });
+    pub const MESSAGE_SIZE: usize = 8;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
     /// Construct new TheMessage from values
@@ -189,6 +191,7 @@ impl TheOtherMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2a)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
     /// Construct new TheOtherMessage from values

--- a/tests-snapshots/dbc-cantools/attributes.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
@@ -70,6 +70,8 @@ impl Message2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x53)
     });
+    pub const MESSAGE_SIZE: usize = 8;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(50);
     pub const SIGNAL_2_MIN: i8 = 0_i8;
     pub const SIGNAL_2_MAX: i8 = 0_i8;
     /// Construct new Message_2 from values
@@ -187,6 +189,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x52)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL_1_MIN: i8 = 0_i8;
     pub const SIGNAL_1_MAX: i8 = 0_i8;
     /// Construct new Message_1 from values

--- a/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/big_numbers.snap.rs
+++ b/tests-snapshots/dbc-cantools/big_numbers.snap.rs
@@ -73,6 +73,8 @@ impl TheMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x39)
     });
+    pub const MESSAGE_SIZE: usize = 8;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
     /// Construct new TheMessage from values
@@ -189,6 +191,7 @@ impl TheOtherMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2a)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
     /// Construct new TheOtherMessage from values

--- a/tests-snapshots/dbc-cantools/big_numbers.snap.rs
+++ b/tests-snapshots/dbc-cantools/big_numbers.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/bus_comment.snap.rs
+++ b/tests-snapshots/dbc-cantools/bus_comment.snap.rs
@@ -66,6 +66,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x123456)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
     /// Construct new Message1 from values

--- a/tests-snapshots/dbc-cantools/choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices.snap.rs
@@ -66,6 +66,7 @@ impl Foo {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: i8 = -128_i8;
     pub const FOO_MAX: i8 = 127_i8;
     /// Construct new Foo from values

--- a/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
@@ -68,6 +68,7 @@ impl TestMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x90000)
     });
+    pub const MESSAGE_SIZE: usize = 1;
     /// Construct new TestMessage from values
     pub fn new(signal_with_choices: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 1] };

--- a/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
+++ b/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
@@ -70,6 +70,7 @@ impl Msg1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x620)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const SIG22_MIN: u8 = 0_u8;
     pub const SIG22_MAX: u8 = 1_u8;
     pub const SIG12_MIN: u8 = 0_u8;
@@ -367,6 +368,7 @@ impl Msg2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x555)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST7_MIN: u8 = 0_u8;
     pub const TEST7_MAX: u8 = 0_u8;
     pub const TEST6_MIN: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
@@ -67,6 +67,7 @@ impl Message0 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x400)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_SIGNAL_MIN: u8 = 0_u8;
     pub const FOO_SIGNAL_MAX: u8 = 0_u8;
     pub const BAR_SIGNAL_MIN: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/emc32.snap.rs
+++ b/tests-snapshots/dbc-cantools/emc32.snap.rs
@@ -67,6 +67,7 @@ impl EmvStati {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x222)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new EMV_Stati from values
     pub fn new(
         emv_aktion_status_5: bool,

--- a/tests-snapshots/dbc-cantools/empty_choice.snap.rs
+++ b/tests-snapshots/dbc-cantools/empty_choice.snap.rs
@@ -69,6 +69,7 @@ impl ExampleMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xa)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const NO_CHOICE_MIN: i8 = 0_i8;
     pub const NO_CHOICE_MAX: i8 = 0_i8;
     pub const EMPTY_CHOICE_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/empty_choice.snap.stderr
+++ b/tests-snapshots/dbc-cantools/empty_choice.snap.stderr
@@ -1,7 +1,7 @@
 error: literal out of range for `i8`
-   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:313:59
+   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:314:59
     |
-313 |             ExampleMessageNonEmptyChoice::NotAvailable => 255,
+314 |             ExampleMessageNonEmptyChoice::NotAvailable => 255,
     |                                                           ^^^
     |
     = note: the literal `255` does not fit into the type `i8` whose range is `-128..=127`
@@ -9,9 +9,9 @@ error: literal out of range for `i8`
     = note: `#[deny(overflowing_literals)]` on by default
 
 error: literal out of range for `i8`
-   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:314:52
+   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:315:52
     |
-314 |             ExampleMessageNonEmptyChoice::Error => 254,
+315 |             ExampleMessageNonEmptyChoice::Error => 254,
     |                                                    ^^^
     |
     = note: the literal `254` does not fit into the type `i8` whose range is `-128..=127`

--- a/tests-snapshots/dbc-cantools/fd_test.snap.rs
+++ b/tests-snapshots/dbc-cantools/fd_test.snap.rs
@@ -81,6 +81,7 @@ impl TestMsgEx {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x3)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_COPY_1_MIN: i8 = 0_i8;
     pub const TEST_SIG_COPY_1_MAX: i8 = 0_i8;
     /// Construct new TestMsg_Ex from values
@@ -197,6 +198,7 @@ impl TestMsgStd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_COPY_3_MIN: i8 = 0_i8;
     pub const TEST_SIG_COPY_3_MAX: i8 = 0_i8;
     /// Construct new TestMsg_Std from values
@@ -313,6 +315,7 @@ impl TestMsgFdStd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_COPY_2_MIN: i8 = 0_i8;
     pub const TEST_SIG_COPY_2_MAX: i8 = 0_i8;
     /// Construct new TestMsg_FDStd from values
@@ -429,6 +432,7 @@ impl TestMsgFdEx {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
     /// Construct new TestMsg_FDEx from values

--- a/tests-snapshots/dbc-cantools/floating_point.snap.rs
+++ b/tests-snapshots/dbc-cantools/floating_point.snap.rs
@@ -70,6 +70,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x400)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i64 = 0_i64;
     pub const SIGNAL1_MAX: i64 = 0_i64;
     /// Construct new Message1 from values
@@ -187,6 +188,7 @@ impl Message2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x401)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL2_MIN: i32 = 0_i32;
     pub const SIGNAL2_MAX: i32 = 0_i32;
     pub const SIGNAL1_MIN: i32 = 0_i32;

--- a/tests-snapshots/dbc-cantools/floating_point_use_float.snap.rs
+++ b/tests-snapshots/dbc-cantools/floating_point_use_float.snap.rs
@@ -73,6 +73,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x400)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i64 = 0_i64;
     pub const SIGNAL1_MAX: i64 = 0_i64;
     /// Construct new Message1 from values
@@ -190,6 +191,7 @@ impl Message2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x401)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL2_MIN: i32 = 0_i32;
     pub const SIGNAL2_MAX: i32 = 0_i32;
     pub const SIGNAL1_MIN: i32 = 0_i32;
@@ -353,6 +355,7 @@ impl Message3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x402)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL3_MIN: f32 = 0_f32;
     pub const SIGNAL3_MAX: f32 = 0_f32;
     /// Construct new Message3 from values

--- a/tests-snapshots/dbc-cantools/foobar.snap.rs
+++ b/tests-snapshots/dbc-cantools/foobar.snap.rs
@@ -81,6 +81,7 @@ impl Foo {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x12330)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;
     pub const BAR_MIN: f32 = 0_f32;
@@ -239,6 +240,8 @@ impl Fum {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x12331)
     });
+    pub const MESSAGE_SIZE: usize = 5;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1);
     pub const FUM_MIN: i16 = 0_i16;
     pub const FUM_MAX: i16 = 10_i16;
     pub const FAM_MIN: i16 = 0_i16;
@@ -433,6 +436,7 @@ impl Bar {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x12332)
     });
+    pub const MESSAGE_SIZE: usize = 4;
     pub const BINARY32_MIN: i32 = 0_i32;
     pub const BINARY32_MAX: i32 = 0_i32;
     /// Construct new Bar from values
@@ -550,6 +554,7 @@ impl CanFd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x12333)
     });
+    pub const MESSAGE_SIZE: usize = 64;
     pub const FIE_MIN: u64 = 0_u64;
     pub const FIE_MAX: u64 = 0_u64;
     pub const FAS_MIN: u64 = 0_u64;
@@ -710,6 +715,7 @@ impl Foobar {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x30c)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const ACC_02_CRC_MIN: i16 = 0_i16;
     pub const ACC_02_CRC_MAX: i16 = 1_i16;
     /// Construct new FOOBAR from values

--- a/tests-snapshots/dbc-cantools/foobar.snap.rs
+++ b/tests-snapshots/dbc-cantools/foobar.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/issue_163_newline.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_163_newline.snap.rs
@@ -67,6 +67,7 @@ impl DummyMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new dummy_msg from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };

--- a/tests-snapshots/dbc-cantools/issue_168.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_168.snap.rs
@@ -81,6 +81,7 @@ impl Foo {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x12330)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;
     pub const BAR_MIN: f32 = 0_f32;
@@ -239,6 +240,8 @@ impl Fum {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x12331)
     });
+    pub const MESSAGE_SIZE: usize = 5;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1);
     pub const FUM_MIN: i16 = 0_i16;
     pub const FUM_MAX: i16 = 10_i16;
     pub const FAM_MIN: i16 = 0_i16;
@@ -433,6 +436,7 @@ impl Bar {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x12332)
     });
+    pub const MESSAGE_SIZE: usize = 4;
     pub const BINARY32_MIN: i32 = 0_i32;
     pub const BINARY32_MAX: i32 = 0_i32;
     /// Construct new Bar from values
@@ -550,6 +554,7 @@ impl CanFd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x12333)
     });
+    pub const MESSAGE_SIZE: usize = 64;
     pub const FIE_MIN: u64 = 0_u64;
     pub const FIE_MAX: u64 = 0_u64;
     pub const FAS_MIN: u64 = 0_u64;
@@ -710,6 +715,7 @@ impl Foobar {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x30c)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const ACC_02_CRC_MIN: i16 = 0_i16;
     pub const ACC_02_CRC_MAX: i16 = 1_i16;
     /// Construct new FOOBAR from values

--- a/tests-snapshots/dbc-cantools/issue_168.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_168.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded.snap.rs
@@ -68,6 +68,7 @@ impl ExtMuxCascaded {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_B_1_MIN: i8 = 0_i8;
     pub const MUXED_B_1_MAX: i8 = 0_i8;
     pub const MUXED_B_0_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs
@@ -68,6 +68,7 @@ impl ExtMuxCascaded {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_B_1_MIN: i8 = 0_i8;
     pub const MUXED_B_1_MAX: i8 = 0_i8;
     pub const MUXED_B_0_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
@@ -105,6 +105,22 @@ error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:196:21
     |
 196 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+196 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+196 +                     ExtMuxCascadedMuxedA2MuxBIndex::M0(ExtMuxCascadedMuxAM0 {
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:202:21
+    |
+202 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
     |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
@@ -105,22 +105,6 @@ error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:196:21
     |
 196 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-196 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-196 +                     ExtMuxCascadedMuxedA2MuxBIndex::M0(ExtMuxCascadedMuxAM0 {
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:202:21
-    |
-202 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
     |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
@@ -1,16 +1,16 @@
 error[E0425]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:191:39
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:192:39
     |
-191 |     pub fn mux_a(&mut self) -> Result<ExtMuxCascadedMuxAIndex, CanError> {
+192 |     pub fn mux_a(&mut self) -> Result<ExtMuxCascadedMuxAIndex, CanError> {
     |                                       ^^^^^^^^^^^^^^^^^^^^^^^
 ...
-301 | pub enum ExtMuxCascadedMuxedA2MuxBIndex {
+302 | pub enum ExtMuxCascadedMuxedA2MuxBIndex {
     | --------------------------------------- similarly named enum `ExtMuxCascadedMuxedA2MuxBIndex` defined here
     |
 help: an enum with a similar name exists
     |
-191 -     pub fn mux_a(&mut self) -> Result<ExtMuxCascadedMuxAIndex, CanError> {
-191 +     pub fn mux_a(&mut self) -> Result<ExtMuxCascadedMuxedA2MuxBIndex, CanError> {
+192 -     pub fn mux_a(&mut self) -> Result<ExtMuxCascadedMuxAIndex, CanError> {
+192 +     pub fn mux_a(&mut self) -> Result<ExtMuxCascadedMuxedA2MuxBIndex, CanError> {
     |
 help: you might be missing a type parameter
     |
@@ -18,109 +18,109 @@ help: you might be missing a type parameter
     |     +++++++++++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:195:49
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:196:49
     |
  55 | pub struct ExtMuxCascaded {
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
-195 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+196 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
     |                                                 ^^^^^^^^^^^^^^^^^^^^
     |
 help: a struct with a similar name exists
     |
-195 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-195 +                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascaded {
+196 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+196 +                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascaded {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:202:49
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:203:49
     |
  55 | pub struct ExtMuxCascaded {
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
-202 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+203 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
     |                                                 ^^^^^^^^^^^^^^^^^^^^
     |
 help: a struct with a similar name exists
     |
-202 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-202 +                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascaded {
+203 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+203 +                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascaded {
     |
 
 error[E0425]: cannot find type `ExtMuxCascadedMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:236:37
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:237:37
     |
  55 | pub struct ExtMuxCascaded {
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
-236 |     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
+237 |     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
     |                                     ^^^^^^^^^^^^^^^^^^^^
     |
 help: a struct with a similar name exists
     |
-236 -     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
-236 +     pub fn set_m0(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
+237 -     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
+237 +     pub fn set_m0(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
     |
 
 error[E0425]: cannot find type `ExtMuxCascadedMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:245:37
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:246:37
     |
  55 | pub struct ExtMuxCascaded {
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
-245 |     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
+246 |     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
     |                                     ^^^^^^^^^^^^^^^^^^^^
     |
 help: a struct with a similar name exists
     |
-245 -     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
-245 +     pub fn set_m1(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
+246 -     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
+246 +     pub fn set_m1(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
     |
 
 error[E0592]: duplicate definitions with name `set_m0`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:236:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:237:5
     |
-154 | /     pub fn set_m0(
-155 | |         &mut self,
-156 | |         value: ExtMuxCascadedMuxedA2MuxBM0,
-157 | |     ) -> Result<(), CanError> {
+155 | /     pub fn set_m0(
+156 | |         &mut self,
+157 | |         value: ExtMuxCascadedMuxedA2MuxBM0,
+158 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m0`
 ...
-236 |       pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
+237 |       pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m1`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:245:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:246:5
     |
-166 | /     pub fn set_m1(
-167 | |         &mut self,
-168 | |         value: ExtMuxCascadedMuxedA2MuxBM1,
-169 | |     ) -> Result<(), CanError> {
+167 | /     pub fn set_m1(
+168 | |         &mut self,
+169 | |         value: ExtMuxCascadedMuxedA2MuxBM1,
+170 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m1`
 ...
-245 |       pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
+246 |       pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m1`
 
 error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:195:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:196:21
     |
-195 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+196 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-195 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-195 +                     ExtMuxCascadedMuxedA2MuxBIndex::M0(ExtMuxCascadedMuxAM0 {
+196 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+196 +                     ExtMuxCascadedMuxedA2MuxBIndex::M0(ExtMuxCascadedMuxAM0 {
     |
 
 error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:202:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:203:21
     |
-202 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+203 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-202 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-202 +                     ExtMuxCascadedMuxedA2MuxBIndex::M1(ExtMuxCascadedMuxAM1 {
+203 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+203 +                     ExtMuxCascadedMuxedA2MuxBIndex::M1(ExtMuxCascadedMuxAM1 {
     |

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs
@@ -70,6 +70,7 @@ impl ExtMuxIndepMultiplexors {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_B_2_MIN: i8 = 0_i8;
     pub const MUXED_B_2_MAX: i8 = 0_i8;
     pub const MUXED_B_1_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
@@ -156,6 +156,22 @@ error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:217:21
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:223:21
+    |
+223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
@@ -168,6 +184,22 @@ error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:224:21
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:230:21
+    |
+230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
@@ -1,16 +1,16 @@
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:212:39
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:213:39
     |
-212 |     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
+213 |     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
     |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-347 | pub enum ExtMuxIndepMultiplexorsMuxBIndex {
+348 | pub enum ExtMuxIndepMultiplexorsMuxBIndex {
     | ----------------------------------------- similarly named enum `ExtMuxIndepMultiplexorsMuxBIndex` defined here
     |
 help: an enum with a similar name exists
     |
-212 -     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
-212 +     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxBIndex, CanError> {
+213 -     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
+213 +     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxBIndex, CanError> {
     |
 help: you might be missing a type parameter
     |
@@ -18,172 +18,172 @@ help: you might be missing a type parameter
     |     ++++++++++++++++++++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:216:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:217:58
     |
-216 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-362 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
+363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
     |
 help: a struct with a similar name exists
     |
-216 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-216 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:223:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:224:58
     |
-223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-433 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
+434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
     |
 help: a struct with a similar name exists
     |
-223 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-223 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:230:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:231:58
     |
-230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-548 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
+549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
     |
 help: a struct with a similar name exists
     |
-230 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-230 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
+231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:266:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:267:16
     |
-266 |         value: ExtMuxIndepMultiplexorsMuxAM0,
+267 |         value: ExtMuxIndepMultiplexorsMuxAM0,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-362 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
+363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
     |
 help: a struct with a similar name exists
     |
-266 -         value: ExtMuxIndepMultiplexorsMuxAM0,
-266 +         value: ExtMuxIndepMultiplexorsMuxBM0,
+267 -         value: ExtMuxIndepMultiplexorsMuxAM0,
+267 +         value: ExtMuxIndepMultiplexorsMuxBM0,
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:278:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:279:16
     |
-278 |         value: ExtMuxIndepMultiplexorsMuxAM1,
+279 |         value: ExtMuxIndepMultiplexorsMuxAM1,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-433 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
+434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
     |
 help: a struct with a similar name exists
     |
-278 -         value: ExtMuxIndepMultiplexorsMuxAM1,
-278 +         value: ExtMuxIndepMultiplexorsMuxBM1,
+279 -         value: ExtMuxIndepMultiplexorsMuxAM1,
+279 +         value: ExtMuxIndepMultiplexorsMuxBM1,
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:290:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:291:16
     |
-290 |         value: ExtMuxIndepMultiplexorsMuxAM2,
+291 |         value: ExtMuxIndepMultiplexorsMuxAM2,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-548 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
+549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
     |
 help: a struct with a similar name exists
     |
-290 -         value: ExtMuxIndepMultiplexorsMuxAM2,
-290 +         value: ExtMuxIndepMultiplexorsMuxBM2,
+291 -         value: ExtMuxIndepMultiplexorsMuxAM2,
+291 +         value: ExtMuxIndepMultiplexorsMuxBM2,
     |
 
 error[E0592]: duplicate definitions with name `set_m0`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:264:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:265:5
     |
-163 | /     pub fn set_m0(
-164 | |         &mut self,
-165 | |         value: ExtMuxIndepMultiplexorsMuxBM0,
-166 | |     ) -> Result<(), CanError> {
+164 | /     pub fn set_m0(
+165 | |         &mut self,
+166 | |         value: ExtMuxIndepMultiplexorsMuxBM0,
+167 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m0`
 ...
-264 | /     pub fn set_m0(
-265 | |         &mut self,
-266 | |         value: ExtMuxIndepMultiplexorsMuxAM0,
-267 | |     ) -> Result<(), CanError> {
+265 | /     pub fn set_m0(
+266 | |         &mut self,
+267 | |         value: ExtMuxIndepMultiplexorsMuxAM0,
+268 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m1`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:276:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:277:5
     |
-175 | /     pub fn set_m1(
-176 | |         &mut self,
-177 | |         value: ExtMuxIndepMultiplexorsMuxBM1,
-178 | |     ) -> Result<(), CanError> {
+176 | /     pub fn set_m1(
+177 | |         &mut self,
+178 | |         value: ExtMuxIndepMultiplexorsMuxBM1,
+179 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m1`
 ...
-276 | /     pub fn set_m1(
-277 | |         &mut self,
-278 | |         value: ExtMuxIndepMultiplexorsMuxAM1,
-279 | |     ) -> Result<(), CanError> {
+277 | /     pub fn set_m1(
+278 | |         &mut self,
+279 | |         value: ExtMuxIndepMultiplexorsMuxAM1,
+280 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m1`
 
 error[E0592]: duplicate definitions with name `set_m2`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:288:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:289:5
     |
-187 | /     pub fn set_m2(
-188 | |         &mut self,
-189 | |         value: ExtMuxIndepMultiplexorsMuxBM2,
-190 | |     ) -> Result<(), CanError> {
+188 | /     pub fn set_m2(
+189 | |         &mut self,
+190 | |         value: ExtMuxIndepMultiplexorsMuxBM2,
+191 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m2`
 ...
-288 | /     pub fn set_m2(
-289 | |         &mut self,
-290 | |         value: ExtMuxIndepMultiplexorsMuxAM2,
-291 | |     ) -> Result<(), CanError> {
+289 | /     pub fn set_m2(
+290 | |         &mut self,
+291 | |         value: ExtMuxIndepMultiplexorsMuxAM2,
+292 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:216:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:217:21
     |
-216 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-216 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-216 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:223:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:224:21
     |
-223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-223 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-223 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:230:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:231:21
     |
-230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-230 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-230 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
@@ -156,22 +156,6 @@ error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:217:21
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:223:21
-    |
-223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
@@ -184,22 +168,6 @@ error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:224:21
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:230:21
-    |
-230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs
@@ -70,6 +70,7 @@ impl ExtMuxIndepMultiplexors {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_B_1_MIN: i8 = 0_i8;
     pub const MUXED_B_1_MAX: i8 = 0_i8;
     pub const MUXED_B_2_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
@@ -156,22 +156,6 @@ error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:217:21
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:223:21
-    |
-223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
@@ -184,22 +168,6 @@ error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:224:21
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:230:21
-    |
-230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
@@ -156,6 +156,22 @@ error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:217:21
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:223:21
+    |
+223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
@@ -168,6 +184,22 @@ error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:224:21
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:230:21
+    |
+230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
@@ -1,16 +1,16 @@
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:212:39
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:213:39
     |
-212 |     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
+213 |     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
     |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-347 | pub enum ExtMuxIndepMultiplexorsMuxBIndex {
+348 | pub enum ExtMuxIndepMultiplexorsMuxBIndex {
     | ----------------------------------------- similarly named enum `ExtMuxIndepMultiplexorsMuxBIndex` defined here
     |
 help: an enum with a similar name exists
     |
-212 -     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
-212 +     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxBIndex, CanError> {
+213 -     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxAIndex, CanError> {
+213 +     pub fn mux_a(&mut self) -> Result<ExtMuxIndepMultiplexorsMuxBIndex, CanError> {
     |
 help: you might be missing a type parameter
     |
@@ -18,172 +18,172 @@ help: you might be missing a type parameter
     |     ++++++++++++++++++++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:216:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:217:58
     |
-216 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-362 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
+363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
     |
 help: a struct with a similar name exists
     |
-216 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-216 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:223:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:224:58
     |
-223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-433 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
+434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
     |
 help: a struct with a similar name exists
     |
-223 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-223 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:230:58
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:231:58
     |
-230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-548 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
+549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
     |
 help: a struct with a similar name exists
     |
-230 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-230 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
+231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:266:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:267:16
     |
-266 |         value: ExtMuxIndepMultiplexorsMuxAM0,
+267 |         value: ExtMuxIndepMultiplexorsMuxAM0,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-362 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
+363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
     |
 help: a struct with a similar name exists
     |
-266 -         value: ExtMuxIndepMultiplexorsMuxAM0,
-266 +         value: ExtMuxIndepMultiplexorsMuxBM0,
+267 -         value: ExtMuxIndepMultiplexorsMuxAM0,
+267 +         value: ExtMuxIndepMultiplexorsMuxBM0,
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:278:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:279:16
     |
-278 |         value: ExtMuxIndepMultiplexorsMuxAM1,
+279 |         value: ExtMuxIndepMultiplexorsMuxAM1,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-433 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
+434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
     |
 help: a struct with a similar name exists
     |
-278 -         value: ExtMuxIndepMultiplexorsMuxAM1,
-278 +         value: ExtMuxIndepMultiplexorsMuxBM1,
+279 -         value: ExtMuxIndepMultiplexorsMuxAM1,
+279 +         value: ExtMuxIndepMultiplexorsMuxBM1,
     |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:290:16
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:291:16
     |
-290 |         value: ExtMuxIndepMultiplexorsMuxAM2,
+291 |         value: ExtMuxIndepMultiplexorsMuxAM2,
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-548 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
+549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
     |
 help: a struct with a similar name exists
     |
-290 -         value: ExtMuxIndepMultiplexorsMuxAM2,
-290 +         value: ExtMuxIndepMultiplexorsMuxBM2,
+291 -         value: ExtMuxIndepMultiplexorsMuxAM2,
+291 +         value: ExtMuxIndepMultiplexorsMuxBM2,
     |
 
 error[E0592]: duplicate definitions with name `set_m0`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:264:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:265:5
     |
-163 | /     pub fn set_m0(
-164 | |         &mut self,
-165 | |         value: ExtMuxIndepMultiplexorsMuxBM0,
-166 | |     ) -> Result<(), CanError> {
+164 | /     pub fn set_m0(
+165 | |         &mut self,
+166 | |         value: ExtMuxIndepMultiplexorsMuxBM0,
+167 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m0`
 ...
-264 | /     pub fn set_m0(
-265 | |         &mut self,
-266 | |         value: ExtMuxIndepMultiplexorsMuxAM0,
-267 | |     ) -> Result<(), CanError> {
+265 | /     pub fn set_m0(
+266 | |         &mut self,
+267 | |         value: ExtMuxIndepMultiplexorsMuxAM0,
+268 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m1`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:276:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:277:5
     |
-175 | /     pub fn set_m1(
-176 | |         &mut self,
-177 | |         value: ExtMuxIndepMultiplexorsMuxBM1,
-178 | |     ) -> Result<(), CanError> {
+176 | /     pub fn set_m1(
+177 | |         &mut self,
+178 | |         value: ExtMuxIndepMultiplexorsMuxBM1,
+179 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m1`
 ...
-276 | /     pub fn set_m1(
-277 | |         &mut self,
-278 | |         value: ExtMuxIndepMultiplexorsMuxAM1,
-279 | |     ) -> Result<(), CanError> {
+277 | /     pub fn set_m1(
+278 | |         &mut self,
+279 | |         value: ExtMuxIndepMultiplexorsMuxAM1,
+280 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m1`
 
 error[E0592]: duplicate definitions with name `set_m2`
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:288:5
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:289:5
     |
-187 | /     pub fn set_m2(
-188 | |         &mut self,
-189 | |         value: ExtMuxIndepMultiplexorsMuxBM2,
-190 | |     ) -> Result<(), CanError> {
+188 | /     pub fn set_m2(
+189 | |         &mut self,
+190 | |         value: ExtMuxIndepMultiplexorsMuxBM2,
+191 | |     ) -> Result<(), CanError> {
     | |_____________________________- other definition for `set_m2`
 ...
-288 | /     pub fn set_m2(
-289 | |         &mut self,
-290 | |         value: ExtMuxIndepMultiplexorsMuxAM2,
-291 | |     ) -> Result<(), CanError> {
+289 | /     pub fn set_m2(
+290 | |         &mut self,
+291 | |         value: ExtMuxIndepMultiplexorsMuxAM2,
+292 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:216:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:217:21
     |
-216 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-216 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-216 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:223:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:224:21
     |
-223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-223 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-223 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |
 
 error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
-   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:230:21
+   --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:231:21
     |
-230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
     |
 help: an enum with a similar name exists
     |
-230 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-230 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
     |

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values.snap.rs
@@ -68,6 +68,7 @@ impl ExtMuxMultipleValues {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_2_MIN: i8 = 0_i8;
     pub const MUXED_2_MAX: i8 = 0_i8;
     pub const MUXED_1_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values_dumped.snap.rs
@@ -68,6 +68,7 @@ impl ExtMuxMultipleValues {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MUXED_0_3_4_5_MIN: i8 = 0_i8;
     pub const MUXED_0_3_4_5_MAX: i8 = 0_i8;
     pub const MUXED_1_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_199.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.rs
@@ -117,6 +117,7 @@ impl DriverDoorStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 1;
     /// Construct new DriverDoorStatus from values
     pub fn new(driver_door_opened: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 1] };
@@ -248,6 +249,7 @@ impl Chime {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 5;
     pub const CHIME_TYPE_MIN: u8 = 0_u8;
     pub const CHIME_TYPE_MAX: u8 = 0_u8;
     pub const CHIME_REPEAT_MIN: u8 = 0_u8;
@@ -574,6 +576,7 @@ impl BlinkerStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xc000)
     });
+    pub const MESSAGE_SIZE: usize = 5;
     /// Construct new BlinkerStatus from values
     pub fn new(
         right_blinker: bool,
@@ -831,6 +834,7 @@ impl SteeringWheelAngle {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const STEERING_WHEEL_ANGLE_MIN: f32 = -540_f32;
     pub const STEERING_WHEEL_ANGLE_MAX: f32 = 540_f32;
     /// Construct new SteeringWheelAngle from values
@@ -969,6 +973,7 @@ impl GearShifter {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xc000)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GEAR_SHIFTER_MIN: u8 = 0_u8;
     pub const GEAR_SHIFTER_MAX: u8 = 3_u8;
     /// Construct new GearShifter from values
@@ -1164,6 +1169,7 @@ impl GasPedalRegenCruise {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xa000)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GAS_PEDAL_MIN: u8 = 0_u8;
     pub const GAS_PEDAL_MAX: u8 = 254_u8;
     pub const GEAR_SHIFTER2_NOT_USED_MIN: u8 = 0_u8;
@@ -1425,6 +1431,7 @@ impl BrakePedal {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const BRAKE_LEVEL_MIN: u8 = 0_u8;
     pub const BRAKE_LEVEL_MAX: u8 = 3_u8;
     pub const BRAKE_SENSOR_MIN: u8 = 0_u8;
@@ -1610,6 +1617,7 @@ impl WheelSpeed {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x8000)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const WHEEL_SPEED_FL_MIN: f32 = 0_f32;
     pub const WHEEL_SPEED_FL_MAX: f32 = 70_f32;
     pub const WHEEL_SPEED_FR_MIN: f32 = 0_f32;
@@ -1853,6 +1861,7 @@ impl VehicleSpeed {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VEHICLE_SPEED1_MIN: f32 = 0_f32;
     pub const VEHICLE_SPEED1_MAX: f32 = 100_f32;
     pub const VEHICLE_SPEED2_MIN: f32 = 0_f32;
@@ -2032,6 +2041,7 @@ impl CruiseButtons {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x8000)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const CRUISE_BUTTONS_MIN: u8 = 0_u8;
     pub const CRUISE_BUTTONS_MAX: u8 = 12_u8;
     /// Construct new CruiseButtons from values
@@ -2155,6 +2165,7 @@ impl CruiseButtons2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x6000)
     });
+    pub const MESSAGE_SIZE: usize = 1;
     pub const LKA_GAP_BUTTON_MIN: u8 = 0_u8;
     pub const LKA_GAP_BUTTON_MAX: u8 = 2_u8;
     /// Construct new CruiseButtons2 from values

--- a/tests-snapshots/dbc-cantools/issue_199.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.stderr
@@ -22,6 +22,22 @@ error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
 2279 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
+<<<<<<< HEAD
+=======
+help: an enum with a similar name exists
+     |
+2064 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2064 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
+   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:994:18
+    |
+994 |             3 => GearShifterGearShifter::Park,
+    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+    |
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
 help: an enum with a similar name exists
      |
 2064 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
@@ -32,6 +48,22 @@ error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:999:18
     |
 999 |             3 => GearShifterGearShifter::Park,
+<<<<<<< HEAD
+=======
+    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+    |
+help: an enum with a similar name exists
+    |
+999 -             3 => GearShifterGearShifter::Park,
+999 +             3 => GearShifterLeftBlinker::Park,
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
+   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:995:18
+    |
+995 |             0 => GearShifterGearShifter::DriveLow,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
@@ -68,6 +100,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2067:18
      |
 2067 |             6 => CruiseButtonsCruiseButtons::Cancel,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2067 -             6 => CruiseButtonsCruiseButtons::Cancel,
+2067 +             6 => CruiseButtons2LkaGapButton::Cancel,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2058:18
+     |
+2058 |             5 => CruiseButtonsCruiseButtons::Main,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -80,6 +128,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2068:18
      |
 2068 |             5 => CruiseButtonsCruiseButtons::Main,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2068 -             5 => CruiseButtonsCruiseButtons::Main,
+2068 +             5 => CruiseButtons2LkaGapButton::Main,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2059:18
+     |
+2059 |             3 => CruiseButtonsCruiseButtons::Set,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -92,6 +156,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2069:18
      |
 2069 |             3 => CruiseButtonsCruiseButtons::Set,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2069 -             3 => CruiseButtonsCruiseButtons::Set,
+2069 +             3 => CruiseButtons2LkaGapButton::Set,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2060:18
+     |
+2060 |             2 => CruiseButtonsCruiseButtons::Resume,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -104,6 +184,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2070:18
      |
 2070 |             2 => CruiseButtonsCruiseButtons::Resume,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2070 -             2 => CruiseButtonsCruiseButtons::Resume,
+2070 +             2 => CruiseButtons2LkaGapButton::Resume,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2061:18
+     |
+2061 |             1 => CruiseButtonsCruiseButtons::None,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -116,6 +212,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2071:18
      |
 2071 |             1 => CruiseButtonsCruiseButtons::None,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2071 -             1 => CruiseButtonsCruiseButtons::None,
+2071 +             1 => CruiseButtons2LkaGapButton::None,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2062:18
+     |
+2062 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_199.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.stderr
@@ -1,139 +1,139 @@
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:991:35
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:996:35
      |
- 991 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+ 996 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
      |                                   ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1106 | pub enum GearShifterLeftBlinker {
+1111 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
- 991 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
- 991 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+ 996 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+ 996 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2054:37
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2064:37
      |
-2054 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2064 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
      |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2268 | pub enum CruiseButtons2LkaGapButton {
+2279 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-2054 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-2054 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+2064 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2064 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
      |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:994:18
+   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:999:18
     |
-994 |             3 => GearShifterGearShifter::Park,
+999 |             3 => GearShifterGearShifter::Park,
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-994 -             3 => GearShifterGearShifter::Park,
-994 +             3 => GearShifterLeftBlinker::Park,
+999 -             3 => GearShifterGearShifter::Park,
+999 +             3 => GearShifterLeftBlinker::Park,
     |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:995:18
-    |
-995 |             0 => GearShifterGearShifter::DriveLow,
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1000:18
+     |
+1000 |             0 => GearShifterGearShifter::DriveLow,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+     |
 help: an enum with a similar name exists
-    |
-995 -             0 => GearShifterGearShifter::DriveLow,
-995 +             0 => GearShifterLeftBlinker::DriveLow,
-    |
+     |
+1000 -             0 => GearShifterGearShifter::DriveLow,
+1000 +             0 => GearShifterLeftBlinker::DriveLow,
+     |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:996:18
-    |
-996 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1001:18
+     |
+1001 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+     |
 help: an enum with a similar name exists
-    |
-996 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-996 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
-    |
+     |
+1001 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+1001 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
+     |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2057:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2067:18
      |
-2057 |             6 => CruiseButtonsCruiseButtons::Cancel,
+2067 |             6 => CruiseButtonsCruiseButtons::Cancel,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2057 -             6 => CruiseButtonsCruiseButtons::Cancel,
-2057 +             6 => CruiseButtons2LkaGapButton::Cancel,
+2067 -             6 => CruiseButtonsCruiseButtons::Cancel,
+2067 +             6 => CruiseButtons2LkaGapButton::Cancel,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2058:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2068:18
      |
-2058 |             5 => CruiseButtonsCruiseButtons::Main,
+2068 |             5 => CruiseButtonsCruiseButtons::Main,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2058 -             5 => CruiseButtonsCruiseButtons::Main,
-2058 +             5 => CruiseButtons2LkaGapButton::Main,
+2068 -             5 => CruiseButtonsCruiseButtons::Main,
+2068 +             5 => CruiseButtons2LkaGapButton::Main,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2059:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2069:18
      |
-2059 |             3 => CruiseButtonsCruiseButtons::Set,
+2069 |             3 => CruiseButtonsCruiseButtons::Set,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2059 -             3 => CruiseButtonsCruiseButtons::Set,
-2059 +             3 => CruiseButtons2LkaGapButton::Set,
+2069 -             3 => CruiseButtonsCruiseButtons::Set,
+2069 +             3 => CruiseButtons2LkaGapButton::Set,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2060:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2070:18
      |
-2060 |             2 => CruiseButtonsCruiseButtons::Resume,
+2070 |             2 => CruiseButtonsCruiseButtons::Resume,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2060 -             2 => CruiseButtonsCruiseButtons::Resume,
-2060 +             2 => CruiseButtons2LkaGapButton::Resume,
+2070 -             2 => CruiseButtonsCruiseButtons::Resume,
+2070 +             2 => CruiseButtons2LkaGapButton::Resume,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2061:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2071:18
      |
-2061 |             1 => CruiseButtonsCruiseButtons::None,
+2071 |             1 => CruiseButtonsCruiseButtons::None,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2061 -             1 => CruiseButtonsCruiseButtons::None,
-2061 +             1 => CruiseButtons2LkaGapButton::None,
+2071 -             1 => CruiseButtonsCruiseButtons::None,
+2071 +             1 => CruiseButtons2LkaGapButton::None,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2062:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2072:18
      |
-2062 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+2072 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2062 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-2062 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
+2072 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+2072 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
      |
 
 error: unreachable pattern

--- a/tests-snapshots/dbc-cantools/issue_199.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.stderr
@@ -22,22 +22,6 @@ error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
 2279 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
-<<<<<<< HEAD
-=======
-help: an enum with a similar name exists
-     |
-2064 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-2064 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:994:18
-    |
-994 |             3 => GearShifterGearShifter::Park,
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
 help: an enum with a similar name exists
      |
 2064 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
@@ -48,22 +32,6 @@ error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:999:18
     |
 999 |             3 => GearShifterGearShifter::Park,
-<<<<<<< HEAD
-=======
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
-help: an enum with a similar name exists
-    |
-999 -             3 => GearShifterGearShifter::Park,
-999 +             3 => GearShifterLeftBlinker::Park,
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:995:18
-    |
-995 |             0 => GearShifterGearShifter::DriveLow,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
@@ -100,22 +68,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2067:18
      |
 2067 |             6 => CruiseButtonsCruiseButtons::Cancel,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2067 -             6 => CruiseButtonsCruiseButtons::Cancel,
-2067 +             6 => CruiseButtons2LkaGapButton::Cancel,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2058:18
-     |
-2058 |             5 => CruiseButtonsCruiseButtons::Main,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -128,22 +80,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2068:18
      |
 2068 |             5 => CruiseButtonsCruiseButtons::Main,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2068 -             5 => CruiseButtonsCruiseButtons::Main,
-2068 +             5 => CruiseButtons2LkaGapButton::Main,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2059:18
-     |
-2059 |             3 => CruiseButtonsCruiseButtons::Set,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -156,22 +92,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2069:18
      |
 2069 |             3 => CruiseButtonsCruiseButtons::Set,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2069 -             3 => CruiseButtonsCruiseButtons::Set,
-2069 +             3 => CruiseButtons2LkaGapButton::Set,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2060:18
-     |
-2060 |             2 => CruiseButtonsCruiseButtons::Resume,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -184,22 +104,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2070:18
      |
 2070 |             2 => CruiseButtonsCruiseButtons::Resume,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2070 -             2 => CruiseButtonsCruiseButtons::Resume,
-2070 +             2 => CruiseButtons2LkaGapButton::Resume,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2061:18
-     |
-2061 |             1 => CruiseButtonsCruiseButtons::None,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -212,22 +116,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2071:18
      |
 2071 |             1 => CruiseButtonsCruiseButtons::None,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2071 -             1 => CruiseButtonsCruiseButtons::None,
-2071 +             1 => CruiseButtons2LkaGapButton::None,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2062:18
-     |
-2062 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
@@ -117,6 +117,7 @@ impl DriverDoorStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x1fffffff)
     });
+    pub const MESSAGE_SIZE: usize = 1;
     /// Construct new DriverDoorStatus from values
     pub fn new(driver_door_opened: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0u8; 1] };
@@ -248,6 +249,7 @@ impl Chime {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 5;
     pub const CHIME_TYPE_MIN: u8 = 0_u8;
     pub const CHIME_TYPE_MAX: u8 = 0_u8;
     pub const CHIME_REPEAT_MIN: u8 = 0_u8;
@@ -549,6 +551,7 @@ impl BlinkerStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xc000)
     });
+    pub const MESSAGE_SIZE: usize = 5;
     /// Construct new BlinkerStatus from values
     pub fn new(
         right_blinker: bool,
@@ -806,6 +809,7 @@ impl SteeringWheelAngle {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const STEERING_WHEEL_ANGLE_MIN: f32 = -540_f32;
     pub const STEERING_WHEEL_ANGLE_MAX: f32 = 540_f32;
     /// Construct new SteeringWheelAngle from values
@@ -919,6 +923,7 @@ impl GearShifter {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xc000)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GEAR_SHIFTER_MIN: u8 = 0_u8;
     pub const GEAR_SHIFTER_MAX: u8 = 3_u8;
     /// Construct new GearShifter from values
@@ -1114,6 +1119,7 @@ impl GasPedalRegenCruise {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xa000)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GAS_PEDAL_MIN: u8 = 0_u8;
     pub const GAS_PEDAL_MAX: u8 = 254_u8;
     pub const GEAR_SHIFTER2_NOT_USED_MIN: u8 = 0_u8;
@@ -1375,6 +1381,7 @@ impl BrakePedal {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const BRAKE_LEVEL_MIN: u8 = 0_u8;
     pub const BRAKE_LEVEL_MAX: u8 = 3_u8;
     pub const BRAKE_SENSOR_MIN: u8 = 0_u8;
@@ -1535,6 +1542,7 @@ impl WheelSpeed {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x8000)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const WHEEL_SPEED_FL_MIN: f32 = 0_f32;
     pub const WHEEL_SPEED_FL_MAX: f32 = 70_f32;
     pub const WHEEL_SPEED_FR_MIN: f32 = 0_f32;
@@ -1778,6 +1786,7 @@ impl VehicleSpeed {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VEHICLE_SPEED1_MIN: f32 = 0_f32;
     pub const VEHICLE_SPEED1_MAX: f32 = 100_f32;
     pub const VEHICLE_SPEED2_MIN: f32 = 0_f32;
@@ -1932,6 +1941,7 @@ impl CruiseButtons {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x8000)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const CRUISE_BUTTONS_MIN: u8 = 0_u8;
     pub const CRUISE_BUTTONS_MAX: u8 = 12_u8;
     /// Construct new CruiseButtons from values
@@ -2055,6 +2065,7 @@ impl CruiseButtons2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x6000)
     });
+    pub const MESSAGE_SIZE: usize = 1;
     pub const LKA_GAP_BUTTON_MIN: u8 = 0_u8;
     pub const LKA_GAP_BUTTON_MAX: u8 = 2_u8;
     /// Construct new CruiseButtons2 from values

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
@@ -1,139 +1,139 @@
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:941:35
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:946:35
      |
- 941 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+ 946 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
      |                                   ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1056 | pub enum GearShifterLeftBlinker {
+1061 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
- 941 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
- 941 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+ 946 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+ 946 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1954:37
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1964:37
      |
-1954 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+1964 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
      |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2168 | pub enum CruiseButtons2LkaGapButton {
+2179 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-1954 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-1954 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+1964 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+1964 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
      |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:944:18
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:949:18
     |
-944 |             3 => GearShifterGearShifter::Park,
+949 |             3 => GearShifterGearShifter::Park,
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-944 -             3 => GearShifterGearShifter::Park,
-944 +             3 => GearShifterLeftBlinker::Park,
+949 -             3 => GearShifterGearShifter::Park,
+949 +             3 => GearShifterLeftBlinker::Park,
     |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:945:18
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:950:18
     |
-945 |             0 => GearShifterGearShifter::DriveLow,
+950 |             0 => GearShifterGearShifter::DriveLow,
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-945 -             0 => GearShifterGearShifter::DriveLow,
-945 +             0 => GearShifterLeftBlinker::DriveLow,
+950 -             0 => GearShifterGearShifter::DriveLow,
+950 +             0 => GearShifterLeftBlinker::DriveLow,
     |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:946:18
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:951:18
     |
-946 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+951 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-946 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-946 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
+951 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+951 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
     |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1957:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1967:18
      |
-1957 |             6 => CruiseButtonsCruiseButtons::Cancel,
+1967 |             6 => CruiseButtonsCruiseButtons::Cancel,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1957 -             6 => CruiseButtonsCruiseButtons::Cancel,
-1957 +             6 => CruiseButtons2LkaGapButton::Cancel,
+1967 -             6 => CruiseButtonsCruiseButtons::Cancel,
+1967 +             6 => CruiseButtons2LkaGapButton::Cancel,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1958:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1968:18
      |
-1958 |             5 => CruiseButtonsCruiseButtons::Main,
+1968 |             5 => CruiseButtonsCruiseButtons::Main,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1958 -             5 => CruiseButtonsCruiseButtons::Main,
-1958 +             5 => CruiseButtons2LkaGapButton::Main,
+1968 -             5 => CruiseButtonsCruiseButtons::Main,
+1968 +             5 => CruiseButtons2LkaGapButton::Main,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1959:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1969:18
      |
-1959 |             3 => CruiseButtonsCruiseButtons::Set,
+1969 |             3 => CruiseButtonsCruiseButtons::Set,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1959 -             3 => CruiseButtonsCruiseButtons::Set,
-1959 +             3 => CruiseButtons2LkaGapButton::Set,
+1969 -             3 => CruiseButtonsCruiseButtons::Set,
+1969 +             3 => CruiseButtons2LkaGapButton::Set,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1960:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1970:18
      |
-1960 |             2 => CruiseButtonsCruiseButtons::Resume,
+1970 |             2 => CruiseButtonsCruiseButtons::Resume,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1960 -             2 => CruiseButtonsCruiseButtons::Resume,
-1960 +             2 => CruiseButtons2LkaGapButton::Resume,
+1970 -             2 => CruiseButtonsCruiseButtons::Resume,
+1970 +             2 => CruiseButtons2LkaGapButton::Resume,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1961:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1971:18
      |
-1961 |             1 => CruiseButtonsCruiseButtons::None,
+1971 |             1 => CruiseButtonsCruiseButtons::None,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1961 -             1 => CruiseButtonsCruiseButtons::None,
-1961 +             1 => CruiseButtons2LkaGapButton::None,
+1971 -             1 => CruiseButtonsCruiseButtons::None,
+1971 +             1 => CruiseButtons2LkaGapButton::None,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1962:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1972:18
      |
-1962 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+1972 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1962 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-1962 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
+1972 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+1972 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
      |
 
 error: unreachable pattern

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
@@ -22,6 +22,22 @@ error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
 2179 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
+<<<<<<< HEAD
+=======
+help: an enum with a similar name exists
+     |
+1964 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+1964 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:944:18
+    |
+944 |             3 => GearShifterGearShifter::Park,
+    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+    |
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
 help: an enum with a similar name exists
      |
 1964 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
@@ -32,6 +48,22 @@ error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:949:18
     |
 949 |             3 => GearShifterGearShifter::Park,
+<<<<<<< HEAD
+=======
+    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+    |
+help: an enum with a similar name exists
+    |
+949 -             3 => GearShifterGearShifter::Park,
+949 +             3 => GearShifterLeftBlinker::Park,
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:945:18
+    |
+945 |             0 => GearShifterGearShifter::DriveLow,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
@@ -44,6 +76,22 @@ error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:950:18
     |
 950 |             0 => GearShifterGearShifter::DriveLow,
+<<<<<<< HEAD
+=======
+    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+    |
+help: an enum with a similar name exists
+    |
+950 -             0 => GearShifterGearShifter::DriveLow,
+950 +             0 => GearShifterLeftBlinker::DriveLow,
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:946:18
+    |
+946 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
@@ -58,6 +106,22 @@ error[E0433]: cannot find type `GearShifterGearShifter` in this scope
 951 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
+<<<<<<< HEAD
+=======
+help: an enum with a similar name exists
+    |
+951 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+951 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1957:18
+     |
+1957 |             6 => CruiseButtonsCruiseButtons::Cancel,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
 help: an enum with a similar name exists
     |
 951 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
@@ -68,6 +132,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1967:18
      |
 1967 |             6 => CruiseButtonsCruiseButtons::Cancel,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1967 -             6 => CruiseButtonsCruiseButtons::Cancel,
+1967 +             6 => CruiseButtons2LkaGapButton::Cancel,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1958:18
+     |
+1958 |             5 => CruiseButtonsCruiseButtons::Main,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -80,6 +160,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1968:18
      |
 1968 |             5 => CruiseButtonsCruiseButtons::Main,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1968 -             5 => CruiseButtonsCruiseButtons::Main,
+1968 +             5 => CruiseButtons2LkaGapButton::Main,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1959:18
+     |
+1959 |             3 => CruiseButtonsCruiseButtons::Set,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -92,6 +188,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1969:18
      |
 1969 |             3 => CruiseButtonsCruiseButtons::Set,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1969 -             3 => CruiseButtonsCruiseButtons::Set,
+1969 +             3 => CruiseButtons2LkaGapButton::Set,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1960:18
+     |
+1960 |             2 => CruiseButtonsCruiseButtons::Resume,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -104,6 +216,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1970:18
      |
 1970 |             2 => CruiseButtonsCruiseButtons::Resume,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1970 -             2 => CruiseButtonsCruiseButtons::Resume,
+1970 +             2 => CruiseButtons2LkaGapButton::Resume,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1961:18
+     |
+1961 |             1 => CruiseButtonsCruiseButtons::None,
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -116,6 +244,22 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1971:18
      |
 1971 |             1 => CruiseButtonsCruiseButtons::None,
+<<<<<<< HEAD
+=======
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1971 -             1 => CruiseButtonsCruiseButtons::None,
+1971 +             1 => CruiseButtons2LkaGapButton::None,
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1962:18
+     |
+1962 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
@@ -22,22 +22,6 @@ error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
 2179 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
-<<<<<<< HEAD
-=======
-help: an enum with a similar name exists
-     |
-1964 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-1964 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:944:18
-    |
-944 |             3 => GearShifterGearShifter::Park,
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
 help: an enum with a similar name exists
      |
 1964 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
@@ -48,22 +32,6 @@ error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:949:18
     |
 949 |             3 => GearShifterGearShifter::Park,
-<<<<<<< HEAD
-=======
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
-help: an enum with a similar name exists
-    |
-949 -             3 => GearShifterGearShifter::Park,
-949 +             3 => GearShifterLeftBlinker::Park,
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:945:18
-    |
-945 |             0 => GearShifterGearShifter::DriveLow,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
@@ -76,22 +44,6 @@ error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:950:18
     |
 950 |             0 => GearShifterGearShifter::DriveLow,
-<<<<<<< HEAD
-=======
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
-help: an enum with a similar name exists
-    |
-950 -             0 => GearShifterGearShifter::DriveLow,
-950 +             0 => GearShifterLeftBlinker::DriveLow,
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:946:18
-    |
-946 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
@@ -106,22 +58,6 @@ error[E0433]: cannot find type `GearShifterGearShifter` in this scope
 951 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
-<<<<<<< HEAD
-=======
-help: an enum with a similar name exists
-    |
-951 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-951 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1957:18
-     |
-1957 |             6 => CruiseButtonsCruiseButtons::Cancel,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
 help: an enum with a similar name exists
     |
 951 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
@@ -132,22 +68,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1967:18
      |
 1967 |             6 => CruiseButtonsCruiseButtons::Cancel,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-1967 -             6 => CruiseButtonsCruiseButtons::Cancel,
-1967 +             6 => CruiseButtons2LkaGapButton::Cancel,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1958:18
-     |
-1958 |             5 => CruiseButtonsCruiseButtons::Main,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -160,22 +80,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1968:18
      |
 1968 |             5 => CruiseButtonsCruiseButtons::Main,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-1968 -             5 => CruiseButtonsCruiseButtons::Main,
-1968 +             5 => CruiseButtons2LkaGapButton::Main,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1959:18
-     |
-1959 |             3 => CruiseButtonsCruiseButtons::Set,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -188,22 +92,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1969:18
      |
 1969 |             3 => CruiseButtonsCruiseButtons::Set,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-1969 -             3 => CruiseButtonsCruiseButtons::Set,
-1969 +             3 => CruiseButtons2LkaGapButton::Set,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1960:18
-     |
-1960 |             2 => CruiseButtonsCruiseButtons::Resume,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -216,22 +104,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1970:18
      |
 1970 |             2 => CruiseButtonsCruiseButtons::Resume,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-1970 -             2 => CruiseButtonsCruiseButtons::Resume,
-1970 +             2 => CruiseButtons2LkaGapButton::Resume,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1961:18
-     |
-1961 |             1 => CruiseButtonsCruiseButtons::None,
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
@@ -244,22 +116,6 @@ error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1971:18
      |
 1971 |             1 => CruiseButtonsCruiseButtons::None,
-<<<<<<< HEAD
-=======
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-1971 -             1 => CruiseButtonsCruiseButtons::None,
-1971 +             1 => CruiseButtons2LkaGapButton::None,
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1962:18
-     |
-1962 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/issue_207_sig_plus.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_207_sig_plus.snap.rs
@@ -66,6 +66,7 @@ impl MyMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MY_EXTRA_SIG_WITH_PLUS_MIN: i16 = -128_i16;
     pub const MY_EXTRA_SIG_WITH_PLUS_MAX: i16 = 127_i16;
     pub const MY_NORMAL_SIG_MIN: i16 = -128_i16;

--- a/tests-snapshots/dbc-cantools/issue_228.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_228.snap.rs
@@ -69,6 +69,7 @@ impl SgMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
     pub const SG2_MIN: i8 = 0_i8;
@@ -279,6 +280,7 @@ impl NormalMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_2_MIN: i8 = 0_i8;
     pub const SIG_2_MAX: i8 = 0_i8;
     pub const SIG_1_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/issue_63.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_63.snap.rs
@@ -66,6 +66,7 @@ impl Aft1psi2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x18fc8bfe)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const HTR_RES_MIN: f32 = 0_f32;
     pub const HTR_RES_MAX: f32 = 6425.5_f32;
     pub const MAX_RES_MIN: u32 = 0_u32;

--- a/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
@@ -71,6 +71,7 @@ impl ExampleMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1f0)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_MIN: f32 = 4070_f32;
     pub const TEMPERATURE_MAX: f32 = 4100_f32;
     /// Construct new ExampleMessage from values

--- a/tests-snapshots/dbc-cantools/issue_725.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_725.snap.rs
@@ -69,6 +69,7 @@ impl TestMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 1;
     pub const SIGNAL1_MIN: u8 = 0_u8;
     pub const SIGNAL1_MAX: u8 = 250_u8;
     /// Construct new TestMessage from values

--- a/tests-snapshots/dbc-cantools/j1939.snap.rs
+++ b/tests-snapshots/dbc-cantools/j1939.snap.rs
@@ -70,6 +70,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x15340201)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i8 = 0_i8;
     pub const SIGNAL1_MAX: i8 = 0_i8;
     /// Construct new Message1 from values
@@ -187,6 +188,7 @@ impl Message2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x15f01002)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL2_MIN: i8 = 0_i8;
     pub const SIGNAL2_MAX: i8 = 0_i8;
     /// Construct new Message2 from values

--- a/tests-snapshots/dbc-cantools/long_names.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names.snap.rs
@@ -133,6 +133,7 @@ impl Ss123456789012345678901234587890 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x9)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new SS123456789012345678901234587890 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -202,6 +203,7 @@ impl Ss12345678901234567890123450000 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x8)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new SS1234567890123456789012345_0000 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -271,6 +273,7 @@ impl Ss12345678901234567890123450001 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x7)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new SS1234567890123456789012345_0001 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -340,6 +343,7 @@ impl Ss123456789012345678901234577890 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x6)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new SS123456789012345678901234577890 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -409,6 +413,7 @@ impl Ss123456789012345678901234567890 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x5)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new SS123456789012345678901234567890 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -478,6 +483,7 @@ impl S1234567890123456789012345678901 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x4)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SS123456789012345678901234567890_MIN: i8 = 0_i8;
     pub const SS123456789012345678901234567890_MAX: i8 = 0_i8;
     /// Construct new S1234567890123456789012345678901 from values
@@ -597,6 +603,7 @@ impl M123456789012345678901234560000 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SSS12345678901234567890123456789_MIN: i8 = 0_i8;
     pub const SSS12345678901234567890123456789_MAX: i8 = 0_i8;
     /// Construct new M12345678901234567890123456_0000 from values
@@ -717,6 +724,7 @@ impl M1234567890123456789012345678901 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SS1234567890123456789012345_0000_MIN: i8 = 0_i8;
     pub const SS1234567890123456789012345_0000_MAX: i8 = 0_i8;
     pub const SS1234567890123456789012345_0001_MIN: i8 = 0_i8;
@@ -1043,6 +1051,7 @@ impl M123456789012345678901234560001 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SS1234567890123456789012345_0003_MIN: i8 = 0_i8;
     pub const SS1234567890123456789012345_0003_MAX: i8 = 0_i8;
     pub const SS1234567890123456789012345_0004_MIN: i8 = 0_i8;
@@ -1317,6 +1326,7 @@ impl Mm123456789012345678901234567890 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x3)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SSS123456789012345678901234_0000_MIN: i8 = 0_i8;
     pub const SSS123456789012345678901234_0000_MAX: i8 = 0_i8;
     pub const SS1234567890123456789012345_0005_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
@@ -107,6 +107,7 @@ impl MsgLongName5678912345678912 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x55)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_11111111111111111111111_MIN: i8 = 0_i8;
     pub const RX_TWICE_11111111111111111111111_MAX: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MIN: i32 = 0_i32;
@@ -328,6 +329,7 @@ impl TxTwice {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x6)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MIN: i8 = 0_i8;
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MAX: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MIN: i8 = 0_i8;
@@ -498,6 +500,7 @@ impl RxTx1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x5)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MIN: i16 = 0_i16;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MAX: i16 = 0_i16;
     /// Construct new RX_TX_1 from values
@@ -617,6 +620,7 @@ impl MsgCaseTest {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x4)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new MSG_CASE_TEST from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -686,6 +690,7 @@ impl MsgCaseTest {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x3)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new msg_case_test from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -755,6 +760,7 @@ impl MsgWithValueTableSigs {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const SIG_WITH_SHORT_VAL_TABLE_MIN: i8 = 0_i8;
     pub const SIG_WITH_SHORT_VAL_TABLE_MAX: i8 = 0_i8;
     pub const SIG_WITH_LONG_VAL_TABLE_2_MIN: i8 = 0_i8;
@@ -1125,6 +1131,7 @@ impl MsgLongName5678912345670000 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_11111111111111111111111_MIN: i8 = 0_i8;
     pub const RX_TWICE_11111111111111111111111_MAX: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0001_MIN: i8 = 0_i8;
@@ -1297,6 +1304,7 @@ impl MsgLongName5678912345670001 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_SHORT_MIN: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MAX: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0002_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
@@ -10,77 +10,86 @@ error[E0428]: the name `MsgCaseTest` is defined multiple times
    = note: `MsgCaseTest` must be defined only once in the type namespace of this enum
 
 error[E0428]: the name `MsgCaseTest` is defined multiple times
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:673:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:677:1
     |
-604 | pub struct MsgCaseTest {
+607 | pub struct MsgCaseTest {
     | ---------------------- previous definition of the type `MsgCaseTest` here
 ...
-673 | pub struct MsgCaseTest {
+677 | pub struct MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^ `MsgCaseTest` redefined here
     |
     = note: `MsgCaseTest` must be defined only once in the type namespace of this module
 
 error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:672:10
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:676:10
     |
-603 | #[derive(Clone, Copy)]
+606 | #[derive(Clone, Copy)]
     |          ----- first implementation here
 ...
-672 | #[derive(Clone, Copy)]
+676 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:672:17
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:676:17
     |
-603 | #[derive(Clone, Copy)]
+606 | #[derive(Clone, Copy)]
     |                 ---- first implementation here
 ...
-672 | #[derive(Clone, Copy)]
+676 | #[derive(Clone, Copy)]
     |                 ^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `TryFrom<&[u8]>` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:699:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:704:1
     |
-630 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
+634 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
     | -------------------------------------------------- first implementation here
 ...
-699 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
+704 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `Frame` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:711:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:716:1
     |
-642 | impl embedded_can::Frame for MsgCaseTest {
+646 | impl embedded_can::Frame for MsgCaseTest {
     | ---------------------------------------- first implementation here
 ...
-711 | impl embedded_can::Frame for MsgCaseTest {
+716 | impl embedded_can::Frame for MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0592]: duplicate definitions with name `MESSAGE_ID`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `MESSAGE_ID`
 ...
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     -------------------------------------- other definition for `MESSAGE_ID`
 
-error[E0592]: duplicate definitions with name `new`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:621:5
+error[E0592]: duplicate definitions with name `MESSAGE_SIZE`
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:623:5
     |
-621 |     pub fn new() -> Result<Self, CanError> {
+623 |     pub const MESSAGE_SIZE: usize = 8;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `MESSAGE_SIZE`
+...
+693 |     pub const MESSAGE_SIZE: usize = 8;
+    |     ----------------------------- other definition for `MESSAGE_SIZE`
+
+error[E0592]: duplicate definitions with name `new`
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:625:5
+    |
+625 |     pub fn new() -> Result<Self, CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `new`
 ...
-690 |     pub fn new() -> Result<Self, CanError> {
+695 |     pub fn new() -> Result<Self, CanError> {
     |     -------------------------------------- other definition for `new`
 
 error[E0592]: duplicate definitions with name `raw`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:626:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:630:5
     |
-626 |     pub fn raw(&self) -> &[u8; 8] {
+630 |     pub fn raw(&self) -> &[u8; 8] {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `raw`
 ...
-695 |     pub fn raw(&self) -> &[u8; 8] {
+700 |     pub fn raw(&self) -> &[u8; 8] {
     |     ----------------------------- other definition for `raw`
 
 error[E0034]: multiple applicable items in scope
@@ -90,14 +99,14 @@ error[E0034]: multiple applicable items in scope
     |                          ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
@@ -107,80 +116,80 @@ error[E0034]: multiple applicable items in scope
     |                          ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:644:31
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:648:31
     |
-644 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
+648 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
     |                               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:659:15
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:663:15
     |
-659 |         Self::MESSAGE_ID
+663 |         Self::MESSAGE_ID
     |               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:713:31
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:718:31
     |
-713 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
+718 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
     |                               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:728:15
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:733:15
     |
-728 |         Self::MESSAGE_ID
+733 |         Self::MESSAGE_ID
     |               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
@@ -107,6 +107,7 @@ impl MsgLongName5678912345678912 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x55)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_SHORT_MIN: i32 = 0_i32;
     pub const RX_TWICE_SHORT_MAX: i32 = 0_i32;
     pub const RX_TWICE_11111111111111111111111_MIN: i8 = 0_i8;
@@ -328,6 +329,7 @@ impl TxTwice {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x6)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MIN: i8 = 0_i8;
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MAX: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MIN: i8 = 0_i8;
@@ -498,6 +500,7 @@ impl RxTx1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x5)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MIN: i16 = 0_i16;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MAX: i16 = 0_i16;
     /// Construct new RX_TX_1 from values
@@ -617,6 +620,7 @@ impl MsgCaseTest {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x4)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new MSG_CASE_TEST from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -686,6 +690,7 @@ impl MsgCaseTest {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x3)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     /// Construct new msg_case_test from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 8] };
@@ -755,6 +760,7 @@ impl MsgWithValueTableSigs {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const SIG_WITH_SHORT_VAL_TABLE_MIN: i8 = 0_i8;
     pub const SIG_WITH_SHORT_VAL_TABLE_MAX: i8 = 0_i8;
     pub const SIG_WITH_LONG_VAL_TABLE_2_MIN: i8 = 0_i8;
@@ -1125,6 +1131,7 @@ impl MsgLongName5678912345670000 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_11111111111111111111111_MIN: i8 = 0_i8;
     pub const RX_TWICE_11111111111111111111111_MAX: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0001_MIN: i8 = 0_i8;
@@ -1297,6 +1304,7 @@ impl MsgLongName5678912345670001 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const RX_TWICE_SHORT_MIN: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MAX: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0002_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
@@ -10,77 +10,86 @@ error[E0428]: the name `MsgCaseTest` is defined multiple times
    = note: `MsgCaseTest` must be defined only once in the type namespace of this enum
 
 error[E0428]: the name `MsgCaseTest` is defined multiple times
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:673:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:677:1
     |
-604 | pub struct MsgCaseTest {
+607 | pub struct MsgCaseTest {
     | ---------------------- previous definition of the type `MsgCaseTest` here
 ...
-673 | pub struct MsgCaseTest {
+677 | pub struct MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^ `MsgCaseTest` redefined here
     |
     = note: `MsgCaseTest` must be defined only once in the type namespace of this module
 
 error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:672:10
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:676:10
     |
-603 | #[derive(Clone, Copy)]
+606 | #[derive(Clone, Copy)]
     |          ----- first implementation here
 ...
-672 | #[derive(Clone, Copy)]
+676 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:672:17
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:676:17
     |
-603 | #[derive(Clone, Copy)]
+606 | #[derive(Clone, Copy)]
     |                 ---- first implementation here
 ...
-672 | #[derive(Clone, Copy)]
+676 | #[derive(Clone, Copy)]
     |                 ^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `TryFrom<&[u8]>` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:699:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:704:1
     |
-630 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
+634 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
     | -------------------------------------------------- first implementation here
 ...
-699 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
+704 | impl core::convert::TryFrom<&[u8]> for MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0119]: conflicting implementations of trait `Frame` for type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:711:1
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:716:1
     |
-642 | impl embedded_can::Frame for MsgCaseTest {
+646 | impl embedded_can::Frame for MsgCaseTest {
     | ---------------------------------------- first implementation here
 ...
-711 | impl embedded_can::Frame for MsgCaseTest {
+716 | impl embedded_can::Frame for MsgCaseTest {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MsgCaseTest`
 
 error[E0592]: duplicate definitions with name `MESSAGE_ID`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `MESSAGE_ID`
 ...
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     -------------------------------------- other definition for `MESSAGE_ID`
 
-error[E0592]: duplicate definitions with name `new`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:621:5
+error[E0592]: duplicate definitions with name `MESSAGE_SIZE`
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:623:5
     |
-621 |     pub fn new() -> Result<Self, CanError> {
+623 |     pub const MESSAGE_SIZE: usize = 8;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `MESSAGE_SIZE`
+...
+693 |     pub const MESSAGE_SIZE: usize = 8;
+    |     ----------------------------- other definition for `MESSAGE_SIZE`
+
+error[E0592]: duplicate definitions with name `new`
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:625:5
+    |
+625 |     pub fn new() -> Result<Self, CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `new`
 ...
-690 |     pub fn new() -> Result<Self, CanError> {
+695 |     pub fn new() -> Result<Self, CanError> {
     |     -------------------------------------- other definition for `new`
 
 error[E0592]: duplicate definitions with name `raw`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:626:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:630:5
     |
-626 |     pub fn raw(&self) -> &[u8; 8] {
+630 |     pub fn raw(&self) -> &[u8; 8] {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `raw`
 ...
-695 |     pub fn raw(&self) -> &[u8; 8] {
+700 |     pub fn raw(&self) -> &[u8; 8] {
     |     ----------------------------- other definition for `raw`
 
 error[E0034]: multiple applicable items in scope
@@ -90,14 +99,14 @@ error[E0034]: multiple applicable items in scope
     |                          ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
@@ -107,80 +116,80 @@ error[E0034]: multiple applicable items in scope
     |                          ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:644:31
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:648:31
     |
-644 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
+648 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
     |                               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:659:15
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:663:15
     |
-659 |         Self::MESSAGE_ID
+663 |         Self::MESSAGE_ID
     |               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:713:31
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:718:31
     |
-713 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
+718 |         if id.into() != Self::MESSAGE_ID { None } else { data.try_into().ok() }
     |                               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0034]: multiple applicable items in scope
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:728:15
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:733:15
     |
-728 |         Self::MESSAGE_ID
+733 |         Self::MESSAGE_ID
     |               ^^^^^^^^^^ multiple `MESSAGE_ID` found
     |
 note: candidate #1 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:617:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:620:5
     |
-617 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+620 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `MsgCaseTest`
-   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:686:5
+   --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:690:5
     |
-686 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
+690 |     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests-snapshots/dbc-cantools/message-dlc-zero.snap.rs
+++ b/tests-snapshots/dbc-cantools/message-dlc-zero.snap.rs
@@ -67,6 +67,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x400)
     });
+    pub const MESSAGE_SIZE: usize = 0;
     /// Construct new Message1 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 0] };

--- a/tests-snapshots/dbc-cantools/mod_name_len_dest.snap.rs
+++ b/tests-snapshots/dbc-cantools/mod_name_len_dest.snap.rs
@@ -69,6 +69,7 @@ impl MsgNowShort {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_NOW_SHORT_MIN: u8 = 0_u8;
     pub const SIG_NOW_SHORT_MAX: u8 = 0_u8;
     /// Construct new msg_now_short from values

--- a/tests-snapshots/dbc-cantools/mod_name_len_src.snap.rs
+++ b/tests-snapshots/dbc-cantools/mod_name_len_src.snap.rs
@@ -71,6 +71,7 @@ impl MsgWillBeShortened345678912 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_WILL_BE_SHORTENED_3456789_12_MIN: u8 = 0_u8;
     pub const SIG_WILL_BE_SHORTENED_3456789_12_MAX: u8 = 0_u8;
     /// Construct new Msg_will_be_shortened_3456789_12 from values

--- a/tests-snapshots/dbc-cantools/motohawk.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk.snap.rs
@@ -71,6 +71,7 @@ impl ExampleMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1f0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEMPERATURE_MIN: f32 = 229.52_f32;
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;
     pub const AVERAGE_RADIUS_MIN: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
@@ -71,6 +71,7 @@ impl ExampleMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x1f0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEMPERATURE_MIN: f32 = 229.52_f32;
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;
     pub const AVERAGE_RADIUS_MIN: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
@@ -71,6 +71,7 @@ impl ExampleMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1f0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEMPERATURE_MIN: f32 = 229.52_f32;
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;
     pub const AVERAGE_RADIUS_MIN: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
@@ -71,6 +71,7 @@ impl ExampleMessage {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1f0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEMPERATURE_MIN: f32 = 229.52_f32;
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;
     pub const AVERAGE_RADIUS_MIN: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/msxii_system_can.snap.rs
+++ b/tests-snapshots/dbc-cantools/msxii_system_can.snap.rs
@@ -67,6 +67,7 @@ impl BatteryVt {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x401)
     });
+    pub const MESSAGE_SIZE: usize = 6;
     pub const MODULE_TEMP_35_MIN: u16 = 0_u16;
     pub const MODULE_TEMP_35_MAX: u16 = 0_u16;
     pub const MODULE_TEMP_34_MIN: u16 = 0_u16;

--- a/tests-snapshots/dbc-cantools/multiple_senders.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiple_senders.snap.rs
@@ -67,6 +67,7 @@ impl Bar {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 4;
     pub const BINARY32_MIN: i32 = 0_i32;
     pub const BINARY32_MAX: i32 = 0_i32;
     /// Construct new Bar from values

--- a/tests-snapshots/dbc-cantools/multiplex.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex.snap.rs
@@ -66,6 +66,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x123456)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
     /// Construct new Message1 from values

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.rs
@@ -77,6 +77,7 @@ impl Shared {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xc02fefe)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S2_MIN: i8 = 0_i8;
     pub const S2_MAX: i8 = 0_i8;
     pub const S1_MIN: i8 = 0_i8;
@@ -373,6 +374,7 @@ impl Normal {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xc01fefe)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S2_MIN: i8 = 0_i8;
     pub const S2_MAX: i8 = 0_i8;
     pub const S1_MIN: i8 = 0_i8;
@@ -669,6 +671,7 @@ impl Extended {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xc00fefe)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S8_MIN: i8 = 0_i8;
     pub const S8_MAX: i8 = 0_i8;
     pub const S7_MIN: i32 = 0_i32;
@@ -1266,6 +1269,7 @@ impl ExtendedTypes {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xc03fefe)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S9_MIN: i32 = -1.34_i32;
     pub const S9_MAX: i32 = 1235_i32;
     pub const S10_MIN: i32 = -340000000000000000000000000000000000000_i32;

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
@@ -154,6 +154,22 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:795:21
     |
 795 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+795 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+795 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:793:21
+    |
+793 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
@@ -166,6 +182,22 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:796:21
     |
 796 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+796 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+796 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:794:21
+    |
+794 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
@@ -1,187 +1,187 @@
 error[E0425]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:790:36
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:793:36
     |
-790 |     pub fn s0(&mut self) -> Result<ExtendedS0Index, CanError> {
+793 |     pub fn s0(&mut self) -> Result<ExtendedS0Index, CanError> {
     |                                    ^^^^^^^^^^^^^^^
 ...
-898 | pub enum ExtendedS6Index {
+901 | pub enum ExtendedS6Index {
     | ------------------------ similarly named enum `ExtendedS6Index` defined here
     |
 help: an enum with a similar name exists
     |
-790 -     pub fn s0(&mut self) -> Result<ExtendedS0Index, CanError> {
-790 +     pub fn s0(&mut self) -> Result<ExtendedS6Index, CanError> {
+793 -     pub fn s0(&mut self) -> Result<ExtendedS0Index, CanError> {
+793 +     pub fn s0(&mut self) -> Result<ExtendedS6Index, CanError> {
     |
 help: you might be missing a type parameter
     |
-668 | impl<ExtendedS0Index> Extended {
+670 | impl<ExtendedS0Index> Extended {
     |     +++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M0` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:792:41
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:795:41
     |
-792 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+795 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
     |                                         ^^^^^^^^^^^^
 ...
-913 | pub struct ExtendedS6M0 {
+916 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
     |
 help: a struct with a similar name exists
     |
-792 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-792 +             0 => Ok(ExtendedS0Index::M0(ExtendedS6M0 { raw: self.raw })),
+795 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+795 +             0 => Ok(ExtendedS0Index::M0(ExtendedS6M0 { raw: self.raw })),
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M1` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:793:41
+    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:796:41
      |
- 793 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+ 796 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
      |                                         ^^^^^^^^^^^^
 ...
-1028 | pub struct ExtendedS6M1 {
+1031 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
      |
 help: a struct with a similar name exists
      |
- 793 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
- 793 +             1 => Ok(ExtendedS0Index::M1(ExtendedS6M1 { raw: self.raw })),
+ 796 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+ 796 +             1 => Ok(ExtendedS0Index::M1(ExtendedS6M1 { raw: self.raw })),
      |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M2` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:794:41
+    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:797:41
      |
- 794 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+ 797 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
      |                                         ^^^^^^^^^^^^
 ...
-1143 | pub struct ExtendedS6M2 {
+1146 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
      |
 help: a struct with a similar name exists
      |
- 794 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
- 794 +             2 => Ok(ExtendedS0Index::M2(ExtendedS6M2 { raw: self.raw })),
+ 797 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+ 797 +             2 => Ok(ExtendedS0Index::M2(ExtendedS6M2 { raw: self.raw })),
      |
 
 error[E0425]: cannot find type `ExtendedS0M0` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:824:37
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:827:37
     |
-824 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
+827 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
     |                                     ^^^^^^^^^^^^
 ...
-913 | pub struct ExtendedS6M0 {
+916 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
     |
 help: a struct with a similar name exists
     |
-824 -     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
-824 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
+827 -     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
+827 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
     |
 
 error[E0425]: cannot find type `ExtendedS0M1` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:833:37
+    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:836:37
      |
- 833 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
+ 836 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
      |                                     ^^^^^^^^^^^^
 ...
-1028 | pub struct ExtendedS6M1 {
+1031 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
      |
 help: a struct with a similar name exists
      |
- 833 -     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
- 833 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
+ 836 -     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
+ 836 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
      |
 
 error[E0425]: cannot find type `ExtendedS0M2` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:842:37
+    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:845:37
      |
- 842 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
+ 845 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
      |                                     ^^^^^^^^^^^^
 ...
-1143 | pub struct ExtendedS6M2 {
+1146 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
      |
 help: a struct with a similar name exists
      |
- 842 -     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
- 842 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
+ 845 -     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
+ 845 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
      |
 
 error: invalid suffix `i32` for float literal
-    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:1269:30
+    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:1273:30
      |
-1269 |     pub const S9_MIN: i32 = -1.34_i32;
+1273 |     pub const S9_MIN: i32 = -1.34_i32;
      |                              ^^^^^^^^ invalid suffix `i32`
      |
      = help: valid suffixes are `f32` and `f64`
 
 error: invalid suffix `i32` for float literal
-    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:1541:21
+    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:1545:21
      |
-1541 |         if value < -1.34_i32 || 1235_i32 < value {
+1545 |         if value < -1.34_i32 || 1235_i32 < value {
      |                     ^^^^^^^^ invalid suffix `i32`
      |
      = help: valid suffixes are `f32` and `f64`
 
 error[E0592]: duplicate definitions with name `set_m0`
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:824:5
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:827:5
     |
-750 |     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
+753 |     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
     |     --------------------------------------------------------------------- other definition for `set_m0`
 ...
-824 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
+827 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m1`
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:833:5
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:836:5
     |
-759 |     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
+762 |     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
     |     --------------------------------------------------------------------- other definition for `set_m1`
 ...
-833 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
+836 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m1`
 
 error[E0592]: duplicate definitions with name `set_m2`
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:842:5
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:845:5
     |
-768 |     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
+771 |     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
     |     --------------------------------------------------------------------- other definition for `set_m2`
 ...
-842 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
+845 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m2`
 
 error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:792:21
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:795:21
     |
-792 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+795 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
     |
-792 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-792 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
+795 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+795 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
     |
 
 error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:793:21
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:796:21
     |
-793 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+796 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
     |
-793 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-793 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
+796 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+796 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
     |
 
 error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:794:21
+   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:797:21
     |
-794 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+797 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
     |
-794 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-794 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
+797 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+797 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
     |

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
@@ -154,22 +154,6 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:795:21
     |
 795 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-795 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-795 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:793:21
-    |
-793 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
@@ -182,22 +166,6 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:796:21
     |
 796 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-796 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-796 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:794:21
-    |
-794 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs
@@ -77,6 +77,7 @@ impl Shared {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xc02fefe)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S2_MIN: i8 = 0_i8;
     pub const S2_MAX: i8 = 0_i8;
     pub const S1_MIN: i8 = 0_i8;
@@ -373,6 +374,7 @@ impl Normal {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xc01fefe)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S2_MIN: i8 = 0_i8;
     pub const S2_MAX: i8 = 0_i8;
     pub const S1_MIN: i8 = 0_i8;
@@ -669,6 +671,7 @@ impl Extended {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xc00fefe)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S7_MIN: i32 = 0_i32;
     pub const S7_MAX: i32 = 0_i32;
     pub const S8_MIN: i8 = 0_i8;
@@ -1341,6 +1344,7 @@ impl ExtendedTypes {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xc03fefe)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S9_MIN: i32 = -1.34_i32;
     pub const S9_MAX: i32 = 1235_i32;
     pub const S10_MIN: i32 = -340000000000000000000000000000000000000_i32;

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
@@ -387,6 +387,22 @@ error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:796:21
     |
 796 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
+    |
+help: an enum with a similar name exists
+    |
+796 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
+796 +             0 => Ok(ExtendedS6Index::M0(ExtendedS1M0 { raw: self.raw })),
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtendedS1Index` in this scope
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:794:21
+    |
+794 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
     |
 help: an enum with a similar name exists
@@ -399,6 +415,22 @@ error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:797:21
     |
 797 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
+    |
+help: an enum with a similar name exists
+    |
+797 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
+797 +             1 => Ok(ExtendedS6Index::M1(ExtendedS1M1 { raw: self.raw })),
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtendedS1Index` in this scope
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:795:21
+    |
+795 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
     |
 help: an enum with a similar name exists
@@ -412,6 +444,22 @@ error[E0433]: cannot find type `ExtendedS1Index` in this scope
     |
 798 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
+<<<<<<< HEAD
+=======
+    |
+help: an enum with a similar name exists
+    |
+798 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
+798 +             2 => Ok(ExtendedS6Index::M2(ExtendedS1M2 { raw: self.raw })),
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:867:21
+    |
+867 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |
 help: an enum with a similar name exists
     |
@@ -423,6 +471,22 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:870:21
     |
 870 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+870 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+870 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:868:21
+    |
+868 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
@@ -435,6 +499,22 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:871:21
     |
 871 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+<<<<<<< HEAD
+=======
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+871 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+871 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:869:21
+    |
+869 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
@@ -449,6 +529,22 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
 872 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
+<<<<<<< HEAD
+=======
+help: an enum with a similar name exists
+    |
+872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+872 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
+    |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1445:21
+     |
+1445 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
+     |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
+     |
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
 help: an enum with a similar name exists
     |
 872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
@@ -459,6 +555,22 @@ error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1449:21
      |
 1449 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
+<<<<<<< HEAD
+=======
+     |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
+     |
+help: an enum with a similar name exists
+     |
+1449 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
+1449 +                     ExtendedTypesS0Index::M0(ExtendedTypesS11M0 {
+     |
+
+<<<<<<< HEAD
+error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1452:21
+     |
+1452 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
+>>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
      |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
@@ -1,480 +1,480 @@
 error[E0425]: cannot find type `ExtendedS1Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:791:36
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:794:36
     |
-791 |     pub fn s1(&mut self) -> Result<ExtendedS1Index, CanError> {
+794 |     pub fn s1(&mut self) -> Result<ExtendedS1Index, CanError> {
     |                                    ^^^^^^^^^^^^^^^
 ...
-973 | pub enum ExtendedS6Index {
+976 | pub enum ExtendedS6Index {
     | ------------------------ similarly named enum `ExtendedS6Index` defined here
     |
 help: an enum with a similar name exists
     |
-791 -     pub fn s1(&mut self) -> Result<ExtendedS1Index, CanError> {
-791 +     pub fn s1(&mut self) -> Result<ExtendedS6Index, CanError> {
+794 -     pub fn s1(&mut self) -> Result<ExtendedS1Index, CanError> {
+794 +     pub fn s1(&mut self) -> Result<ExtendedS6Index, CanError> {
     |
 help: you might be missing a type parameter
     |
-668 | impl<ExtendedS1Index> Extended {
+670 | impl<ExtendedS1Index> Extended {
     |     +++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS1M0` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:793:41
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:796:41
     |
-793 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
+796 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
     |                                         ^^^^^^^^^^^^
 ...
-988 | pub struct ExtendedS6M0 {
+991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
     |
 help: a struct with a similar name exists
     |
-793 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-793 +             0 => Ok(ExtendedS1Index::M0(ExtendedS6M0 { raw: self.raw })),
+796 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
+796 +             0 => Ok(ExtendedS1Index::M0(ExtendedS6M0 { raw: self.raw })),
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS1M1` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:794:41
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:797:41
      |
- 794 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
+ 797 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
      |                                         ^^^^^^^^^^^^
 ...
-1103 | pub struct ExtendedS6M1 {
+1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
      |
 help: a struct with a similar name exists
      |
- 794 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
- 794 +             1 => Ok(ExtendedS1Index::M1(ExtendedS6M1 { raw: self.raw })),
+ 797 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
+ 797 +             1 => Ok(ExtendedS1Index::M1(ExtendedS6M1 { raw: self.raw })),
      |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS1M2` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:795:41
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:798:41
      |
- 795 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
+ 798 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
      |                                         ^^^^^^^^^^^^
 ...
-1218 | pub struct ExtendedS6M2 {
+1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
      |
 help: a struct with a similar name exists
      |
- 795 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
- 795 +             2 => Ok(ExtendedS1Index::M2(ExtendedS6M2 { raw: self.raw })),
+ 798 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
+ 798 +             2 => Ok(ExtendedS1Index::M2(ExtendedS6M2 { raw: self.raw })),
      |
 
 error[E0425]: cannot find type `ExtendedS1M0` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:825:37
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:828:37
     |
-825 |     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
+828 |     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
     |                                     ^^^^^^^^^^^^
 ...
-988 | pub struct ExtendedS6M0 {
+991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
     |
 help: a struct with a similar name exists
     |
-825 -     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
-825 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
+828 -     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
+828 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
     |
 
 error[E0425]: cannot find type `ExtendedS1M1` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:834:37
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:837:37
      |
- 834 |     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
+ 837 |     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
      |                                     ^^^^^^^^^^^^
 ...
-1103 | pub struct ExtendedS6M1 {
+1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
      |
 help: a struct with a similar name exists
      |
- 834 -     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
- 834 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
+ 837 -     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
+ 837 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
      |
 
 error[E0425]: cannot find type `ExtendedS1M2` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:843:37
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:846:37
      |
- 843 |     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
+ 846 |     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
      |                                     ^^^^^^^^^^^^
 ...
-1218 | pub struct ExtendedS6M2 {
+1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
      |
 help: a struct with a similar name exists
      |
- 843 -     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
- 843 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
+ 846 -     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
+ 846 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
      |
 
 error[E0425]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:865:36
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:868:36
     |
-865 |     pub fn s0(&mut self) -> Result<ExtendedS0Index, CanError> {
+868 |     pub fn s0(&mut self) -> Result<ExtendedS0Index, CanError> {
     |                                    ^^^^^^^^^^^^^^^
 ...
-973 | pub enum ExtendedS6Index {
+976 | pub enum ExtendedS6Index {
     | ------------------------ similarly named enum `ExtendedS6Index` defined here
     |
 help: an enum with a similar name exists
     |
-865 -     pub fn s0(&mut self) -> Result<ExtendedS0Index, CanError> {
-865 +     pub fn s0(&mut self) -> Result<ExtendedS6Index, CanError> {
+868 -     pub fn s0(&mut self) -> Result<ExtendedS0Index, CanError> {
+868 +     pub fn s0(&mut self) -> Result<ExtendedS6Index, CanError> {
     |
 help: you might be missing a type parameter
     |
-668 | impl<ExtendedS0Index> Extended {
+670 | impl<ExtendedS0Index> Extended {
     |     +++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M0` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:867:41
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:870:41
     |
-867 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+870 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
     |                                         ^^^^^^^^^^^^
 ...
-988 | pub struct ExtendedS6M0 {
+991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
     |
 help: a struct with a similar name exists
     |
-867 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-867 +             0 => Ok(ExtendedS0Index::M0(ExtendedS6M0 { raw: self.raw })),
+870 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+870 +             0 => Ok(ExtendedS0Index::M0(ExtendedS6M0 { raw: self.raw })),
     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M1` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:868:41
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:871:41
      |
- 868 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+ 871 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
      |                                         ^^^^^^^^^^^^
 ...
-1103 | pub struct ExtendedS6M1 {
+1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
      |
 help: a struct with a similar name exists
      |
- 868 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
- 868 +             1 => Ok(ExtendedS0Index::M1(ExtendedS6M1 { raw: self.raw })),
+ 871 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+ 871 +             1 => Ok(ExtendedS0Index::M1(ExtendedS6M1 { raw: self.raw })),
      |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M2` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:869:41
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:872:41
      |
- 869 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+ 872 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
      |                                         ^^^^^^^^^^^^
 ...
-1218 | pub struct ExtendedS6M2 {
+1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
      |
 help: a struct with a similar name exists
      |
- 869 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
- 869 +             2 => Ok(ExtendedS0Index::M2(ExtendedS6M2 { raw: self.raw })),
+ 872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+ 872 +             2 => Ok(ExtendedS0Index::M2(ExtendedS6M2 { raw: self.raw })),
      |
 
 error[E0425]: cannot find type `ExtendedS0M0` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:899:37
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:902:37
     |
-899 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
+902 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
     |                                     ^^^^^^^^^^^^
 ...
-988 | pub struct ExtendedS6M0 {
+991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
     |
 help: a struct with a similar name exists
     |
-899 -     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
-899 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
+902 -     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
+902 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
     |
 
 error[E0425]: cannot find type `ExtendedS0M1` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:908:37
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:911:37
      |
- 908 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
+ 911 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
      |                                     ^^^^^^^^^^^^
 ...
-1103 | pub struct ExtendedS6M1 {
+1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
      |
 help: a struct with a similar name exists
      |
- 908 -     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
- 908 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
+ 911 -     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
+ 911 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
      |
 
 error[E0425]: cannot find type `ExtendedS0M2` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:917:37
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:920:37
      |
- 917 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
+ 920 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
      |                                     ^^^^^^^^^^^^
 ...
-1218 | pub struct ExtendedS6M2 {
+1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
      |
 help: a struct with a similar name exists
      |
- 917 -     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
- 917 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
+ 920 -     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
+ 920 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
      |
 
 error[E0425]: cannot find type `ExtendedTypesS11Index` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1441:37
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1445:37
      |
-1441 |     pub fn s11(&mut self) -> Result<ExtendedTypesS11Index, CanError> {
+1445 |     pub fn s11(&mut self) -> Result<ExtendedTypesS11Index, CanError> {
      |                                     ^^^^^^^^^^^^^^^^^^^^^
 ...
-1550 | pub enum ExtendedTypesS0Index {
+1554 | pub enum ExtendedTypesS0Index {
      | ----------------------------- similarly named enum `ExtendedTypesS0Index` defined here
      |
 help: an enum with a similar name exists
      |
-1441 -     pub fn s11(&mut self) -> Result<ExtendedTypesS11Index, CanError> {
-1441 +     pub fn s11(&mut self) -> Result<ExtendedTypesS0Index, CanError> {
+1445 -     pub fn s11(&mut self) -> Result<ExtendedTypesS11Index, CanError> {
+1445 +     pub fn s11(&mut self) -> Result<ExtendedTypesS0Index, CanError> {
      |
 help: you might be missing a type parameter
      |
-1340 | impl<ExtendedTypesS11Index> ExtendedTypes {
+1343 | impl<ExtendedTypesS11Index> ExtendedTypes {
      |     +++++++++++++++++++++++
 
 error[E0422]: cannot find struct, variant or union type `ExtendedTypesS11M0` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1445:47
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1449:47
      |
-1445 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
+1449 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
      |                                               ^^^^^^^^^^^^^^^^^^
 ...
-1564 | pub struct ExtendedTypesS0M0 {
+1568 | pub struct ExtendedTypesS0M0 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M0` defined here
      |
 help: a struct with a similar name exists
      |
-1445 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-1445 +                     ExtendedTypesS11Index::M0(ExtendedTypesS0M0 {
+1449 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
+1449 +                     ExtendedTypesS11Index::M0(ExtendedTypesS0M0 {
      |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedTypesS11M5` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1452:47
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1456:47
      |
-1452 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
+1456 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
      |                                               ^^^^^^^^^^^^^^^^^^
 ...
-1637 | pub struct ExtendedTypesS0M5 {
+1641 | pub struct ExtendedTypesS0M5 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M5` defined here
      |
 help: a struct with a similar name exists
      |
-1452 -                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
-1452 +                     ExtendedTypesS11Index::M5(ExtendedTypesS0M5 {
+1456 -                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
+1456 +                     ExtendedTypesS11Index::M5(ExtendedTypesS0M5 {
      |
 
 error[E0425]: cannot find type `ExtendedTypesS11M0` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1485:37
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1489:37
      |
-1485 |     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
+1489 |     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
      |                                     ^^^^^^^^^^^^^^^^^^
 ...
-1564 | pub struct ExtendedTypesS0M0 {
+1568 | pub struct ExtendedTypesS0M0 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M0` defined here
      |
 help: a struct with a similar name exists
      |
-1485 -     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
-1485 +     pub fn set_m0(&mut self, value: ExtendedTypesS0M0) -> Result<(), CanError> {
+1489 -     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
+1489 +     pub fn set_m0(&mut self, value: ExtendedTypesS0M0) -> Result<(), CanError> {
      |
 
 error[E0425]: cannot find type `ExtendedTypesS11M5` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1494:37
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1498:37
      |
-1494 |     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
+1498 |     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
      |                                     ^^^^^^^^^^^^^^^^^^
 ...
-1637 | pub struct ExtendedTypesS0M5 {
+1641 | pub struct ExtendedTypesS0M5 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M5` defined here
      |
 help: a struct with a similar name exists
      |
-1494 -     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
-1494 +     pub fn set_m5(&mut self, value: ExtendedTypesS0M5) -> Result<(), CanError> {
+1498 -     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
+1498 +     pub fn set_m5(&mut self, value: ExtendedTypesS0M5) -> Result<(), CanError> {
      |
 
 error: invalid suffix `i32` for float literal
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1344:30
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1348:30
      |
-1344 |     pub const S9_MIN: i32 = -1.34_i32;
+1348 |     pub const S9_MIN: i32 = -1.34_i32;
      |                              ^^^^^^^^ invalid suffix `i32`
      |
      = help: valid suffixes are `f32` and `f64`
 
 error: invalid suffix `i32` for float literal
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1681:21
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1685:21
      |
-1681 |         if value < -1.34_i32 || 1235_i32 < value {
+1685 |         if value < -1.34_i32 || 1235_i32 < value {
      |                     ^^^^^^^^ invalid suffix `i32`
      |
      = help: valid suffixes are `f32` and `f64`
 
 error[E0592]: duplicate definitions with name `set_m0`
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:825:5
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:828:5
     |
-751 |     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
+754 |     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
     |     --------------------------------------------------------------------- other definition for `set_m0`
 ...
-825 |     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
+828 |     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m1`
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:834:5
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:837:5
     |
-760 |     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
+763 |     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
     |     --------------------------------------------------------------------- other definition for `set_m1`
 ...
-834 |     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
+837 |     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m1`
 
 error[E0592]: duplicate definitions with name `set_m2`
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:843:5
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:846:5
     |
-769 |     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
+772 |     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
     |     --------------------------------------------------------------------- other definition for `set_m2`
 ...
-843 |     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
+846 |     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m2`
 
 error[E0592]: duplicate definitions with name `set_m0`
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:899:5
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:902:5
     |
-751 |     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
+754 |     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
     |     --------------------------------------------------------------------- other definition for `set_m0`
 ...
-899 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
+902 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m1`
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:908:5
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:911:5
     |
-760 |     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
+763 |     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
     |     --------------------------------------------------------------------- other definition for `set_m1`
 ...
-908 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
+911 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m1`
 
 error[E0592]: duplicate definitions with name `set_m2`
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:917:5
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:920:5
     |
-769 |     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
+772 |     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
     |     --------------------------------------------------------------------- other definition for `set_m2`
 ...
-917 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
+920 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m2`
 
 error[E0592]: duplicate definitions with name `set_m0`
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1485:5
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1489:5
      |
-1411 |     pub fn set_m0(&mut self, value: ExtendedTypesS0M0) -> Result<(), CanError> {
+1415 |     pub fn set_m0(&mut self, value: ExtendedTypesS0M0) -> Result<(), CanError> {
      |     -------------------------------------------------------------------------- other definition for `set_m0`
 ...
-1485 |     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
+1489 |     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m0`
 
 error[E0592]: duplicate definitions with name `set_m5`
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1494:5
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1498:5
      |
-1420 |     pub fn set_m5(&mut self, value: ExtendedTypesS0M5) -> Result<(), CanError> {
+1424 |     pub fn set_m5(&mut self, value: ExtendedTypesS0M5) -> Result<(), CanError> {
      |     -------------------------------------------------------------------------- other definition for `set_m5`
 ...
-1494 |     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
+1498 |     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m5`
 
 error[E0433]: cannot find type `ExtendedS1Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:793:21
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:796:21
     |
-793 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
+796 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
     |
 help: an enum with a similar name exists
     |
-793 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-793 +             0 => Ok(ExtendedS6Index::M0(ExtendedS1M0 { raw: self.raw })),
+796 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
+796 +             0 => Ok(ExtendedS6Index::M0(ExtendedS1M0 { raw: self.raw })),
     |
 
 error[E0433]: cannot find type `ExtendedS1Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:794:21
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:797:21
     |
-794 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
+797 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
     |
 help: an enum with a similar name exists
     |
-794 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
-794 +             1 => Ok(ExtendedS6Index::M1(ExtendedS1M1 { raw: self.raw })),
+797 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
+797 +             1 => Ok(ExtendedS6Index::M1(ExtendedS1M1 { raw: self.raw })),
     |
 
 error[E0433]: cannot find type `ExtendedS1Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:795:21
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:798:21
     |
-795 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
+798 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
     |
 help: an enum with a similar name exists
     |
-795 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
-795 +             2 => Ok(ExtendedS6Index::M2(ExtendedS1M2 { raw: self.raw })),
+798 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
+798 +             2 => Ok(ExtendedS6Index::M2(ExtendedS1M2 { raw: self.raw })),
     |
 
 error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:867:21
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:870:21
     |
-867 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+870 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
     |
-867 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-867 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
+870 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+870 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
     |
 
 error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:868:21
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:871:21
     |
-868 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+871 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
     |
-868 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-868 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
+871 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+871 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
     |
 
 error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:869:21
+   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:872:21
     |
-869 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+872 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
     |
-869 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-869 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
+872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+872 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
     |
 
 error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1445:21
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1449:21
      |
-1445 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
+1449 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
      |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
      |
 help: an enum with a similar name exists
      |
-1445 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-1445 +                     ExtendedTypesS0Index::M0(ExtendedTypesS11M0 {
+1449 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
+1449 +                     ExtendedTypesS0Index::M0(ExtendedTypesS11M0 {
      |
 
 error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1452:21
+    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1456:21
      |
-1452 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
+1456 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
      |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
      |
 help: an enum with a similar name exists
      |
-1452 -                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
-1452 +                     ExtendedTypesS0Index::M5(ExtendedTypesS11M5 {
+1456 -                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
+1456 +                     ExtendedTypesS0Index::M5(ExtendedTypesS11M5 {
      |

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
@@ -387,22 +387,6 @@ error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:796:21
     |
 796 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
-    |
-help: an enum with a similar name exists
-    |
-796 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-796 +             0 => Ok(ExtendedS6Index::M0(ExtendedS1M0 { raw: self.raw })),
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtendedS1Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:794:21
-    |
-794 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
     |
 help: an enum with a similar name exists
@@ -415,22 +399,6 @@ error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:797:21
     |
 797 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
-    |
-help: an enum with a similar name exists
-    |
-797 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
-797 +             1 => Ok(ExtendedS6Index::M1(ExtendedS1M1 { raw: self.raw })),
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtendedS1Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:795:21
-    |
-795 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
     |
 help: an enum with a similar name exists
@@ -444,22 +412,6 @@ error[E0433]: cannot find type `ExtendedS1Index` in this scope
     |
 798 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
-<<<<<<< HEAD
-=======
-    |
-help: an enum with a similar name exists
-    |
-798 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
-798 +             2 => Ok(ExtendedS6Index::M2(ExtendedS1M2 { raw: self.raw })),
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:867:21
-    |
-867 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |
 help: an enum with a similar name exists
     |
@@ -471,22 +423,6 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:870:21
     |
 870 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-870 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-870 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:868:21
-    |
-868 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
@@ -499,22 +435,6 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:871:21
     |
 871 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-<<<<<<< HEAD
-=======
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-871 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-871 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
-   --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:869:21
-    |
-869 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
 help: an enum with a similar name exists
@@ -529,22 +449,6 @@ error[E0433]: cannot find type `ExtendedS0Index` in this scope
 872 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
     |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
     |
-<<<<<<< HEAD
-=======
-help: an enum with a similar name exists
-    |
-872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-872 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
-    |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1445:21
-     |
-1445 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-     |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
-     |
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
 help: an enum with a similar name exists
     |
 872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
@@ -555,22 +459,6 @@ error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1449:21
      |
 1449 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-<<<<<<< HEAD
-=======
-     |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
-     |
-help: an enum with a similar name exists
-     |
-1449 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-1449 +                     ExtendedTypesS0Index::M0(ExtendedTypesS11M0 {
-     |
-
-<<<<<<< HEAD
-error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
-    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1452:21
-     |
-1452 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
->>>>>>> 69c067c (Regenerate snap files on Rust 1.94)
      |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
      |
 help: an enum with a similar name exists

--- a/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
@@ -72,6 +72,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x123456)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
     /// Construct new Message1 from values
@@ -673,6 +674,7 @@ impl Message2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x123457)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
     /// Construct new Message2 from values
@@ -1246,6 +1248,7 @@ impl Message3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x123458)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
     /// Construct new Message3 from values

--- a/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
@@ -72,6 +72,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x123456)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
     /// Construct new Message1 from values
@@ -673,6 +674,7 @@ impl Message2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x123457)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
     /// Construct new Message2 from values
@@ -1246,6 +1248,7 @@ impl Message3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x123458)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
     /// Construct new Message3 from values

--- a/tests-snapshots/dbc-cantools/multiplex_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_dumped.snap.rs
@@ -66,6 +66,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x123456)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
     /// Construct new Message1 from values

--- a/tests-snapshots/dbc-cantools/no_sender.snap.rs
+++ b/tests-snapshots/dbc-cantools/no_sender.snap.rs
@@ -68,6 +68,7 @@ impl Foo {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1d8)
     });
+    pub const MESSAGE_SIZE: usize = 1;
     pub const SIGNAL_WITHOUT_SENDER_MIN: i8 = 0_i8;
     pub const SIGNAL_WITHOUT_SENDER_MAX: i8 = 0_i8;
     /// Construct new Foo from values

--- a/tests-snapshots/dbc-cantools/no_signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/no_signals.snap.rs
@@ -70,6 +70,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x400)
     });
+    pub const MESSAGE_SIZE: usize = 5;
     /// Construct new Message1 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 5] };
@@ -140,6 +141,7 @@ impl Message2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x401)
     });
+    pub const MESSAGE_SIZE: usize = 0;
     /// Construct new Message2 from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0u8; 0] };

--- a/tests-snapshots/dbc-cantools/open_actuator.snap.rs
+++ b/tests-snapshots/dbc-cantools/open_actuator.snap.rs
@@ -87,6 +87,7 @@ impl ControlCmd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xfa)
     });
+    pub const MESSAGE_SIZE: usize = 7;
     pub const CRC8_CMD1_MIN: u8 = 0_u8;
     pub const CRC8_CMD1_MAX: u8 = 255_u8;
     pub const COUNTER_CMD1_MIN: u8 = 0_u8;
@@ -526,6 +527,7 @@ impl LimitsCmd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xfb)
     });
+    pub const MESSAGE_SIZE: usize = 6;
     pub const CRC8_CMD2_MIN: u8 = 0_u8;
     pub const CRC8_CMD2_MAX: u8 = 255_u8;
     pub const COUNTER_CMD2_MIN: u8 = 0_u8;
@@ -781,6 +783,7 @@ impl ControlStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xfc)
     });
+    pub const MESSAGE_SIZE: usize = 4;
     pub const CRC8_STAT1_MIN: u8 = 0_u8;
     pub const CRC8_STAT1_MAX: u8 = 255_u8;
     pub const COUNTER_STAT1_MIN: u8 = 0_u8;
@@ -1031,6 +1034,7 @@ impl SystemStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xfd)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const CRC8_STAT2_MIN: u8 = 0_u8;
     pub const CRC8_STAT2_MAX: u8 = 255_u8;
     pub const COUNTER_STAT2_MIN: u8 = 0_u8;
@@ -1240,6 +1244,7 @@ impl TorqueSensorData {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x71)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const CRC8_DATA1_MIN: u8 = 0_u8;
     pub const CRC8_DATA1_MAX: u8 = 255_u8;
     pub const COUNTER_DATA1_MIN: u8 = 0_u8;

--- a/tests-snapshots/dbc-cantools/padding_bit_order.snap.rs
+++ b/tests-snapshots/dbc-cantools/padding_bit_order.snap.rs
@@ -79,6 +79,7 @@ impl Msg0 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const A_MIN: u16 = 0_u16;
     pub const A_MAX: u16 = 32767_u16;
     pub const C_MIN: u16 = 0_u16;
@@ -301,6 +302,7 @@ impl Msg1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const F_MIN: u16 = 0_u16;
     pub const F_MAX: u16 = 32767_u16;
     pub const H_MIN: u16 = 0_u16;
@@ -523,6 +525,7 @@ impl Msg2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x3)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const I_MIN: u8 = 0_u8;
     pub const I_MAX: u8 = 15_u8;
     pub const J_MIN: u8 = 0_u8;
@@ -728,6 +731,7 @@ impl Msg3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x4)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const L_MIN: u64 = 0_u64;
     pub const L_MAX: u64 = 18446744073709551615_u64;
     /// Construct new MSG3 from values
@@ -843,6 +847,7 @@ impl Msg4 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x5)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const M_MIN: u64 = 0_u64;
     pub const M_MAX: u64 = 18446744073709551615_u64;
     /// Construct new MSG4 from values

--- a/tests-snapshots/dbc-cantools/sig_groups.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups.snap.rs
@@ -76,6 +76,7 @@ impl Test {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x3)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
     /// Construct new Test from values
@@ -192,6 +193,7 @@ impl SgMsgM {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
     pub const SUB_SIG2_1_MIN: i8 = 0_i8;
@@ -454,6 +456,7 @@ impl SgMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
     pub const SG2_MIN: i8 = 0_i8;
@@ -664,6 +667,7 @@ impl NormalMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_2_MIN: i8 = 0_i8;
     pub const SIG_2_MAX: i8 = 0_i8;
     pub const SIG_1_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/sig_groups_del.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups_del.snap.rs
@@ -76,6 +76,7 @@ impl Test {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x3)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
     /// Construct new Test from values
@@ -192,6 +193,7 @@ impl SgMsgM {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
     pub const SUB_SIG2_1_MIN: i8 = 0_i8;
@@ -454,6 +456,7 @@ impl SgMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
     pub const SG2_MIN: i8 = 0_i8;
@@ -664,6 +667,7 @@ impl NormalMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_2_MIN: i8 = 0_i8;
     pub const SIG_2_MAX: i8 = 0_i8;
     pub const SIG_1_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/sig_groups_out.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups_out.snap.rs
@@ -76,6 +76,7 @@ impl Test {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x3)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
     /// Construct new Test from values
@@ -192,6 +193,7 @@ impl SgMsgM {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
     pub const SUB_SIG2_1_MIN: i8 = 0_i8;
@@ -454,6 +456,7 @@ impl SgMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const DUPSIG_MIN: i8 = 0_i8;
     pub const DUPSIG_MAX: i8 = 0_i8;
     pub const SG2_MIN: i8 = 0_i8;
@@ -664,6 +667,7 @@ impl NormalMsg {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_2_MIN: i8 = 0_i8;
     pub const SIG_2_MAX: i8 = 0_i8;
     pub const SIG_1_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/signed.snap.rs
+++ b/tests-snapshots/dbc-cantools/signed.snap.rs
@@ -110,6 +110,7 @@ impl Message378910 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xa)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S3BIG_MIN: i8 = 0_i8;
     pub const S3BIG_MAX: i8 = 0_i8;
     pub const S3_MIN: i8 = 0_i8;
@@ -564,6 +565,7 @@ impl Message63big1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x9)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S63BIG_MIN: i64 = 0_i64;
     pub const S63BIG_MAX: i64 = 0_i64;
     /// Construct new Message63big_1 from values
@@ -680,6 +682,7 @@ impl Message631 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x8)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S63_MIN: i64 = 0_i64;
     pub const S63_MAX: i64 = 0_i64;
     /// Construct new Message63_1 from values
@@ -796,6 +799,7 @@ impl Message63big {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x7)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S63BIG_MIN: i64 = 0_i64;
     pub const S63BIG_MAX: i64 = 0_i64;
     /// Construct new Message63big from values
@@ -912,6 +916,7 @@ impl Message63 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x6)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S63_MIN: i64 = 0_i64;
     pub const S63_MAX: i64 = 0_i64;
     /// Construct new Message63 from values
@@ -1028,6 +1033,7 @@ impl Message32big {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x5)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S32BIG_MIN: i32 = 0_i32;
     pub const S32BIG_MAX: i32 = 0_i32;
     /// Construct new Message32big from values
@@ -1144,6 +1150,7 @@ impl Message33big {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x4)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S33BIG_MIN: i64 = 0_i64;
     pub const S33BIG_MAX: i64 = 0_i64;
     /// Construct new Message33big from values
@@ -1260,6 +1267,7 @@ impl Message64big {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x3)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S64BIG_MIN: i64 = 0_i64;
     pub const S64BIG_MAX: i64 = 0_i64;
     /// Construct new Message64big from values
@@ -1376,6 +1384,7 @@ impl Message64 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S64_MIN: i64 = -9223372036854780000_i64;
     pub const S64_MAX: i64 = 9223372036854780000_i64;
     /// Construct new Message64 from values
@@ -1492,6 +1501,7 @@ impl Message33 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S33_MIN: i64 = -4294967296_i64;
     pub const S33_MAX: i64 = 4294967295_i64;
     /// Construct new Message33 from values
@@ -1608,6 +1618,7 @@ impl Message32 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const S32_MIN: i32 = 0_i32;
     pub const S32_MAX: i32 = 0_i32;
     /// Construct new Message32 from values

--- a/tests-snapshots/dbc-cantools/signed.snap.stderr
+++ b/tests-snapshots/dbc-cantools/signed.snap.stderr
@@ -1,7 +1,7 @@
 error: literal out of range for `i64`
-    --> tests-snapshots/dbc-cantools/signed.snap.rs:1379:30
+    --> tests-snapshots/dbc-cantools/signed.snap.rs:1388:30
      |
-1379 |     pub const S64_MIN: i64 = -9223372036854780000_i64;
+1388 |     pub const S64_MIN: i64 = -9223372036854780000_i64;
      |                              ^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: the literal `-9223372036854780000_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
@@ -9,27 +9,27 @@ error: literal out of range for `i64`
      = note: `#[deny(overflowing_literals)]` on by default
 
 error: literal out of range for `i64`
-    --> tests-snapshots/dbc-cantools/signed.snap.rs:1380:30
+    --> tests-snapshots/dbc-cantools/signed.snap.rs:1389:30
      |
-1380 |     pub const S64_MAX: i64 = 9223372036854780000_i64;
+1389 |     pub const S64_MAX: i64 = 9223372036854780000_i64;
      |                              ^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: the literal `9223372036854780000_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
      = help: consider using the type `u64` instead
 
 error: literal out of range for `i64`
-    --> tests-snapshots/dbc-cantools/signed.snap.rs:1419:20
+    --> tests-snapshots/dbc-cantools/signed.snap.rs:1428:20
      |
-1419 |         if value < -9223372036854780000_i64 || 9223372036854780000_i64 < value {
+1428 |         if value < -9223372036854780000_i64 || 9223372036854780000_i64 < value {
      |                    ^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: the literal `-9223372036854780000_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
      = help: consider using the type `i128` instead
 
 error: literal out of range for `i64`
-    --> tests-snapshots/dbc-cantools/signed.snap.rs:1419:48
+    --> tests-snapshots/dbc-cantools/signed.snap.rs:1428:48
      |
-1419 |         if value < -9223372036854780000_i64 || 9223372036854780000_i64 < value {
+1428 |         if value < -9223372036854780000_i64 || 9223372036854780000_i64 < value {
      |                                                ^^^^^^^^^^^^^^^^^^^^^^^
      |
      = note: the literal `9223372036854780000_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
@@ -87,6 +87,8 @@ impl DriverHeartbeat {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x64)
     });
+    pub const MESSAGE_SIZE: usize = 1;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
     /// Construct new DRIVER_HEARTBEAT from values
@@ -239,6 +241,8 @@ impl IoDebug {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1f4)
     });
+    pub const MESSAGE_SIZE: usize = 4;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const IO_DEBUG_TEST_FLOAT_MIN: f32 = 0_f32;
     pub const IO_DEBUG_TEST_FLOAT_MAX: f32 = 0_f32;
     pub const IO_DEBUG_TEST_SIGNED_MIN: i8 = 0_i8;
@@ -523,6 +527,8 @@ impl MotorCmd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x65)
     });
+    pub const MESSAGE_SIZE: usize = 1;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
     pub const MOTOR_CMD_DRIVE_MAX: u8 = 9_u8;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
@@ -685,6 +691,8 @@ impl MotorStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x190)
     });
+    pub const MESSAGE_SIZE: usize = 3;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
     /// Construct new MOTOR_STATUS from values
@@ -831,6 +839,8 @@ impl SensorSonars {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xc8)
     });
+    pub const MESSAGE_SIZE: usize = 8;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const SENSOR_SONARS_NO_FILT_REAR_MIN: f32 = 0_f32;
     pub const SENSOR_SONARS_NO_FILT_REAR_MAX: f32 = 0_f32;
     pub const SENSOR_SONARS_REAR_MIN: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
@@ -87,6 +87,8 @@ impl DriverHeartbeat {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x64)
     });
+    pub const MESSAGE_SIZE: usize = 1;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
     /// Construct new DRIVER_HEARTBEAT from values
@@ -239,6 +241,8 @@ impl IoDebug {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1f4)
     });
+    pub const MESSAGE_SIZE: usize = 4;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const IO_DEBUG_TEST_ENUM_MIN: u8 = 0_u8;
     pub const IO_DEBUG_TEST_ENUM_MAX: u8 = 0_u8;
     pub const IO_DEBUG_TEST_FLOAT_MIN: f32 = 0_f32;
@@ -523,6 +527,8 @@ impl MotorCmd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x65)
     });
+    pub const MESSAGE_SIZE: usize = 1;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
     pub const MOTOR_CMD_DRIVE_MAX: u8 = 9_u8;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
@@ -685,6 +691,8 @@ impl MotorStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x190)
     });
+    pub const MESSAGE_SIZE: usize = 3;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
     /// Construct new MOTOR_STATUS from values
@@ -831,6 +839,8 @@ impl SensorSonars {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xc8)
     });
+    pub const MESSAGE_SIZE: usize = 8;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const SENSOR_SONARS_ERR_COUNT_MIN: u16 = 0_u16;
     pub const SENSOR_SONARS_ERR_COUNT_MAX: u16 = 0_u16;
     pub const SENSOR_SONARS_LEFT_MIN: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
@@ -87,6 +87,8 @@ impl DriverHeartbeat {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x64)
     });
+    pub const MESSAGE_SIZE: usize = 1;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
     /// Construct new DRIVER_HEARTBEAT from values
@@ -239,6 +241,8 @@ impl IoDebug {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1f4)
     });
+    pub const MESSAGE_SIZE: usize = 4;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const IO_DEBUG_TEST_UNSIGNED_MIN: u8 = 0_u8;
     pub const IO_DEBUG_TEST_UNSIGNED_MAX: u8 = 0_u8;
     pub const IO_DEBUG_TEST_ENUM_MIN: u8 = 0_u8;
@@ -523,6 +527,8 @@ impl MotorCmd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x65)
     });
+    pub const MESSAGE_SIZE: usize = 1;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
     pub const MOTOR_CMD_STEER_MAX: i8 = 5_i8;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
@@ -685,6 +691,8 @@ impl MotorStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x190)
     });
+    pub const MESSAGE_SIZE: usize = 3;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
     /// Construct new MOTOR_STATUS from values
@@ -831,6 +839,8 @@ impl SensorSonars {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xc8)
     });
+    pub const MESSAGE_SIZE: usize = 8;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const SENSOR_SONARS_MUX_MIN: u8 = 0_u8;
     pub const SENSOR_SONARS_MUX_MAX: u8 = 0_u8;
     pub const SENSOR_SONARS_ERR_COUNT_MIN: u16 = 0_u16;

--- a/tests-snapshots/dbc-cantools/socialledge.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/socialledge.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge.snap.rs
@@ -87,6 +87,8 @@ impl DriverHeartbeat {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x64)
     });
+    pub const MESSAGE_SIZE: usize = 1;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
     /// Construct new DRIVER_HEARTBEAT from values
@@ -239,6 +241,8 @@ impl IoDebug {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1f4)
     });
+    pub const MESSAGE_SIZE: usize = 4;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const IO_DEBUG_TEST_UNSIGNED_MIN: u8 = 0_u8;
     pub const IO_DEBUG_TEST_UNSIGNED_MAX: u8 = 0_u8;
     pub const IO_DEBUG_TEST_ENUM_MIN: u8 = 0_u8;
@@ -523,6 +527,8 @@ impl MotorCmd {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x65)
     });
+    pub const MESSAGE_SIZE: usize = 1;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
     pub const MOTOR_CMD_STEER_MAX: i8 = 5_i8;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
@@ -685,6 +691,8 @@ impl MotorStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x190)
     });
+    pub const MESSAGE_SIZE: usize = 3;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
     /// Construct new MOTOR_STATUS from values
@@ -831,6 +839,8 @@ impl SensorSonars {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0xc8)
     });
+    pub const MESSAGE_SIZE: usize = 8;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
     pub const SENSOR_SONARS_MUX_MIN: u8 = 0_u8;
     pub const SENSOR_SONARS_MUX_MAX: u8 = 0_u8;
     pub const SENSOR_SONARS_ERR_COUNT_MIN: u16 = 0_u16;

--- a/tests-snapshots/dbc-cantools/test_extended_id_dump.snap.rs
+++ b/tests-snapshots/dbc-cantools/test_extended_id_dump.snap.rs
@@ -71,6 +71,7 @@ impl SomeFrame {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x100)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SOME_DIFFERENT_SIG_MIN: i8 = 0_i8;
     pub const SOME_DIFFERENT_SIG_MAX: i8 = 0_i8;
     /// Construct new SomeFrame from values
@@ -187,6 +188,7 @@ impl SomeExtFrame {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x1c2a2a2a)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SOME_SIG_MIN: i8 = 0_i8;
     pub const SOME_SIG_MAX: i8 = 0_i8;
     /// Construct new SomeExtFrame from values

--- a/tests-snapshots/dbc-cantools/test_multiplex_dump.snap.rs
+++ b/tests-snapshots/dbc-cantools/test_multiplex_dump.snap.rs
@@ -68,6 +68,7 @@ impl MuxedFrame {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x100)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const UNMULTIPLEXED_SIG_MIN: i8 = 0_i8;
     pub const UNMULTIPLEXED_SIG_MAX: i8 = 0_i8;
     pub const MULTIPLEXED_SIG_MIN: i8 = 0_i8;

--- a/tests-snapshots/dbc-cantools/timing.snap.rs
+++ b/tests-snapshots/dbc-cantools/timing.snap.rs
@@ -10,6 +10,7 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
+use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,

--- a/tests-snapshots/dbc-cantools/timing.snap.rs
+++ b/tests-snapshots/dbc-cantools/timing.snap.rs
@@ -70,6 +70,8 @@ impl Foo {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
+    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(200);
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;
     /// Construct new Foo from values
@@ -183,6 +185,7 @@ impl Bar {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x2)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;
     /// Construct new Bar from values

--- a/tests-snapshots/dbc-cantools/val_table.snap.rs
+++ b/tests-snapshots/dbc-cantools/val_table.snap.rs
@@ -66,6 +66,7 @@ impl Message1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i8 = 0_i8;
     pub const SIGNAL1_MAX: i8 = 0_i8;
     /// Construct new Message1 from values

--- a/tests-snapshots/dbc-cantools/variable_dlc.snap.rs
+++ b/tests-snapshots/dbc-cantools/variable_dlc.snap.rs
@@ -74,6 +74,7 @@ impl TestMessage1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xff0100)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const SIGNAL1_MIN: u8 = 0_u8;
     pub const SIGNAL1_MAX: u8 = 0_u8;
     pub const SIGNAL2_MIN: u8 = 0_u8;
@@ -279,6 +280,7 @@ impl TestMessage2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0xff0200)
     });
+    pub const MESSAGE_SIZE: usize = 10;
     pub const SIGNAL4_MIN: u16 = 0_u16;
     pub const SIGNAL4_MAX: u16 = 0_u16;
     pub const SIGNAL5_MIN: u16 = 0_u16;

--- a/tests-snapshots/dbc-cantools/vehicle.snap.rs
+++ b/tests-snapshots/dbc-cantools/vehicle.snap.rs
@@ -1166,6 +1166,7 @@ impl RtSbInsVelBodyAxes {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9588322)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_SIDEWAYS_2D_MIN: f32 = -838_f32;
     pub const INS_VEL_SIDEWAYS_2D_MAX: f32 = 838_f32;
     pub const INS_VEL_FORWARDS_2D_MIN: f32 = -838_f32;
@@ -1450,6 +1451,7 @@ impl RtDl1mk3Speed {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94a7c24)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SPEED_MIN: f32 = -20000_f32;
     pub const SPEED_MAX: f32 = 20000_f32;
     pub const ACCURACY_SPEED_MIN: u8 = 0_u8;
@@ -1646,6 +1648,7 @@ impl RtDl1mk3GpsTime {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9566d24)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_WEEK_MIN: u16 = 0_u16;
     pub const GPS_WEEK_MAX: u16 = 65535_u16;
     pub const GPS_TIME_MIN: f32 = 0_f32;
@@ -1921,6 +1924,7 @@ impl RtDl1mk3GpsPosLlh2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9566f24)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_LLH_ALTITUDE_MIN: f32 = -1000_f32;
     pub const GPS_POS_LLH_ALTITUDE_MAX: f32 = 100000_f32;
     pub const GPS_POS_LLH_LONGITUDE_MIN: f32 = -180_f32;
@@ -2079,6 +2083,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9566e24)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_LLH_LATITUDE_MIN: f32 = -90_f32;
     pub const GPS_POS_LLH_LATITUDE_MAX: f32 = 90_f32;
     pub const ACCURACY_GPS_POS_LLH_ALTITUDE_MIN: u8 = 0_u8;
@@ -2457,6 +2462,7 @@ impl RtDl1mk3GpsSpeed {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9567c24)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_SPEED_3D_MIN: f32 = 0_f32;
     pub const GPS_SPEED_3D_MAX: f32 = 1675_f32;
     pub const GPS_SPEED_2D_MIN: f32 = 0_f32;
@@ -2733,6 +2739,7 @@ impl RtIrTempTemp7 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7325)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_7_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_7_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_7 from values
@@ -2845,6 +2852,7 @@ impl RtIrTempTempRr2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9627425)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_32_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_32_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_31_MIN: f32 = 0_f32;
@@ -3091,6 +3099,7 @@ impl RtIrTempTempRl2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9627225)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_24_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_24_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_23_MIN: f32 = 0_f32;
@@ -3337,6 +3346,7 @@ impl RtIrTempTempFr2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9627025)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_16_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_16_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_15_MIN: f32 = 0_f32;
@@ -3583,6 +3593,7 @@ impl RtIrTempTempFl2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9626e25)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_8_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_8_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_7_MIN: f32 = 0_f32;
@@ -3829,6 +3840,7 @@ impl RtIrTempTempRr1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9627325)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_28_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_28_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_27_MIN: f32 = 0_f32;
@@ -4075,6 +4087,7 @@ impl RtIrTempTempRl1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9627125)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_20_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_20_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_19_MIN: f32 = 0_f32;
@@ -4321,6 +4334,7 @@ impl RtIrTempTempFr1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9626f25)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_12_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_12_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_11_MIN: f32 = 0_f32;
@@ -4567,6 +4581,7 @@ impl RtIrTempTempFl1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9626d25)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const IR_TEMPERATURE_4_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_4_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_3_MIN: f32 = 0_f32;
@@ -4813,6 +4828,7 @@ impl RtIrTempTemp32 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8c25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_32_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_32_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_32 from values
@@ -4925,6 +4941,7 @@ impl RtIrTempTemp31 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8b25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_31_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_31_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_31 from values
@@ -5037,6 +5054,7 @@ impl RtIrTempTemp30 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8a25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_30_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_30_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_30 from values
@@ -5149,6 +5167,7 @@ impl RtIrTempTemp29 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8925)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_29_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_29_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_29 from values
@@ -5261,6 +5280,7 @@ impl RtIrTempTemp28 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8825)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_28_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_28_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_28 from values
@@ -5373,6 +5393,7 @@ impl RtIrTempTemp27 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8725)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_27_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_27_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_27 from values
@@ -5485,6 +5506,7 @@ impl RtIrTempTemp26 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8625)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_26_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_26_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_26 from values
@@ -5597,6 +5619,7 @@ impl RtIrTempTemp25 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8525)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_25_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_25_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_25 from values
@@ -5709,6 +5732,7 @@ impl RtIrTempTemp24 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8425)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_24_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_24_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_24 from values
@@ -5821,6 +5845,7 @@ impl RtIrTempTemp22 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8225)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_22_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_22_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_22 from values
@@ -5933,6 +5958,7 @@ impl RtIrTempTemp23 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8325)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_23_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_23_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_23 from values
@@ -6045,6 +6071,7 @@ impl RtIrTempTemp21 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8125)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_21_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_21_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_21 from values
@@ -6157,6 +6184,7 @@ impl RtIrTempTemp20 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8025)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_20_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_20_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_20 from values
@@ -6269,6 +6297,7 @@ impl RtIrTempTemp19 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7f25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_19_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_19_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_19 from values
@@ -6381,6 +6410,7 @@ impl RtIrTempTemp18 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7e25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_18_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_18_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_18 from values
@@ -6493,6 +6523,7 @@ impl RtIrTempTemp16 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7c25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_16_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_16_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_16 from values
@@ -6605,6 +6636,7 @@ impl RtIrTempTemp15 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7b25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_15_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_15_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_15 from values
@@ -6717,6 +6749,7 @@ impl RtIrTempTemp14 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7a25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_14_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_14_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_14 from values
@@ -6829,6 +6862,7 @@ impl RtIrTempTemp13 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7925)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_13_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_13_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_13 from values
@@ -6941,6 +6975,7 @@ impl RtIrTempTemp12 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7825)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_12_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_12_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_12 from values
@@ -7053,6 +7088,7 @@ impl RtIrTempTemp11 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7725)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_11_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_11_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_11 from values
@@ -7165,6 +7201,7 @@ impl RtIrTempTemp10 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7625)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_10_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_10_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_10 from values
@@ -7277,6 +7314,7 @@ impl RtIrTempTemp8 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7425)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_8_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_8_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_8 from values
@@ -7389,6 +7427,7 @@ impl RtIrTempTemp9 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7525)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_9_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_9_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_9 from values
@@ -7501,6 +7540,7 @@ impl RtIrTempTemp17 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7d25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_17_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_17_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_17 from values
@@ -7613,6 +7653,7 @@ impl RtIrTempTemp6 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7225)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_6_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_6_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_6 from values
@@ -7725,6 +7766,7 @@ impl RtIrTempTemp5 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7125)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_5_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_5_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_5 from values
@@ -7837,6 +7879,7 @@ impl RtIrTempTemp4 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7025)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_4_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_4_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_4 from values
@@ -7949,6 +7992,7 @@ impl RtIrTempTemp3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b6f25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_3_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_3_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_3 from values
@@ -8061,6 +8105,7 @@ impl RtIrTempTemp2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b6e25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_2_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_2_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_2 from values
@@ -8173,6 +8218,7 @@ impl RtIrTempTemp1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b6d25)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_1_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_1_MAX: f32 = 0_f32;
     /// Construct new RT_IRTemp_Temp_1 from values
@@ -8285,6 +8331,7 @@ impl RtSbTrigFinalCondition {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9577322)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const FINAL_SPEED_MIN: f32 = 0_f32;
     pub const FINAL_SPEED_MAX: f32 = 1675_f32;
     /// Construct new RT_SB_Trig_Final_Condition from values
@@ -8431,6 +8478,7 @@ impl RtSbTrigInitialCondition {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9577222)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const MFDD_END_THRESHOLD_MIN: u8 = 0_u8;
     pub const MFDD_END_THRESHOLD_MAX: u8 = 100_u8;
     pub const MFDD_START_THRESHOLD_MIN: u8 = 0_u8;
@@ -8752,6 +8800,7 @@ impl RtSbTrigDirectDist {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9577122)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const PATH_DISTANCE_2D_MIN: f32 = 0_f32;
     pub const PATH_DISTANCE_2D_MAX: f32 = 4294967_f32;
     pub const DIRECT_DISTANCE_MIN: f32 = 0_f32;
@@ -8909,6 +8958,7 @@ impl RtSbTrigForwardDist {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9577022)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const DEVIATION_DISTANCE_MIN: f32 = -2147483.648_f32;
     pub const DEVIATION_DISTANCE_MAX: f32 = 2147483.647_f32;
     pub const FORWARD_DISTANCE_MIN: f32 = -2147483.648_f32;
@@ -9071,6 +9121,7 @@ impl RtSbTrigPathDist {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9576f22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const PATH_DISTANCE_3D_MIN: f32 = 0_f32;
     pub const PATH_DISTANCE_3D_MAX: f32 = 4294967_f32;
     /// Construct new RT_SB_Trig_Path_Dist from values
@@ -9184,6 +9235,7 @@ impl RtSbTrigAccel {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9576e22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TRIGGERED_TIME_MIN: f32 = 0_f32;
     pub const TRIGGERED_TIME_MAX: f32 = 167772_f32;
     pub const AVERAGE_ACCEL_MIN: f32 = -65_f32;
@@ -9493,6 +9545,7 @@ impl RtDl1mk3MeasureTime12 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9607824)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_12_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_12_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_12 from values
@@ -9607,6 +9660,7 @@ impl RtDl1mk3MeasureTime11 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9607724)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_11_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_11_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_11 from values
@@ -9721,6 +9775,7 @@ impl RtDl1mk3MeasureTime10 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9607624)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_10_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_10_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_10 from values
@@ -9835,6 +9890,7 @@ impl RtDl1mk3MeasureTime9 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9607524)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_9_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_9_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_9 from values
@@ -9949,6 +10005,7 @@ impl RtDl1mk3MeasureTime8 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9607424)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_8_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_8_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_8 from values
@@ -10063,6 +10120,7 @@ impl RtDl1mk3MeasureTime7 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9607324)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_7_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_7_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_7 from values
@@ -10177,6 +10235,7 @@ impl RtDl1mk3MeasureTime6 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9607224)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_6_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_6_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_6 from values
@@ -10291,6 +10350,7 @@ impl RtDl1mk3MeasureTime5 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9607124)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_5_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_5_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_5 from values
@@ -10405,6 +10465,7 @@ impl RtDl1mk3MeasureTime4 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9607024)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_4_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_4_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_4 from values
@@ -10519,6 +10580,7 @@ impl RtDl1mk3MeasureTime3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9606f24)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_3_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_3_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_3 from values
@@ -10633,6 +10695,7 @@ impl RtDl1mk3MeasureTime2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9606e24)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_2_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_2_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_2 from values
@@ -10747,6 +10810,7 @@ impl RtDl1mk3MeasureTime1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9606d24)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_1_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_1_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Measure_Time_1 from values
@@ -10861,6 +10925,7 @@ impl RtDl1mk3Rpm {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95f7824)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const RPM_MIN: u16 = 0_u16;
     pub const RPM_MAX: u16 = 0_u16;
     /// Construct new RT_DL1MK3_RPM from values
@@ -10975,6 +11040,7 @@ impl RtDl1mk3Freq4 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95f7724)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const FREQUENCY_4_MIN: f32 = 0_f32;
     pub const FREQUENCY_4_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Freq_4 from values
@@ -11086,6 +11152,7 @@ impl RtDl1mk3Freq3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95f7624)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const FREQUENCY_3_MIN: f32 = 0_f32;
     pub const FREQUENCY_3_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Freq_3 from values
@@ -11197,6 +11264,7 @@ impl RtDl1mk3Freq2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95f7524)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const FREQUENCY_2_MIN: f32 = 0_f32;
     pub const FREQUENCY_2_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Freq_2 from values
@@ -11308,6 +11376,7 @@ impl RtDl1mk3Misc3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9616f24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const MISC_3_MIN: f32 = 0_f32;
     pub const MISC_3_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Misc_3 from values
@@ -11419,6 +11488,7 @@ impl RtDl1mk3Misc2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9616e24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const MISC_2_MIN: f32 = 0_f32;
     pub const MISC_2_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Misc_2 from values
@@ -11530,6 +11600,7 @@ impl RtDl1mk3Misc1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9616d24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const MISC_1_MIN: f32 = 0_f32;
     pub const MISC_1_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Misc_1 from values
@@ -11641,6 +11712,7 @@ impl RtDl1mk3Aux31 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8b24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_31_MIN: f32 = 0_f32;
     pub const AUX_31_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_31 from values
@@ -11752,6 +11824,7 @@ impl RtDl1mk3Aux30 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8a24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_30_MIN: f32 = 0_f32;
     pub const AUX_30_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_30 from values
@@ -11863,6 +11936,7 @@ impl RtDl1mk3Aux29 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8924)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_29_MIN: f32 = 0_f32;
     pub const AUX_29_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_29 from values
@@ -11974,6 +12048,7 @@ impl RtDl1mk3Aux28 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8824)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_28_MIN: f32 = 0_f32;
     pub const AUX_28_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_28 from values
@@ -12085,6 +12160,7 @@ impl RtDl1mk3Aux27 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8724)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_27_MIN: f32 = 0_f32;
     pub const AUX_27_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_27 from values
@@ -12196,6 +12272,7 @@ impl RtDl1mk3Aux26 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8624)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_26_MIN: f32 = 0_f32;
     pub const AUX_26_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_26 from values
@@ -12307,6 +12384,7 @@ impl RtDl1mk3Aux25 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8524)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_25_MIN: f32 = 0_f32;
     pub const AUX_25_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_25 from values
@@ -12418,6 +12496,7 @@ impl RtDl1mk3Aux24 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8424)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_24_MIN: f32 = 0_f32;
     pub const AUX_24_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_24 from values
@@ -12529,6 +12608,7 @@ impl RtDl1mk3Aux23 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8324)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_23_MIN: f32 = 0_f32;
     pub const AUX_23_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_23 from values
@@ -12640,6 +12720,7 @@ impl RtDl1mk3Aux22 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8224)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_22_MIN: u32 = 0_u32;
     pub const AUX_22_MAX: u32 = 0_u32;
     /// Construct new RT_DL1MK3_Aux_22 from values
@@ -12754,6 +12835,7 @@ impl RtDl1mk3Aux21 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8124)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_21_MIN: f32 = 0_f32;
     pub const AUX_21_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_21 from values
@@ -12865,6 +12947,7 @@ impl RtDl1mk3Aux20 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e8024)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_20_MIN: f32 = 0_f32;
     pub const AUX_20_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_20 from values
@@ -12976,6 +13059,7 @@ impl RtDl1mk3Aux19 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7f24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_19_MIN: f32 = 0_f32;
     pub const AUX_19_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_19 from values
@@ -13087,6 +13171,7 @@ impl RtDl1mk3Aux18 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7e24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_18_MIN: f32 = 0_f32;
     pub const AUX_18_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_18 from values
@@ -13198,6 +13283,7 @@ impl RtDl1mk3Aux17 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7d24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_17_MIN: f32 = 0_f32;
     pub const AUX_17_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_17 from values
@@ -13309,6 +13395,7 @@ impl RtDl1mk3Aux16 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7c24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_16_MIN: f32 = 0_f32;
     pub const AUX_16_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_16 from values
@@ -13420,6 +13507,7 @@ impl RtDl1mk3Aux15 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7b24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_15_MIN: f32 = 0_f32;
     pub const AUX_15_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_15 from values
@@ -13531,6 +13619,7 @@ impl RtDl1mk3Aux14 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7a24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_14_MIN: f32 = 0_f32;
     pub const AUX_14_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_14 from values
@@ -13642,6 +13731,7 @@ impl RtDl1mk3Aux13 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7924)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_13_MIN: f32 = 0_f32;
     pub const AUX_13_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_13 from values
@@ -13753,6 +13843,7 @@ impl RtDl1mk3Aux12 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7824)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_12_MIN: f32 = 0_f32;
     pub const AUX_12_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_12 from values
@@ -13864,6 +13955,7 @@ impl RtDl1mk3Aux11 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7724)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_11_MIN: f32 = 0_f32;
     pub const AUX_11_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_11 from values
@@ -13975,6 +14067,7 @@ impl RtDl1mk3Aux9 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7524)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_9_MIN: f32 = 0_f32;
     pub const AUX_9_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_9 from values
@@ -14086,6 +14179,7 @@ impl RtDl1mk3Aux10 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7624)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_10_MIN: f32 = 0_f32;
     pub const AUX_10_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_10 from values
@@ -14197,6 +14291,7 @@ impl RtDl1mk3Aux8 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7424)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_8_MIN: f32 = 0_f32;
     pub const AUX_8_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_8 from values
@@ -14308,6 +14403,7 @@ impl RtDl1mk3Aux7 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7324)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_7_MIN: f32 = 0_f32;
     pub const AUX_7_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_7 from values
@@ -14419,6 +14515,7 @@ impl RtDl1mk3Aux6 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7224)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_6_MIN: f32 = 0_f32;
     pub const AUX_6_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_6 from values
@@ -14530,6 +14627,7 @@ impl RtDl1mk3Aux5 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7124)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_5_MIN: f32 = 0_f32;
     pub const AUX_5_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_5 from values
@@ -14641,6 +14739,7 @@ impl RtDl1mk3Aux4 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e7024)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_4_MIN: f32 = 0_f32;
     pub const AUX_4_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_4 from values
@@ -14752,6 +14851,7 @@ impl RtDl1mk3Aux3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e6f24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_3_MIN: f32 = 0_f32;
     pub const AUX_3_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_3 from values
@@ -14863,6 +14963,7 @@ impl RtDl1mk3Aux2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e6e24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_2_MIN: f32 = 0_f32;
     pub const AUX_2_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_2 from values
@@ -14974,6 +15075,7 @@ impl RtDl1mk3Aux1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95e6d24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_1_MIN: f32 = 0_f32;
     pub const AUX_1_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Aux_1 from values
@@ -15085,6 +15187,7 @@ impl RtDl1mk3Pressure5 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95a7124)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_5_MIN: f32 = 0_f32;
     pub const PRESSURE_5_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Pressure_5 from values
@@ -15196,6 +15299,7 @@ impl RtDl1mk3Pressure4 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95a7024)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_4_MIN: f32 = 0_f32;
     pub const PRESSURE_4_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Pressure_4 from values
@@ -15307,6 +15411,7 @@ impl RtDl1mk3Pressure3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95a6f24)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_3_MIN: f32 = 0_f32;
     pub const PRESSURE_3_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Pressure_3 from values
@@ -15418,6 +15523,7 @@ impl RtDl1mk3Pressure2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95a6e24)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_2_MIN: f32 = 0_f32;
     pub const PRESSURE_2_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Pressure_2 from values
@@ -15529,6 +15635,7 @@ impl RtDl1mk3Pressure1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95a6d24)
     });
+    pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_1_MIN: f32 = 0_f32;
     pub const PRESSURE_1_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Pressure_1 from values
@@ -15640,6 +15747,7 @@ impl RtDl1mk3Angle3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95c6f24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANGLE_3_MIN: f32 = 0_f32;
     pub const ANGLE_3_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Angle_3 from values
@@ -15752,6 +15860,7 @@ impl RtDl1mk3Angle2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95c6e24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANGLE_2_MIN: f32 = 0_f32;
     pub const ANGLE_2_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Angle_2 from values
@@ -15864,6 +15973,7 @@ impl RtDl1mk3Angle1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95c6d24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANGLE_1_MIN: f32 = 0_f32;
     pub const ANGLE_1_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Angle_1 from values
@@ -15976,6 +16086,7 @@ impl RtDl1mk3Temp25 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8524)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_25_MIN: f32 = 0_f32;
     pub const TEMPERATURE_25_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_25 from values
@@ -16088,6 +16199,7 @@ impl RtDl1mk3Temp24 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8424)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_24_MIN: f32 = 0_f32;
     pub const TEMPERATURE_24_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_24 from values
@@ -16200,6 +16312,7 @@ impl RtDl1mk3Temp23 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8324)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_23_MIN: f32 = 0_f32;
     pub const TEMPERATURE_23_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_23 from values
@@ -16312,6 +16425,7 @@ impl RtDl1mk3Temp22 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8224)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_22_MIN: f32 = 0_f32;
     pub const TEMPERATURE_22_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_22 from values
@@ -16424,6 +16538,7 @@ impl RtDl1mk3Temp21 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8124)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_21_MIN: f32 = 0_f32;
     pub const TEMPERATURE_21_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_21 from values
@@ -16536,6 +16651,7 @@ impl RtDl1mk3Temp20 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b8024)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_20_MIN: f32 = 0_f32;
     pub const TEMPERATURE_20_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_20 from values
@@ -16648,6 +16764,7 @@ impl RtDl1mk3Temp19 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7f24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_19_MIN: f32 = 0_f32;
     pub const TEMPERATURE_19_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_19 from values
@@ -16760,6 +16877,7 @@ impl RtDl1mk3Temp18 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7e24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_18_MIN: f32 = 0_f32;
     pub const TEMPERATURE_18_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_18 from values
@@ -16872,6 +16990,7 @@ impl RtDl1mk3Temp17 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7d24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_17_MIN: f32 = 0_f32;
     pub const TEMPERATURE_17_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_17 from values
@@ -16984,6 +17103,7 @@ impl RtDl1mk3Temp16 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7c24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_16_MIN: f32 = 0_f32;
     pub const TEMPERATURE_16_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_16 from values
@@ -17096,6 +17216,7 @@ impl RtDl1mk3Temp15 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7b24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_15_MIN: f32 = 0_f32;
     pub const TEMPERATURE_15_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_15 from values
@@ -17208,6 +17329,7 @@ impl RtDl1mk3Temp14 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7a24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_14_MIN: f32 = 0_f32;
     pub const TEMPERATURE_14_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_14 from values
@@ -17320,6 +17442,7 @@ impl RtDl1mk3Temp13 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7924)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_13_MIN: f32 = 0_f32;
     pub const TEMPERATURE_13_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_13 from values
@@ -17432,6 +17555,7 @@ impl RtDl1mk3Temp12 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7824)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_12_MIN: f32 = 0_f32;
     pub const TEMPERATURE_12_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_12 from values
@@ -17544,6 +17668,7 @@ impl RtDl1mk3Temp11 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7724)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_11_MIN: f32 = 0_f32;
     pub const TEMPERATURE_11_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_11 from values
@@ -17656,6 +17781,7 @@ impl RtDl1mk3Temp10 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7624)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_10_MIN: f32 = 0_f32;
     pub const TEMPERATURE_10_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_10 from values
@@ -17768,6 +17894,7 @@ impl RtDl1mk3Temp9 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7524)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_9_MIN: f32 = 0_f32;
     pub const TEMPERATURE_9_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_9 from values
@@ -17880,6 +18007,7 @@ impl RtDl1mk3Temp8 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7424)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_8_MIN: f32 = 0_f32;
     pub const TEMPERATURE_8_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_8 from values
@@ -17992,6 +18120,7 @@ impl RtDl1mk3Temp7 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7324)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_7_MIN: f32 = 0_f32;
     pub const TEMPERATURE_7_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_7 from values
@@ -18104,6 +18233,7 @@ impl RtDl1mk3Temp6 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7224)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_6_MIN: f32 = 0_f32;
     pub const TEMPERATURE_6_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_6 from values
@@ -18216,6 +18346,7 @@ impl RtDl1mk3Temp5 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7124)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_5_MIN: f32 = 0_f32;
     pub const TEMPERATURE_5_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_5 from values
@@ -18328,6 +18459,7 @@ impl RtDl1mk3Temp4 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b7024)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_4_MIN: f32 = 0_f32;
     pub const TEMPERATURE_4_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_4 from values
@@ -18440,6 +18572,7 @@ impl RtDl1mk3Temp3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b6f24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_3_MIN: f32 = 0_f32;
     pub const TEMPERATURE_3_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_3 from values
@@ -18552,6 +18685,7 @@ impl RtDl1mk3Temp2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b6e24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_2_MIN: f32 = 0_f32;
     pub const TEMPERATURE_2_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_2 from values
@@ -18664,6 +18798,7 @@ impl RtDl1mk3Temp1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x95b6d24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_1_MIN: f32 = 0_f32;
     pub const TEMPERATURE_1_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Temp_1 from values
@@ -18776,6 +18911,7 @@ impl RtDl1mk3Analog32 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8b24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_32_MIN: f32 = 0_f32;
     pub const ANALOG_32_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_32 from values
@@ -18887,6 +19023,7 @@ impl RtDl1mk3Analog31 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8a24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_31_MIN: f32 = 0_f32;
     pub const ANALOG_31_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_31 from values
@@ -18998,6 +19135,7 @@ impl RtDl1mk3Analog30 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8924)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_30_MIN: f32 = 0_f32;
     pub const ANALOG_30_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_30 from values
@@ -19109,6 +19247,7 @@ impl RtDl1mk3Analog29 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8824)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_29_MIN: f32 = 0_f32;
     pub const ANALOG_29_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_29 from values
@@ -19220,6 +19359,7 @@ impl RtDl1mk3Analog28 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8724)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_28_MIN: f32 = 0_f32;
     pub const ANALOG_28_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_28 from values
@@ -19331,6 +19471,7 @@ impl RtDl1mk3Analog27 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8624)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_27_MIN: f32 = 0_f32;
     pub const ANALOG_27_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_27 from values
@@ -19442,6 +19583,7 @@ impl RtDl1mk3Analog26 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8524)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_26_MIN: f32 = 0_f32;
     pub const ANALOG_26_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_26 from values
@@ -19553,6 +19695,7 @@ impl RtDl1mk3Analog25 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8424)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_25_MIN: f32 = 0_f32;
     pub const ANALOG_25_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_25 from values
@@ -19664,6 +19807,7 @@ impl RtDl1mk3Analog15 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7a24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_15_MIN: f32 = 0_f32;
     pub const ANALOG_15_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_15 from values
@@ -19775,6 +19919,7 @@ impl RtDl1mk3Analog14 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7924)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_14_MIN: f32 = 0_f32;
     pub const ANALOG_14_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_14 from values
@@ -19886,6 +20031,7 @@ impl RtDl1mk3Analog17 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7c24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_17_MIN: f32 = 0_f32;
     pub const ANALOG_17_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_17 from values
@@ -19997,6 +20143,7 @@ impl RtDl1mk3Analog24 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8324)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_24_MIN: f32 = 0_f32;
     pub const ANALOG_24_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_24 from values
@@ -20108,6 +20255,7 @@ impl RtDl1mk3Analog23 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8224)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_23_MIN: f32 = 0_f32;
     pub const ANALOG_23_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_23 from values
@@ -20219,6 +20367,7 @@ impl RtDl1mk3Analog22 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8124)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_22_MIN: f32 = 0_f32;
     pub const ANALOG_22_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_22 from values
@@ -20330,6 +20479,7 @@ impl RtDl1mk3Analog21 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c8024)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_21_MIN: f32 = 0_f32;
     pub const ANALOG_21_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_21 from values
@@ -20441,6 +20591,7 @@ impl RtDl1mk3Analog20 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7f24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_20_MIN: f32 = 0_f32;
     pub const ANALOG_20_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_20 from values
@@ -20552,6 +20703,7 @@ impl RtDl1mk3Analog19 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7e24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_19_MIN: f32 = 0_f32;
     pub const ANALOG_19_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_19 from values
@@ -20663,6 +20815,7 @@ impl RtDl1mk3Analog16 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7b24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_16_MIN: f32 = 0_f32;
     pub const ANALOG_16_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_16 from values
@@ -20774,6 +20927,7 @@ impl RtDl1mk3Analog18 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7d24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_18_MIN: f32 = 0_f32;
     pub const ANALOG_18_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_18 from values
@@ -20885,6 +21039,7 @@ impl RtDl1mk3Analog12 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7724)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_12_MIN: f32 = 0_f32;
     pub const ANALOG_12_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_12 from values
@@ -20996,6 +21151,7 @@ impl RtDl1mk3Analog11 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7624)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_11_MIN: f32 = 0_f32;
     pub const ANALOG_11_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_11 from values
@@ -21107,6 +21263,7 @@ impl RtDl1mk3Analog10 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7524)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_10_MIN: f32 = 0_f32;
     pub const ANALOG_10_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_10 from values
@@ -21218,6 +21375,7 @@ impl RtDl1mk3Analog9 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7424)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_9_MIN: f32 = 0_f32;
     pub const ANALOG_9_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_9 from values
@@ -21329,6 +21487,7 @@ impl RtDl1mk3Analog8 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7324)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_8_MIN: f32 = 0_f32;
     pub const ANALOG_8_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_8 from values
@@ -21440,6 +21599,7 @@ impl RtDl1mk3Analog7 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7224)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_7_MIN: f32 = 0_f32;
     pub const ANALOG_7_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_7 from values
@@ -21551,6 +21711,7 @@ impl RtDl1mk3Analog6 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7124)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_6_MIN: f32 = 0_f32;
     pub const ANALOG_6_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_6 from values
@@ -21662,6 +21823,7 @@ impl RtDl1mk3Analog5 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c7024)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_5_MIN: f32 = 0_f32;
     pub const ANALOG_5_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_5 from values
@@ -21773,6 +21935,7 @@ impl RtDl1mk3Analog4 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c6f24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_4_MIN: f32 = 0_f32;
     pub const ANALOG_4_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_4 from values
@@ -21884,6 +22047,7 @@ impl RtDl1mk3Analog3 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c6e24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_3_MIN: f32 = 0_f32;
     pub const ANALOG_3_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_3 from values
@@ -21995,6 +22159,7 @@ impl RtDl1mk3Analog2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c6d24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_2_MIN: f32 = 0_f32;
     pub const ANALOG_2_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_2 from values
@@ -22106,6 +22271,7 @@ impl RtDl1mk3Analog1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94c6c24)
     });
+    pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_1_MIN: f32 = 0_f32;
     pub const ANALOG_1_MAX: f32 = 0_f32;
     /// Construct new RT_DL1MK3_Analog_1 from values
@@ -22217,6 +22383,7 @@ impl RtDl1mk3Accel {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94a6c24)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const ACCEL_VERTICAL_MIN: f32 = -65_f32;
     pub const ACCEL_VERTICAL_MAX: f32 = 65_f32;
     pub const ACCEL_LATERAL_MIN: f32 = -65_f32;
@@ -22578,6 +22745,7 @@ impl RtSbInsVpt4VelNed2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9599e22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_4_SLIP_MIN: f32 = -180_f32;
     pub const VIRTUAL_4_SLIP_MAX: f32 = 180_f32;
     pub const VIRTUAL_4_HEADING_MIN: f32 = -180_f32;
@@ -22786,6 +22954,7 @@ impl RtSbInsVpt4VelNed1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9599d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_4_VEL_NED_E_MIN: f32 = -838_f32;
     pub const VIRTUAL_4_VEL_NED_E_MAX: f32 = 838_f32;
     pub const VIRTUAL_4_VEL_NED_N_MIN: f32 = -838_f32;
@@ -22948,6 +23117,7 @@ impl RtSbInsVpt4Offset {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9599c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_4_OFFSET_Z_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_4_OFFSET_Z_MAX: f32 = 32.767_f32;
     pub const VIRTUAL_4_OFFSET_Y_MIN: f32 = -32.768_f32;
@@ -23156,6 +23326,7 @@ impl RtSbInsVpt3VelNed2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9598e22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_3_SLIP_MIN: f32 = -180_f32;
     pub const VIRTUAL_3_SLIP_MAX: f32 = 180_f32;
     pub const VIRTUAL_3_HEADING_MIN: f32 = -180_f32;
@@ -23364,6 +23535,7 @@ impl RtSbInsVpt3VelNed1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9598d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_3_VEL_NED_E_MIN: f32 = -838_f32;
     pub const VIRTUAL_3_VEL_NED_E_MAX: f32 = 838_f32;
     pub const VIRTUAL_3_VEL_NED_N_MIN: f32 = -838_f32;
@@ -23526,6 +23698,7 @@ impl RtSbInsVpt3Offset {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9598c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_3_OFFSET_Z_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_3_OFFSET_Z_MAX: f32 = 32.767_f32;
     pub const VIRTUAL_3_OFFSET_Y_MIN: f32 = -32.768_f32;
@@ -23734,6 +23907,7 @@ impl RtSbInsVpt2VelNed2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9597e22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_2_SLIP_MIN: f32 = -180_f32;
     pub const VIRTUAL_2_SLIP_MAX: f32 = 180_f32;
     pub const VIRTUAL_2_HEADING_MIN: f32 = -180_f32;
@@ -23942,6 +24116,7 @@ impl RtSbInsVpt2VelNed1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9597d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_2_VEL_NED_E_MIN: f32 = -838_f32;
     pub const VIRTUAL_2_VEL_NED_E_MAX: f32 = 838_f32;
     pub const VIRTUAL_2_VEL_NED_N_MIN: f32 = -838_f32;
@@ -24104,6 +24279,7 @@ impl RtSbInsVpt2Offset {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9597c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_2_OFFSET_Z_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_2_OFFSET_Z_MAX: f32 = 32.767_f32;
     pub const VIRTUAL_2_OFFSET_Y_MIN: f32 = -32.768_f32;
@@ -24312,6 +24488,7 @@ impl RtSbInsVpt1VelNed2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9596e22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_1_SLIP_MIN: f32 = -180_f32;
     pub const VIRTUAL_1_SLIP_MAX: f32 = 180_f32;
     pub const VIRTUAL_1_HEADING_MIN: f32 = -180_f32;
@@ -24520,6 +24697,7 @@ impl RtSbInsVpt1VelNed1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9596d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_1_VEL_NED_E_MIN: f32 = -838_f32;
     pub const VIRTUAL_1_VEL_NED_E_MAX: f32 = 838_f32;
     pub const VIRTUAL_1_VEL_NED_N_MIN: f32 = -838_f32;
@@ -24682,6 +24860,7 @@ impl RtSbInsVpt1Offset {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9596c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const VIRTUAL_1_OFFSET_Z_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_1_OFFSET_Z_MAX: f32 = 32.767_f32;
     pub const VIRTUAL_1_OFFSET_Y_MIN: f32 = -32.768_f32;
@@ -24890,6 +25069,7 @@ impl RtSbInsSlip {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9588222)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_SQUAT_MIN: f32 = -360_f32;
     pub const INS_SQUAT_MAX: f32 = 360_f32;
     pub const ACCURACY_INS_SQUAT_MIN: u8 = 0_u8;
@@ -25212,6 +25392,7 @@ impl RtSbInsVelEcef2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9587f22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_ECEF_Z_MIN: f32 = -838_f32;
     pub const INS_VEL_ECEF_Z_MAX: f32 = 838_f32;
     pub const INS_VEL_ECEF_Y_MIN: f32 = -838_f32;
@@ -25442,6 +25623,7 @@ impl RtSbInsVelEcef1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9587e22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_ECEF_X_MIN: f32 = -838_f32;
     pub const INS_VEL_ECEF_X_MAX: f32 = 838_f32;
     pub const ACCURACY_INS_VEL_ECEF_Z_MIN: u8 = 0_u8;
@@ -25730,6 +25912,7 @@ impl RtSbInsVelNed2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9587d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_NED_D_MIN: f32 = -838_f32;
     pub const INS_VEL_NED_D_MAX: f32 = 838_f32;
     pub const ACCURACY_INS_VEL_D_MIN: u8 = 0_u8;
@@ -25926,6 +26109,7 @@ impl RtSbInsVelNed1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9587c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_VEL_NED_E_MIN: f32 = -838_f32;
     pub const INS_VEL_NED_E_MAX: f32 = 838_f32;
     pub const INS_VEL_NED_N_MIN: f32 = -838_f32;
@@ -26202,6 +26386,7 @@ impl RtSbInsPosEcef2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9587122)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_POS_ECEF_Z_MIN: f32 = -10000000_f32;
     pub const INS_POS_ECEF_Z_MAX: f32 = 10000000_f32;
     pub const INS_POS_ECEF_Y_MIN: f32 = -10000000_f32;
@@ -26361,6 +26546,7 @@ impl RtSbInsPosEcef1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9587022)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_POS_ECEF_X_MIN: f32 = -10000000_f32;
     pub const INS_POS_ECEF_X_MAX: f32 = 10000000_f32;
     pub const ACCURACY_INS_POS_ECEF_Z_MIN: u8 = 0_u8;
@@ -26723,6 +26909,7 @@ impl RtSbInsPosLlh2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9586f22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_POS_LLH_ALTITUDE_MIN: f32 = -1000_f32;
     pub const INS_POS_LLH_ALTITUDE_MAX: f32 = 100000_f32;
     pub const INS_POS_LLH_LONGITUDE_MIN: f32 = -180_f32;
@@ -26881,6 +27068,7 @@ impl RtSbInsPosLlh1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9586e22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_POS_LLH_LATITUDE_MIN: f32 = -90_f32;
     pub const INS_POS_LLH_LATITUDE_MAX: f32 = 90_f32;
     pub const ACCURACY_INS_POS_LLH_ALTITUDE_MIN: u8 = 0_u8;
@@ -27259,6 +27447,7 @@ impl RtSbInsHeadingGradient2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9588122)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_GRADIENT_MIN: f32 = -90_f32;
     pub const INS_GRADIENT_MAX: f32 = 90_f32;
     pub const ACCURACY_INS_GRADIENT_MIN: u8 = 0_u8;
@@ -27584,6 +27773,7 @@ impl RtSbInsHeadingGradient {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9588022)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_GRADIENT_MIN: f32 = -90_f32;
     pub const INS_GRADIENT_MAX: f32 = 90_f32;
     pub const ACCURACY_INS_GRADIENT_MIN: u8 = 0_u8;
@@ -27910,6 +28100,7 @@ impl RtSbInsStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9586c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const INS_STATUS_MIN: u8 = 0_u8;
     pub const INS_STATUS_MAX: u8 = 255_u8;
     /// Construct new RT_SB_INS_Status from values
@@ -28057,6 +28248,7 @@ impl RtSbInsAttitude {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9586d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const ATTITUDE_ROLL_MIN: f32 = -360_f32;
     pub const ATTITUDE_ROLL_MAX: f32 = 360_f32;
     pub const ATTITUDE_PITCH_MIN: f32 = -360_f32;
@@ -28491,6 +28683,7 @@ impl RtSbOutputStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9576d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_TIME_MIN: f32 = 0_f32;
     pub const GPS_TIME_MAX: f32 = 604800_f32;
     /// Construct new RT_SB_Output_Status from values
@@ -29165,6 +29358,7 @@ impl RtSbGpsHeadingGradient2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9568222)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_GRADIENT_MIN: f32 = -90_f32;
     pub const GPS_GRADIENT_MAX: f32 = 90_f32;
     pub const ACCURACY_GPS_GRADIENT_MIN: u8 = 0_u8;
@@ -29492,6 +29686,7 @@ impl RtSbCumulativeDistance2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94a8d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const CUMULATIVE_DISTANCE_MIN: f32 = 0_f32;
     pub const CUMULATIVE_DISTANCE_MAX: f32 = 4294967_f32;
     pub const CUMULATIVE_TIME_MIN: f32 = 0_f32;
@@ -29721,6 +29916,7 @@ impl RtSbCumulativeDistance1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94a8c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const CUMULATIVE_DISTANCE_MIN: f32 = 0_f32;
     pub const CUMULATIVE_DISTANCE_MAX: f32 = 4294967_f32;
     pub const CUMULATIVE_TIME_MIN: f32 = 0_f32;
@@ -29948,6 +30144,7 @@ impl RtSbTriggerTimestamp {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9576c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_HIGH_RESOLUTION_TIME_MIN: f32 = 0_f32;
     pub const GPS_HIGH_RESOLUTION_TIME_MAX: f32 = 604800_f32;
     pub const TRIGGER_NUMBER_MIN: u8 = 0_u8;
@@ -30262,6 +30459,7 @@ impl RtImu06GyroRates {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94a6d21)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GYRO_RATE_ROLL_MIN: f32 = -327_f32;
     pub const GYRO_RATE_ROLL_MAX: f32 = 327_f32;
     pub const GYRO_RATE_PITCH_MIN: f32 = -327_f32;
@@ -30620,6 +30818,7 @@ impl RtImu06Accel {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94a6c21)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const ACCEL_VERTICAL_MIN: f32 = -65_f32;
     pub const ACCEL_VERTICAL_MAX: f32 = 65_f32;
     pub const ACCEL_LATERAL_MIN: f32 = -65_f32;
@@ -30981,6 +31180,7 @@ impl RtSbSpeed {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94a7c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const SPEED_MIN: f32 = -20000_f32;
     pub const SPEED_MAX: f32 = 20000_f32;
     pub const ACCURACY_SPEED_MIN: u8 = 0_u8;
@@ -31177,6 +31377,7 @@ impl RtSbRtkSlip {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9568d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const RTK_BASELINE_MIN: u16 = 0_u16;
     pub const RTK_BASELINE_MAX: u16 = 65535_u16;
     pub const RTK_SQUAT_MIN: f32 = -360_f32;
@@ -31535,6 +31736,7 @@ impl RtSbRtkAttitude {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9568c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const RTK_ATTITUDE_ROLL_MIN: f32 = -90_f32;
     pub const RTK_ATTITUDE_ROLL_MAX: f32 = 90_f32;
     pub const RTK_ATTITUDE_PITCH_MIN: f32 = -90_f32;
@@ -31893,6 +32095,7 @@ impl RtSbGpsMcycleLean {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9569c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_MCYCLE_LEAN_ANGLE_MIN: f32 = -90_f32;
     pub const GPS_MCYCLE_LEAN_ANGLE_MAX: f32 = 90_f32;
     pub const GPS_LATERAL_ACCEL_MIN: f32 = -65_f32;
@@ -32174,6 +32377,7 @@ impl RtSbGpsStatus {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9566c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const RTK_STATUS_MIN: u8 = 0_u8;
     pub const RTK_STATUS_MAX: u8 = 255_u8;
     pub const GPS_N_SV_RTK_MIN: u8 = 0_u8;
@@ -32717,6 +32921,7 @@ impl RtSbGpsPosEcef2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9567122)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_ECEF_Z_MIN: f32 = -10000000_f32;
     pub const GPS_POS_ECEF_Z_MAX: f32 = 10000000_f32;
     pub const GPS_POS_ECEF_Y_MIN: f32 = -10000000_f32;
@@ -32876,6 +33081,7 @@ impl RtSbGpsPosEcef1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9567022)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_ECEF_X_MIN: f32 = -10000000_f32;
     pub const GPS_POS_ECEF_X_MAX: f32 = 10000000_f32;
     pub const ACCURACY_GPS_POS_ECEF_Z_MIN: u8 = 0_u8;
@@ -33238,6 +33444,7 @@ impl RtSbGpsPosLlh2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9566f22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_LLH_ALTITUDE_MIN: f32 = -1000_f32;
     pub const GPS_POS_LLH_ALTITUDE_MAX: f32 = 100000_f32;
     pub const GPS_POS_LLH_LONGITUDE_MIN: f32 = -180_f32;
@@ -33396,6 +33603,7 @@ impl RtSbGpsPosLlh1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9566e22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_POS_LLH_LATITUDE_MIN: f32 = -90_f32;
     pub const GPS_POS_LLH_LATITUDE_MAX: f32 = 90_f32;
     pub const ACCURACY_GPS_POS_LLH_ALTITUDE_MIN: u8 = 0_u8;
@@ -33774,6 +33982,7 @@ impl RtSbGpsHeadingGradient {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9568122)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_GRADIENT_MIN: f32 = -90_f32;
     pub const GPS_GRADIENT_MAX: f32 = 90_f32;
     pub const ACCURACY_GPS_GRADIENT_MIN: u8 = 0_u8;
@@ -34100,6 +34309,7 @@ impl RtSbGpsVelEcef2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9568022)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_VEL_ECEF_Z_MIN: f32 = -838_f32;
     pub const GPS_VEL_ECEF_Z_MAX: f32 = 838_f32;
     pub const GPS_VEL_ECEF_Y_MIN: f32 = -838_f32;
@@ -34330,6 +34540,7 @@ impl RtSbGpsVelEcef1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9567f22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_VEL_ECEF_X_MIN: f32 = -838_f32;
     pub const GPS_VEL_ECEF_X_MAX: f32 = 838_f32;
     pub const ACCURACY_GPS_VEL_ECEF_Z_MIN: u8 = 0_u8;
@@ -34618,6 +34829,7 @@ impl RtSbGpsVelNed2 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9567e22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_VEL_NED_D_MIN: f32 = -838_f32;
     pub const GPS_VEL_NED_D_MAX: f32 = 838_f32;
     pub const ACCURACY_GPS_VEL_D_MIN: u8 = 0_u8;
@@ -34814,6 +35026,7 @@ impl RtSbGpsVelNed1 {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9567d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_VEL_NED_E_MIN: f32 = -838_f32;
     pub const GPS_VEL_NED_E_MAX: f32 = 838_f32;
     pub const GPS_VEL_NED_N_MIN: f32 = -838_f32;
@@ -35090,6 +35303,7 @@ impl RtSbGpsSpeed {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9567c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_SPEED_3D_MIN: f32 = 0_f32;
     pub const GPS_SPEED_3D_MAX: f32 = 1675_f32;
     pub const GPS_SPEED_2D_MIN: f32 = 0_f32;
@@ -35366,6 +35580,7 @@ impl RtSbGpsTime {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x9566d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_WEEK_MIN: u16 = 0_u16;
     pub const GPS_WEEK_MAX: u16 = 65535_u16;
     pub const GPS_TIME_MIN: f32 = 0_f32;
@@ -35641,6 +35856,7 @@ impl RtSbAccel {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94a6c22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const ACCEL_VERTICAL_MIN: f32 = -65_f32;
     pub const ACCEL_VERTICAL_MAX: f32 = 65_f32;
     pub const ACCEL_LATERAL_MIN: f32 = -65_f32;
@@ -36002,6 +36218,7 @@ impl RtSbGyroRates {
     pub const MESSAGE_ID: embedded_can::Id = Id::Extended(unsafe {
         ExtendedId::new_unchecked(0x94a6d22)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const GYRO_RATE_ROLL_MIN: f32 = -327_f32;
     pub const GYRO_RATE_ROLL_MAX: f32 = 327_f32;
     pub const GYRO_RATE_PITCH_MIN: f32 = -327_f32;

--- a/tests-snapshots/oxibus/bug_dbc-codegen_98.snap.rs
+++ b/tests-snapshots/oxibus/bug_dbc-codegen_98.snap.rs
@@ -71,6 +71,7 @@ impl TestInput {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x0)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_INPUT_MUX_MIN: u8 = 0_u8;
     pub const TEST_INPUT_MUX_MAX: u8 = 0_u8;
     pub const VAR1_MIN: u16 = 0_u16;
@@ -578,6 +579,7 @@ impl TestOutput {
     pub const MESSAGE_ID: embedded_can::Id = Id::Standard(unsafe {
         StandardId::new_unchecked(0x1)
     });
+    pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_OUTPUT_MUX_MIN: u8 = 0_u8;
     pub const TEST_OUTPUT_MUX_MAX: u8 = 0_u8;
     pub const VAR5_MIN: u16 = 0_u16;


### PR DESCRIPTION
Generates the following new constants per message:

- `MESSAGE_SIZE` in bytes. This avoids the overhead of using `raw().len()` or `embedded_can::Frame::dlc()` and makes the size known at compile-time.
- `MESSAGE_CYCLE_TIME` containing the value from the corresponding `GenMsgCycleTime` DBC attribute when it is present.

This PR should be stacked on top of #175.