### PR TITLE
Generate enum-typed setters and constructors for signals with value descriptions

### DIFF
--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -8,7 +8,14 @@ use cantools_messages::{
 };
 
 fuzz_target!(|dbc_codegen_bar: can_messages::Bar| {
-    let dbc_codegen_bar = can_messages::Bar::new(3, 2.0, 4, 5, false).unwrap();
+    let dbc_codegen_bar = can_messages::Bar::new(
+        3,
+        2.0,
+        can_messages::BarThree::_Other(4),
+        can_messages::BarFour::_Other(5),
+        can_messages::BarType::X0off,
+    )
+    .unwrap();
 
     println!(
         "{} {} {} {} {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -799,46 +799,23 @@ impl Config<'_> {
         let param_type = signal_pub_type(dbc, msg, signal);
         let is_enum_backed = param_type != typ.to_string();
 
-        if is_enum_backed {
-            writeln!(w, "/// Set value of '{}'", signal.name)?;
-            writeln!(w, "#[inline(always)]")?;
-            writeln!(
-                w,
-                "{visibility}fn set_{field}(&mut self, value: {param_type}) -> Result<(), CanError> {{",
-            )?;
-            {
-                let mut w = PadAdapter::wrap(w);
-                writeln!(w, "self.set_{field}_raw({typ}::from(value))")?;
+        writeln!(w, "/// Set value of '{}'", signal.name)?;
+        writeln!(w, "#[inline(always)]")?;
+        writeln!(
+            w,
+            "{visibility}fn set_{field}(&mut self, value: {param_type}) -> Result<(), CanError> {{",
+        )?;
+        {
+            let mut w = PadAdapter::wrap(w);
+            // Enum-backed signals accept the value-description enum; convert it to
+            // the raw primitive before range checks and packing.
+            if is_enum_backed {
+                writeln!(w, "let value = {typ}::from(value);")?;
             }
-            writeln!(w, "}}")?;
-            writeln!(w)?;
-
-            writeln!(w, "/// Set raw value of '{}'", signal.name)?;
-            writeln!(w, "#[inline(always)]")?;
-            writeln!(
-                w,
-                "{visibility}fn set_{field}_raw(&mut self, value: {typ}) -> Result<(), CanError> {{",
-            )?;
-            {
-                let mut w = PadAdapter::wrap(w);
-                self.render_set_signal_body(&mut w, signal, msg)?;
-            }
-            writeln!(w, "}}")?;
-            writeln!(w)?;
-        } else {
-            writeln!(w, "/// Set value of '{}'", signal.name)?;
-            writeln!(w, "#[inline(always)]")?;
-            writeln!(
-                w,
-                "{visibility}fn set_{field}(&mut self, value: {typ}) -> Result<(), CanError> {{",
-            )?;
-            {
-                let mut w = PadAdapter::wrap(w);
-                self.render_set_signal_body(&mut w, signal, msg)?;
-            }
-            writeln!(w, "}}")?;
-            writeln!(w)?;
+            self.render_set_signal_body(&mut w, signal, msg)?;
         }
+        writeln!(w, "}}")?;
+        writeln!(w)?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -797,8 +797,9 @@ impl Config<'_> {
         let field = signal.field_name();
         let typ = ValType::from_signal(signal);
         let param_ty = signal_pub_type(dbc, msg, signal);
+        let is_enum_backed = param_ty != typ.to_string();
 
-        if param_ty != typ.to_string() {
+        if is_enum_backed {
             writeln!(w, "/// Set value of '{}'", signal.name)?;
             writeln!(w, "#[inline(always)]")?;
             writeln!(
@@ -1542,9 +1543,9 @@ impl Config<'_> {
                     .iter()
                     .map(|signal| {
                         let field = signal.field_name();
-                        if signal_pub_type(dbc, msg, signal)
-                            != ValType::from_signal(signal).to_string()
-                        {
+                        let is_enum_backed = signal_pub_type(dbc, msg, signal)
+                            != ValType::from_signal(signal).to_string();
+                        if is_enum_backed {
                             format!("{}::_Other({field})", enum_name(msg, signal))
                         } else {
                             field

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -796,15 +796,15 @@ impl Config<'_> {
 
         let field = signal.field_name();
         let typ = ValType::from_signal(signal);
-        let param_ty = signal_pub_type(dbc, msg, signal);
-        let is_enum_backed = param_ty != typ.to_string();
+        let param_type = signal_pub_type(dbc, msg, signal);
+        let is_enum_backed = param_type != typ.to_string();
 
         if is_enum_backed {
             writeln!(w, "/// Set value of '{}'", signal.name)?;
             writeln!(w, "#[inline(always)]")?;
             writeln!(
                 w,
-                "{visibility}fn set_{field}(&mut self, value: {param_ty}) -> Result<(), CanError> {{",
+                "{visibility}fn set_{field}(&mut self, value: {param_type}) -> Result<(), CanError> {{",
             )?;
             {
                 let mut w = PadAdapter::wrap(w);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,14 +372,14 @@ impl Config<'_> {
 
             self.render_attribute_structs(&mut w, msg, dbc)?;
 
-            writeln!(w, "/// Construct new {} from values", msg.name)?;
+            writeln!(w, "/// Construct new '{}' from values", msg.name)?;
             let args = msg
                 .signals
                 .iter()
                 .filter_map(|signal| {
                     if matches!(signal.multiplexer_indicator, Plain | Multiplexor) {
                         let field = signal.field_name();
-                        let typ = ValType::from_signal(signal);
+                        let typ = signal_pub_type(dbc, msg, signal);
                         Some(format!("{field}: {typ}"))
                     } else {
                         None
@@ -426,7 +426,7 @@ impl Config<'_> {
                         .render_signal(&mut w, signal, dbc, msg)
                         .with_context(|| format!("write signal impl `{}`", signal.name))?,
                     Multiplexor => {
-                        self.render_multiplexor_signal(&mut w, signal, msg)?;
+                        self.render_multiplexor_signal(&mut w, signal, dbc, msg)?;
                     }
                     MultiplexedSignal(_) | MultiplexorAndMultiplexedSignal(_) => {}
                 }
@@ -470,7 +470,7 @@ impl Config<'_> {
         self.impl_defmt
             .fmt_cfg(&mut *w, |w| render_defmt_impl(w, msg))?;
         self.impl_arbitrary
-            .fmt_cfg(&mut *w, |w| self.render_arbitrary(w, msg))?;
+            .fmt_cfg(&mut *w, |w| self.render_arbitrary(w, dbc, msg))?;
 
         let enums_for_this_message = dbc.value_descriptions.iter().filter_map(|x| {
             if let ValueDescription::Signal {
@@ -685,7 +685,7 @@ impl Config<'_> {
         dbc: &Dbc,
         msg: &Message,
     ) -> Result<()> {
-        writeln!(w, "/// {}", signal.name)?;
+        writeln!(w, "/// Get value of '{}'", signal.name)?;
         if let Some(comment) = dbc.signal_comment(msg.id, &signal.name) {
             writeln!(w, "///")?;
             for line in comment.trim().lines() {
@@ -756,7 +756,7 @@ impl Config<'_> {
             writeln!(w)?;
         }
 
-        writeln!(w, "/// Get raw value of {}", signal.name)?;
+        writeln!(w, "/// Get raw value of '{}'", signal.name)?;
         writeln!(w, "///")?;
         writeln!(w, "/// - Start bit: {}", signal.start_bit)?;
         writeln!(w, "/// - Signal size: {} bits", signal.size)?;
@@ -774,15 +774,18 @@ impl Config<'_> {
         writeln!(w, "}}")?;
         writeln!(w)?;
 
-        self.render_set_signal(w, signal, msg)?;
+        self.render_set_signal(w, signal, dbc, msg)?;
 
         Ok(())
     }
 
-    fn render_set_signal(&self, w: &mut impl Write, signal: &Signal, msg: &Message) -> Result<()> {
-        writeln!(w, "/// Set value of {}", signal.name)?;
-        writeln!(w, "#[inline(always)]")?;
-
+    fn render_set_signal(
+        &self,
+        w: &mut impl Write,
+        signal: &Signal,
+        dbc: &Dbc,
+        msg: &Message,
+    ) -> Result<()> {
         // To avoid accidentally changing the multiplexor value without changing
         // the signals accordingly this fn is kept private for multiplexors.
         let visibility = if signal.multiplexer_indicator == Multiplexor {
@@ -793,42 +796,82 @@ impl Config<'_> {
 
         let field = signal.field_name();
         let typ = ValType::from_signal(signal);
-        writeln!(
-            w,
-            "{visibility}fn set_{field}(&mut self, value: {typ}) -> Result<(), CanError> {{",
-        )?;
+        let param_ty = signal_pub_type(dbc, msg, signal);
 
-        {
-            let mut w = PadAdapter::wrap(w);
-
-            if signal.size != 1 {
-                if let FeatureConfig::Gated(gate) = self.check_ranges {
-                    writeln!(w, r"#[cfg(feature = {gate:?})]")?;
-                }
-
-                if let FeatureConfig::Gated(..) | FeatureConfig::Always = self.check_ranges {
-                    let typ = ValType::from_signal(signal);
-                    let min = signal.min;
-                    let max = signal.max;
-                    writeln!(w, r"if value < {min}_{typ} || {max}_{typ} < value {{")?;
-
-                    {
-                        let mut w = PadAdapter::wrap(&mut w);
-                        let typ = msg.type_name();
-                        writeln!(
-                            w,
-                            r"return Err(CanError::ParameterOutOfRange {{ message_id: {typ}::MESSAGE_ID }});",
-                        )?;
-                    }
-
-                    writeln!(w, r"}}")?;
-                }
+        if param_ty != typ.to_string() {
+            writeln!(w, "/// Set value of '{}'", signal.name)?;
+            writeln!(w, "#[inline(always)]")?;
+            writeln!(
+                w,
+                "{visibility}fn set_{field}(&mut self, value: {param_ty}) -> Result<(), CanError> {{",
+            )?;
+            {
+                let mut w = PadAdapter::wrap(w);
+                writeln!(w, "self.set_{field}_raw({typ}::from(value))")?;
             }
-            signal_to_payload(&mut w, signal, msg).context("signal to payload")?;
+            writeln!(w, "}}")?;
+            writeln!(w)?;
+
+            writeln!(w, "/// Set raw value of '{}'", signal.name)?;
+            writeln!(w, "#[inline(always)]")?;
+            writeln!(
+                w,
+                "{visibility}fn set_{field}_raw(&mut self, value: {typ}) -> Result<(), CanError> {{",
+            )?;
+            {
+                let mut w = PadAdapter::wrap(w);
+                self.render_set_signal_body(&mut w, signal, msg)?;
+            }
+            writeln!(w, "}}")?;
+            writeln!(w)?;
+        } else {
+            writeln!(w, "/// Set value of '{}'", signal.name)?;
+            writeln!(w, "#[inline(always)]")?;
+            writeln!(
+                w,
+                "{visibility}fn set_{field}(&mut self, value: {typ}) -> Result<(), CanError> {{",
+            )?;
+            {
+                let mut w = PadAdapter::wrap(w);
+                self.render_set_signal_body(&mut w, signal, msg)?;
+            }
+            writeln!(w, "}}")?;
+            writeln!(w)?;
         }
 
-        writeln!(w, "}}")?;
-        writeln!(w)?;
+        Ok(())
+    }
+
+    fn render_set_signal_body(
+        &self,
+        w: &mut impl Write,
+        signal: &Signal,
+        msg: &Message,
+    ) -> Result<()> {
+        if signal.size != 1 {
+            if let FeatureConfig::Gated(gate) = self.check_ranges {
+                writeln!(w, r"#[cfg(feature = {gate:?})]")?;
+            }
+
+            if let FeatureConfig::Gated(..) | FeatureConfig::Always = self.check_ranges {
+                let typ = ValType::from_signal(signal);
+                let min = signal.min;
+                let max = signal.max;
+                writeln!(w, r"if value < {min}_{typ} || {max}_{typ} < value {{")?;
+
+                {
+                    let mut w = PadAdapter::wrap(&mut *w);
+                    let typ = msg.type_name();
+                    writeln!(
+                        w,
+                        r"return Err(CanError::ParameterOutOfRange {{ message_id: {typ}::MESSAGE_ID }});",
+                    )?;
+                }
+
+                writeln!(w, r"}}")?;
+            }
+        }
+        signal_to_payload(&mut *w, signal, msg).context("signal to payload")?;
 
         Ok(())
     }
@@ -837,9 +880,10 @@ impl Config<'_> {
         &self,
         w: &mut impl Write,
         signal: &Signal,
+        dbc: &Dbc,
         msg: &Message,
     ) -> Result<()> {
-        writeln!(w, "/// Get raw value of {}", signal.name)?;
+        writeln!(w, "/// Get raw value of '{}'", signal.name)?;
         writeln!(w, "///")?;
         writeln!(w, "/// - Start bit: {}", signal.start_bit)?;
         writeln!(w, "/// - Signal size: {} bits", signal.size)?;
@@ -906,7 +950,7 @@ impl Config<'_> {
         }
         writeln!(w, "}}")?;
 
-        self.render_set_signal(w, signal, msg)?;
+        self.render_set_signal(w, signal, dbc, msg)?;
 
         for switch_index in multiplexer_indexes {
             render_set_signal_multiplexer(w, signal, msg, switch_index)?;
@@ -999,7 +1043,7 @@ fn render_set_signal_multiplexer(
     msg: &Message,
     switch_index: u64,
 ) -> Result<()> {
-    writeln!(w, "/// Set value of {}", multiplexor.name)?;
+    writeln!(w, "/// Set value of '{}'", multiplexor.name)?;
     writeln!(w, "#[inline(always)]")?;
     writeln!(
         w,
@@ -1068,6 +1112,21 @@ fn le_start_end_bit(signal: &Signal, msg: &Message) -> Result<(u64, u64)> {
         "signal ends at {end_bit}, but message is only {msg_bits} bits",
     );
     Ok((start_bit, end_bit))
+}
+
+/// Public type of a signal as seen by `new()` and `set_*`. This is the
+/// enum when the signal has one (and isn't the multiplexor selector), otherwise
+/// it is the raw primitive type.
+fn signal_pub_type(dbc: &Dbc, msg: &Message, signal: &Signal) -> String {
+    if signal.multiplexer_indicator != Multiplexor
+        && dbc
+            .value_descriptions_for_signal(msg.id, &signal.name)
+            .is_some()
+    {
+        enum_name(msg, signal)
+    } else {
+        ValType::from_signal(signal).to_string()
+    }
 }
 
 fn signal_from_payload(w: &mut impl Write, signal: &Signal, msg: &Message) -> Result<()> {
@@ -1450,7 +1509,7 @@ impl Config<'_> {
         Ok(())
     }
 
-    fn render_arbitrary(&self, w: &mut impl Write, msg: &Message) -> Result<()> {
+    fn render_arbitrary(&self, w: &mut impl Write, dbc: &Dbc, msg: &Message) -> Result<()> {
         writeln!(w, "{ALLOW_LINTS}")?;
         self.write_allow_dead_code(w)?;
         let typ = msg.type_name();
@@ -1481,7 +1540,16 @@ impl Config<'_> {
 
                 let args: Vec<String> = filtered_signals
                     .iter()
-                    .map(|signal| signal.field_name())
+                    .map(|signal| {
+                        let field = signal.field_name();
+                        if signal_pub_type(dbc, msg, signal)
+                            != ValType::from_signal(signal).to_string()
+                        {
+                            format!("{}::_Other({field})", enum_name(msg, signal))
+                        } else {
+                            field
+                        }
+                    })
                     .collect();
 
                 writeln!(

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -184,25 +184,6 @@ fn enum_setters_and_getters_are_symmetrical() {
 }
 
 #[test]
-fn raw_setter_mirrors_raw_getter() {
-    let mut bar = Bar::new(1, 2.0, BarThree::Onest, BarFour::Onest, BarType::X1on).unwrap();
-
-    bar.set_three_raw(2).unwrap();
-    assert_eq!(bar.three_raw(), 2);
-    assert_eq!(bar.three(), BarThree::Oner);
-
-    assert_eq!(
-        bar.set_three_raw(8),
-        Err(CanError::ParameterOutOfRange {
-            message_id: Id::Standard(StandardId::new(512).unwrap())
-        })
-    );
-
-    bar.set_xtype_raw(false).unwrap();
-    assert_eq!(bar.xtype(), BarType::X0off);
-}
-
-#[test]
 fn negative_factor() {
     assert_eq!(
         NegativeFactorTest::UNSIGNED_NEGATIVE_FACTOR_SIGNAL_MIN,

--- a/testing/can-messages/tests/all.rs
+++ b/testing/can-messages/tests/all.rs
@@ -5,15 +5,15 @@
 )]
 
 use can_messages::{
-    Amet, Bar, BarThree, CanError, Foo, LargerIntsWithOffsets, MsgExtendedId, MultiplexTest,
-    MultiplexTestMultiplexorIndex, MultiplexTestMultiplexorM0, NegativeFactorTest,
+    Amet, Bar, BarFour, BarThree, BarType, CanError, Foo, LargerIntsWithOffsets, MsgExtendedId,
+    MultiplexTest, MultiplexTestMultiplexorIndex, MultiplexTestMultiplexorM0, NegativeFactorTest,
     TruncatedBeSignal, TruncatedLeSignal,
 };
 use embedded_can::{ExtendedId, Id, StandardId};
 
 #[test]
 fn check_range_value_error() {
-    let result = Bar::new(1, 2.0, 3, 4, true);
+    let result = Bar::new(1, 2.0, BarThree::Onest, BarFour::_Other(4), BarType::X1on);
     assert_eq!(
         result.unwrap_err(),
         CanError::ParameterOutOfRange {
@@ -24,7 +24,7 @@ fn check_range_value_error() {
 
 #[test]
 fn check_range_value_valid() {
-    let result = Bar::new(1, 2.0, 3, 3, true);
+    let result = Bar::new(1, 2.0, BarThree::Onest, BarFour::Onest, BarType::X1on);
     assert!(result.is_ok());
 }
 
@@ -141,14 +141,14 @@ fn offset_integers() {
 
 #[test]
 fn debug_impl() {
-    let result = Bar::new(1, 2.0, 3, 3, true).unwrap();
+    let result = Bar::new(1, 2.0, BarThree::Onest, BarFour::Onest, BarType::X1on).unwrap();
     let dbg = format!("{result:?}");
     assert_eq!(&dbg, "Bar([5, 94, 0, 64, 0, 0, 0, 0])");
 }
 
 #[test]
 fn debug_alternative_impl() {
-    let result = Bar::new(1, 2.0, 3, 3, true).unwrap();
+    let result = Bar::new(1, 2.0, BarThree::Onest, BarFour::Onest, BarType::X1on).unwrap();
     let dbg = format!("{result:#?}");
     assert_eq!(
         &dbg,
@@ -160,6 +160,46 @@ fn debug_alternative_impl() {
 fn from_enum_into_raw() {
     let raw: u8 = BarThree::Onest.into();
     assert_eq!(raw, 3);
+}
+
+#[test]
+fn enum_setters_and_getters_are_symmetrical() {
+    let mut bar = Bar::new(1, 2.0, BarThree::Onest, BarFour::Onest, BarType::X1on).unwrap();
+
+    // The setter accepts the enum directly.
+    bar.set_three(BarThree::Oner).unwrap();
+    assert_eq!(bar.three(), BarThree::Oner);
+
+    // Raw / undescribed values remain settable via the `_Other` variant.
+    bar.set_three(BarThree::_Other(3)).unwrap();
+    assert_eq!(bar.three(), BarThree::Onest);
+
+    // Out-of-range raw values still produce an error.
+    assert_eq!(
+        bar.set_three(BarThree::_Other(8)),
+        Err(CanError::ParameterOutOfRange {
+            message_id: Id::Standard(StandardId::new(512).unwrap())
+        })
+    );
+}
+
+#[test]
+fn raw_setter_mirrors_raw_getter() {
+    let mut bar = Bar::new(1, 2.0, BarThree::Onest, BarFour::Onest, BarType::X1on).unwrap();
+
+    bar.set_three_raw(2).unwrap();
+    assert_eq!(bar.three_raw(), 2);
+    assert_eq!(bar.three(), BarThree::Oner);
+
+    assert_eq!(
+        bar.set_three_raw(8),
+        Err(CanError::ParameterOutOfRange {
+            message_id: Id::Standard(StandardId::new(512).unwrap())
+        })
+    );
+
+    bar.set_xtype_raw(false).unwrap();
+    assert_eq!(bar.xtype(), BarType::X0off);
 }
 
 #[test]

--- a/testing/cantools-messages/src/lib.rs
+++ b/testing/cantools-messages/src/lib.rs
@@ -68,7 +68,8 @@ fn pack_message_signed_positive() {
 
 #[test]
 fn pack_big_endian_signal_with_start_bit_zero() {
-    let dbc_codegen_bar = can_messages::Dolor::new(can_messages::DolorOneFloat::_Other(0.5)).unwrap();
+    let dbc_codegen_bar =
+        can_messages::Dolor::new(can_messages::DolorOneFloat::_Other(0.5)).unwrap();
     let one_float = unsafe { example_dolor_one_float_encode(0.5) };
 
     let dolor = example_dolor_t { one_float };

--- a/testing/cantools-messages/src/lib.rs
+++ b/testing/cantools-messages/src/lib.rs
@@ -16,7 +16,14 @@ use msg_bindings::*;
 
 #[test]
 fn pack_message() {
-    let dbc_codegen_bar = can_messages::Bar::new(3, 2.0, 4, 2, false).unwrap();
+    let dbc_codegen_bar = can_messages::Bar::new(
+        3,
+        2.0,
+        can_messages::BarThree::_Other(4),
+        can_messages::BarFour::Oner,
+        can_messages::BarType::X0off,
+    )
+    .unwrap();
     let one = unsafe { example_bar_one_encode(3.0) };
     let two = unsafe { example_bar_two_encode(2.0) };
     let three = unsafe { example_bar_three_encode(4.0) };
@@ -61,7 +68,7 @@ fn pack_message_signed_positive() {
 
 #[test]
 fn pack_big_endian_signal_with_start_bit_zero() {
-    let dbc_codegen_bar = can_messages::Dolor::new(0.5).unwrap();
+    let dbc_codegen_bar = can_messages::Dolor::new(can_messages::DolorOneFloat::_Other(0.5)).unwrap();
     let one_float = unsafe { example_dolor_one_float_encode(0.5) };
 
     let dolor = example_dolor_t { one_float };

--- a/tests-snapshots/canpy/DBC_template.snap.rs
+++ b/tests-snapshots/canpy/DBC_template.snap.rs
@@ -341,11 +341,7 @@ impl CanMultiplexedMultiplexerM0 {
     /// Set value of 'Value0'
     #[inline(always)]
     pub fn set_value0(&mut self, value: CanMultiplexedValue0) -> Result<(), CanError> {
-        self.set_value0_raw(u8::from(value))
-    }
-    /// Set raw value of 'Value0'
-    #[inline(always)]
-    pub fn set_value0_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CanMultiplexed::MESSAGE_ID,
@@ -422,11 +418,7 @@ impl CanMultiplexedMultiplexerM1 {
     /// Set value of 'Value1'
     #[inline(always)]
     pub fn set_value1(&mut self, value: CanMultiplexedValue1) -> Result<(), CanError> {
-        self.set_value1_raw(u8::from(value))
-    }
-    /// Set raw value of 'Value1'
-    #[inline(always)]
-    pub fn set_value1_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CanMultiplexed::MESSAGE_ID,

--- a/tests-snapshots/canpy/DBC_template.snap.rs
+++ b/tests-snapshots/canpy/DBC_template.snap.rs
@@ -83,7 +83,7 @@ impl CanMultiplexed {
     pub const VALUE0_MAX: u8 = 0_u8;
     pub const MULTIPLEXER_MIN: u8 = 0_u8;
     pub const MULTIPLEXER_MAX: u8 = 0_u8;
-    /// Construct new CANMultiplexed from values
+    /// Construct new 'CANMultiplexed' from values
     pub fn new(multiplexer: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_multiplexer(multiplexer)?;
@@ -93,7 +93,7 @@ impl CanMultiplexed {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Get raw value of Multiplexer
+    /// Get raw value of 'Multiplexer'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -131,7 +131,7 @@ impl CanMultiplexed {
             }
         }
     }
-    /// Set value of Multiplexer
+    /// Set value of 'Multiplexer'
     #[inline(always)]
     fn set_multiplexer(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -149,7 +149,7 @@ impl CanMultiplexed {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexer
+    /// Set value of 'Multiplexer'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -161,7 +161,7 @@ impl CanMultiplexed {
         self.set_multiplexer(0)?;
         Ok(())
     }
-    /// Set value of Multiplexer
+    /// Set value of 'Multiplexer'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -308,7 +308,7 @@ impl CanMultiplexedMultiplexerM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 2] }
     }
-    /// Value0
+    /// Get value of 'Value0'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -324,7 +324,7 @@ impl CanMultiplexedMultiplexerM0 {
             _ => CanMultiplexedValue0::_Other(self.value0_raw()),
         }
     }
-    /// Get raw value of Value0
+    /// Get raw value of 'Value0'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -338,9 +338,14 @@ impl CanMultiplexedMultiplexerM0 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Value0
+    /// Set value of 'Value0'
     #[inline(always)]
-    pub fn set_value0(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_value0(&mut self, value: CanMultiplexedValue0) -> Result<(), CanError> {
+        self.set_value0_raw(u8::from(value))
+    }
+    /// Set raw value of 'Value0'
+    #[inline(always)]
+    pub fn set_value0_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CanMultiplexed::MESSAGE_ID,
@@ -383,7 +388,7 @@ impl CanMultiplexedMultiplexerM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 2] }
     }
-    /// Value1
+    /// Get value of 'Value1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -400,7 +405,7 @@ impl CanMultiplexedMultiplexerM1 {
             _ => CanMultiplexedValue1::_Other(self.value1_raw()),
         }
     }
-    /// Get raw value of Value1
+    /// Get raw value of 'Value1'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -414,9 +419,14 @@ impl CanMultiplexedMultiplexerM1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Value1
+    /// Set value of 'Value1'
     #[inline(always)]
-    pub fn set_value1(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_value1(&mut self, value: CanMultiplexedValue1) -> Result<(), CanError> {
+        self.set_value1_raw(u8::from(value))
+    }
+    /// Set raw value of 'Value1'
+    #[inline(always)]
+    pub fn set_value1_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CanMultiplexed::MESSAGE_ID,
@@ -460,7 +470,7 @@ impl CanMessage {
     pub const SIGNAL1_MAX: u64 = 100_u64;
     pub const SIGNAL0_MIN: i32 = 0_i32;
     pub const SIGNAL0_MAX: i32 = 0_i32;
-    /// Construct new CANMessage from values
+    /// Construct new 'CANMessage' from values
     pub fn new(signal1: u64, signal0: i32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal1(signal1)?;
@@ -471,7 +481,7 @@ impl CanMessage {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Signal1
+    /// Get value of 'Signal1'
     ///
     /// - Min: 0
     /// - Max: 100
@@ -481,7 +491,7 @@ impl CanMessage {
     pub fn signal1(&self) -> u64 {
         self.signal1_raw()
     }
-    /// Get raw value of Signal1
+    /// Get raw value of 'Signal1'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -495,7 +505,7 @@ impl CanMessage {
         let factor = 100;
         u64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal1
+    /// Set value of 'Signal1'
     #[inline(always)]
     pub fn set_signal1(&mut self, value: u64) -> Result<(), CanError> {
         if value < 0_u64 || 100_u64 < value {
@@ -513,7 +523,7 @@ impl CanMessage {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Signal0
+    /// Get value of 'Signal0'
     ///
     /// First signal in this message
     ///
@@ -525,7 +535,7 @@ impl CanMessage {
     pub fn signal0(&self) -> i32 {
         self.signal0_raw()
     }
-    /// Get raw value of Signal0
+    /// Get raw value of 'Signal0'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -540,7 +550,7 @@ impl CanMessage {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal0
+    /// Set value of 'Signal0'
     #[inline(always)]
     pub fn set_signal0(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
@@ -111,11 +111,7 @@ impl Control {
     /// Set value of 'state'
     #[inline(always)]
     pub fn set_state(&mut self, value: ControlState) -> Result<(), CanError> {
-        self.set_state_raw(u8::from(value))
-    }
-    /// Set raw value of 'state'
-    #[inline(always)]
-    pub fn set_state_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 100_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Control::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_.snap.rs
@@ -70,8 +70,8 @@ impl Control {
     pub const MESSAGE_SIZE: usize = 7;
     pub const STATE_MIN: u8 = 0_u8;
     pub const STATE_MAX: u8 = 100_u8;
-    /// Construct new CONTROL from values
-    pub fn new(state: u8) -> Result<Self, CanError> {
+    /// Construct new 'CONTROL' from values
+    pub fn new(state: ControlState) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 7] };
         res.set_state(state)?;
         Ok(res)
@@ -80,7 +80,7 @@ impl Control {
     pub fn raw(&self) -> &[u8; 7] {
         &self.raw
     }
-    /// state
+    /// Get value of 'state'
     ///
     /// - Min: 0
     /// - Max: 100
@@ -94,7 +94,7 @@ impl Control {
             _ => ControlState::_Other(self.state_raw()),
         }
     }
-    /// Get raw value of state
+    /// Get raw value of 'state'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -108,9 +108,14 @@ impl Control {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of state
+    /// Set value of 'state'
     #[inline(always)]
-    pub fn set_state(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_state(&mut self, value: ControlState) -> Result<(), CanError> {
+        self.set_state_raw(u8::from(value))
+    }
+    /// Set raw value of 'state'
+    #[inline(always)]
+    pub fn set_state_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 100_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Control::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
@@ -111,11 +111,7 @@ impl Message1 {
     /// Set value of 'signal_1'
     #[inline(always)]
     pub fn set_signal_1(&mut self, value: Message1Signal1) -> Result<(), CanError> {
-        self.set_signal_1_raw(u8::from(value))
-    }
-    /// Set raw value of 'signal_1'
-    #[inline(always)]
-    pub fn set_signal_1_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 100_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Message1::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
+++ b/tests-snapshots/dbc-cantools/BU_BO_REL_Message.snap.rs
@@ -70,8 +70,8 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 7;
     pub const SIGNAL_1_MIN: u8 = 0_u8;
     pub const SIGNAL_1_MAX: u8 = 100_u8;
-    /// Construct new message_1 from values
-    pub fn new(signal_1: u8) -> Result<Self, CanError> {
+    /// Construct new 'message_1' from values
+    pub fn new(signal_1: Message1Signal1) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 7] };
         res.set_signal_1(signal_1)?;
         Ok(res)
@@ -80,7 +80,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 7] {
         &self.raw
     }
-    /// signal_1
+    /// Get value of 'signal_1'
     ///
     /// - Min: 0
     /// - Max: 100
@@ -94,7 +94,7 @@ impl Message1 {
             _ => Message1Signal1::_Other(self.signal_1_raw()),
         }
     }
-    /// Get raw value of signal_1
+    /// Get raw value of 'signal_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -108,9 +108,14 @@ impl Message1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of signal_1
+    /// Set value of 'signal_1'
     #[inline(always)]
-    pub fn set_signal_1(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_signal_1(&mut self, value: Message1Signal1) -> Result<(), CanError> {
+        self.set_signal_1_raw(u8::from(value))
+    }
+    /// Set raw value of 'signal_1'
+    #[inline(always)]
+    pub fn set_signal_1_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 100_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Message1::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/CamelCaseEmpty.snap.rs
+++ b/tests-snapshots/dbc-cantools/CamelCaseEmpty.snap.rs
@@ -68,7 +68,7 @@ impl Message1 {
         StandardId::new_unchecked(0x400)
     });
     pub const MESSAGE_SIZE: usize = 5;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 5] };
         Ok(res)

--- a/tests-snapshots/dbc-cantools/abs.snap.rs
+++ b/tests-snapshots/dbc-cantools/abs.snap.rs
@@ -5189,11 +5189,7 @@ impl Bremse53 {
     /// Set value of 'Diag_FL'
     #[inline(always)]
     pub fn set_diag_fl(&mut self, value: Bremse53DiagFl) -> Result<(), CanError> {
-        self.set_diag_fl_raw(u8::from(value))
-    }
-    /// Set raw value of 'Diag_FL'
-    #[inline(always)]
-    pub fn set_diag_fl_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,
@@ -5245,11 +5241,7 @@ impl Bremse53 {
     /// Set value of 'Diag_FR'
     #[inline(always)]
     pub fn set_diag_fr(&mut self, value: Bremse53DiagFr) -> Result<(), CanError> {
-        self.set_diag_fr_raw(u8::from(value))
-    }
-    /// Set raw value of 'Diag_FR'
-    #[inline(always)]
-    pub fn set_diag_fr_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,
@@ -5301,11 +5293,7 @@ impl Bremse53 {
     /// Set value of 'Diag_RL'
     #[inline(always)]
     pub fn set_diag_rl(&mut self, value: Bremse53DiagRl) -> Result<(), CanError> {
-        self.set_diag_rl_raw(u8::from(value))
-    }
-    /// Set raw value of 'Diag_RL'
-    #[inline(always)]
-    pub fn set_diag_rl_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,
@@ -5357,11 +5345,7 @@ impl Bremse53 {
     /// Set value of 'Diag_RR'
     #[inline(always)]
     pub fn set_diag_rr(&mut self, value: Bremse53DiagRr) -> Result<(), CanError> {
-        self.set_diag_rr_raw(u8::from(value))
-    }
-    /// Set raw value of 'Diag_RR'
-    #[inline(always)]
-    pub fn set_diag_rr_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,
@@ -5607,11 +5591,7 @@ impl Bremse53 {
         &mut self,
         value: Bremse53AbsFaultInfo,
     ) -> Result<(), CanError> {
-        self.set_abs_fault_info_raw(u8::from(value))
-    }
-    /// Set raw value of 'ABS_fault_info'
-    #[inline(always)]
-    pub fn set_abs_fault_info_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/abs.snap.rs
+++ b/tests-snapshots/dbc-cantools/abs.snap.rs
@@ -127,7 +127,7 @@ impl Bremse33 {
     pub const WHLSPEED_RL_MAX: f32 = 100_f32;
     pub const WHLSPEED_RR_MIN: f32 = 0_f32;
     pub const WHLSPEED_RR_MAX: f32 = 100_f32;
-    /// Construct new BREMSE_33 from values
+    /// Construct new 'BREMSE_33' from values
     pub fn new(
         whlspeed_fl: f32,
         whlspeed_fr: f32,
@@ -145,7 +145,7 @@ impl Bremse33 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// whlspeed_FL
+    /// Get value of 'whlspeed_FL'
     ///
     /// Radgeschwindigkeit / wheel speed absCtrl FL
     ///
@@ -157,7 +157,7 @@ impl Bremse33 {
     pub fn whlspeed_fl(&self) -> f32 {
         self.whlspeed_fl_raw()
     }
-    /// Get raw value of whlspeed_FL
+    /// Get raw value of 'whlspeed_FL'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -172,7 +172,7 @@ impl Bremse33 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of whlspeed_FL
+    /// Set value of 'whlspeed_FL'
     #[inline(always)]
     pub fn set_whlspeed_fl(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -186,7 +186,7 @@ impl Bremse33 {
         self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
         Ok(())
     }
-    /// whlspeed_FR
+    /// Get value of 'whlspeed_FR'
     ///
     /// Radgeschwindigkeit / wheel speed absCtrl FR
     ///
@@ -198,7 +198,7 @@ impl Bremse33 {
     pub fn whlspeed_fr(&self) -> f32 {
         self.whlspeed_fr_raw()
     }
-    /// Get raw value of whlspeed_FR
+    /// Get raw value of 'whlspeed_FR'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -213,7 +213,7 @@ impl Bremse33 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of whlspeed_FR
+    /// Set value of 'whlspeed_FR'
     #[inline(always)]
     pub fn set_whlspeed_fr(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -227,7 +227,7 @@ impl Bremse33 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// whlspeed_RL
+    /// Get value of 'whlspeed_RL'
     ///
     /// Radgeschwindigkeit / wheel speed absCtrl RL
     ///
@@ -239,7 +239,7 @@ impl Bremse33 {
     pub fn whlspeed_rl(&self) -> f32 {
         self.whlspeed_rl_raw()
     }
-    /// Get raw value of whlspeed_RL
+    /// Get raw value of 'whlspeed_RL'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -254,7 +254,7 @@ impl Bremse33 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of whlspeed_RL
+    /// Set value of 'whlspeed_RL'
     #[inline(always)]
     pub fn set_whlspeed_rl(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -268,7 +268,7 @@ impl Bremse33 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// whlspeed_RR
+    /// Get value of 'whlspeed_RR'
     ///
     /// Radgeschwindigkeit / wheel speed absCtrl RR
     ///
@@ -280,7 +280,7 @@ impl Bremse33 {
     pub fn whlspeed_rr(&self) -> f32 {
         self.whlspeed_rr_raw()
     }
-    /// Get raw value of whlspeed_RR
+    /// Get raw value of 'whlspeed_RR'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -295,7 +295,7 @@ impl Bremse33 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of whlspeed_RR
+    /// Set value of 'whlspeed_RR'
     #[inline(always)]
     pub fn set_whlspeed_rr(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -371,7 +371,7 @@ impl Bremse10 {
         StandardId::new_unchecked(0x140)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new BREMSE_10 from values
+    /// Construct new 'BREMSE_10' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -442,7 +442,7 @@ impl Bremse11 {
         StandardId::new_unchecked(0x141)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new BREMSE_11 from values
+    /// Construct new 'BREMSE_11' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -513,7 +513,7 @@ impl Bremse12 {
         StandardId::new_unchecked(0x142)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new BREMSE_12 from values
+    /// Construct new 'BREMSE_12' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -584,7 +584,7 @@ impl Bremse13 {
         StandardId::new_unchecked(0x143)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new BREMSE_13 from values
+    /// Construct new 'BREMSE_13' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -655,7 +655,7 @@ impl DrsRxId0 {
         StandardId::new_unchecked(0x75)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new DRS_RX_ID0 from values
+    /// Construct new 'DRS_RX_ID0' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -730,7 +730,7 @@ impl Mm510Tx1 {
     pub const YAW_RATE_MAX: f32 = 163.83_f32;
     pub const AY1_MIN: f32 = -4.1768_f32;
     pub const AY1_MAX: f32 = 4.1765_f32;
-    /// Construct new MM5_10_TX1 from values
+    /// Construct new 'MM5_10_TX1' from values
     pub fn new(yaw_rate: f32, ay1: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_yaw_rate(yaw_rate)?;
@@ -741,7 +741,7 @@ impl Mm510Tx1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Yaw_Rate
+    /// Get value of 'Yaw_Rate'
     ///
     /// Measured yaw rate around the Z axle.
     ///
@@ -753,7 +753,7 @@ impl Mm510Tx1 {
     pub fn yaw_rate(&self) -> f32 {
         self.yaw_rate_raw()
     }
-    /// Get raw value of Yaw_Rate
+    /// Get raw value of 'Yaw_Rate'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -768,7 +768,7 @@ impl Mm510Tx1 {
         let offset = -163.84_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Yaw_Rate
+    /// Set value of 'Yaw_Rate'
     #[inline(always)]
     pub fn set_yaw_rate(&mut self, value: f32) -> Result<(), CanError> {
         if value < -163.84_f32 || 163.83_f32 < value {
@@ -782,7 +782,7 @@ impl Mm510Tx1 {
         self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
         Ok(())
     }
-    /// AY1
+    /// Get value of 'AY1'
     ///
     /// Measured lateral acceleration.
     ///
@@ -794,7 +794,7 @@ impl Mm510Tx1 {
     pub fn ay1(&self) -> f32 {
         self.ay1_raw()
     }
-    /// Get raw value of AY1
+    /// Get raw value of 'AY1'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -809,7 +809,7 @@ impl Mm510Tx1 {
         let offset = -4.1768_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AY1
+    /// Set value of 'AY1'
     #[inline(always)]
     pub fn set_ay1(&mut self, value: f32) -> Result<(), CanError> {
         if value < -4.1768_f32 || 4.1765_f32 < value {
@@ -889,7 +889,7 @@ impl Mm510Tx2 {
     pub const ROLL_RATE_MAX: f32 = 163.835_f32;
     pub const AX1_MIN: f32 = -4.1768_f32;
     pub const AX1_MAX: f32 = 4.1765_f32;
-    /// Construct new MM5_10_TX2 from values
+    /// Construct new 'MM5_10_TX2' from values
     pub fn new(roll_rate: f32, ax1: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_roll_rate(roll_rate)?;
@@ -900,7 +900,7 @@ impl Mm510Tx2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Roll_Rate
+    /// Get value of 'Roll_Rate'
     ///
     /// Measured roll rate around the X axle.
     ///
@@ -912,7 +912,7 @@ impl Mm510Tx2 {
     pub fn roll_rate(&self) -> f32 {
         self.roll_rate_raw()
     }
-    /// Get raw value of Roll_Rate
+    /// Get raw value of 'Roll_Rate'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -927,7 +927,7 @@ impl Mm510Tx2 {
         let offset = -163.84_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Roll_Rate
+    /// Set value of 'Roll_Rate'
     #[inline(always)]
     pub fn set_roll_rate(&mut self, value: f32) -> Result<(), CanError> {
         if value < -163.84_f32 || 163.835_f32 < value {
@@ -941,7 +941,7 @@ impl Mm510Tx2 {
         self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
         Ok(())
     }
-    /// AX1
+    /// Get value of 'AX1'
     ///
     /// Measured longitudional acceleration.
     ///
@@ -953,7 +953,7 @@ impl Mm510Tx2 {
     pub fn ax1(&self) -> f32 {
         self.ax1_raw()
     }
-    /// Get raw value of AX1
+    /// Get raw value of 'AX1'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -968,7 +968,7 @@ impl Mm510Tx2 {
         let offset = -4.1768_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AX1
+    /// Set value of 'AX1'
     #[inline(always)]
     pub fn set_ax1(&mut self, value: f32) -> Result<(), CanError> {
         if value < -4.1768_f32 || 4.1765_f32 < value {
@@ -1046,7 +1046,7 @@ impl Mm510Tx3 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const AZ_MIN: f32 = -4.1768_f32;
     pub const AZ_MAX: f32 = 4.1765_f32;
-    /// Construct new MM5_10_TX3 from values
+    /// Construct new 'MM5_10_TX3' from values
     pub fn new(az: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_az(az)?;
@@ -1056,7 +1056,7 @@ impl Mm510Tx3 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// AZ
+    /// Get value of 'AZ'
     ///
     /// Measured vertical acceleration.
     ///
@@ -1068,7 +1068,7 @@ impl Mm510Tx3 {
     pub fn az(&self) -> f32 {
         self.az_raw()
     }
-    /// Get raw value of AZ
+    /// Get raw value of 'AZ'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1083,7 +1083,7 @@ impl Mm510Tx3 {
         let offset = -4.1768_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AZ
+    /// Set value of 'AZ'
     #[inline(always)]
     pub fn set_az(&mut self, value: f32) -> Result<(), CanError> {
         if value < -4.1768_f32 || 4.1765_f32 < value {
@@ -1167,7 +1167,7 @@ impl Bremse2 {
     pub const WHLSPEED_RL_BREMSE2_MAX: f32 = 100_f32;
     pub const WHLSPEED_RR_BREMSE2_MIN: f32 = 0_f32;
     pub const WHLSPEED_RR_BREMSE2_MAX: f32 = 100_f32;
-    /// Construct new BREMSE_2 from values
+    /// Construct new 'BREMSE_2' from values
     pub fn new(
         whlspeed_fl_bremse2: f32,
         whlspeed_fr_bremse2: f32,
@@ -1185,7 +1185,7 @@ impl Bremse2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// whlspeed_FL_Bremse2
+    /// Get value of 'whlspeed_FL_Bremse2'
     ///
     /// Radgeschwindigkeit / wheel speed direct FL
     ///
@@ -1197,7 +1197,7 @@ impl Bremse2 {
     pub fn whlspeed_fl_bremse2(&self) -> f32 {
         self.whlspeed_fl_bremse2_raw()
     }
-    /// Get raw value of whlspeed_FL_Bremse2
+    /// Get raw value of 'whlspeed_FL_Bremse2'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -1212,7 +1212,7 @@ impl Bremse2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of whlspeed_FL_Bremse2
+    /// Set value of 'whlspeed_FL_Bremse2'
     #[inline(always)]
     pub fn set_whlspeed_fl_bremse2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -1226,7 +1226,7 @@ impl Bremse2 {
         self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
         Ok(())
     }
-    /// whlspeed_FR_Bremse2
+    /// Get value of 'whlspeed_FR_Bremse2'
     ///
     /// Radgeschwindigkeit / wheel speed direct FR
     ///
@@ -1238,7 +1238,7 @@ impl Bremse2 {
     pub fn whlspeed_fr_bremse2(&self) -> f32 {
         self.whlspeed_fr_bremse2_raw()
     }
-    /// Get raw value of whlspeed_FR_Bremse2
+    /// Get raw value of 'whlspeed_FR_Bremse2'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1253,7 +1253,7 @@ impl Bremse2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of whlspeed_FR_Bremse2
+    /// Set value of 'whlspeed_FR_Bremse2'
     #[inline(always)]
     pub fn set_whlspeed_fr_bremse2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -1267,7 +1267,7 @@ impl Bremse2 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// whlspeed_RL_Bremse2
+    /// Get value of 'whlspeed_RL_Bremse2'
     ///
     /// Radgeschwindigkeit / wheel speed direct RL
     ///
@@ -1279,7 +1279,7 @@ impl Bremse2 {
     pub fn whlspeed_rl_bremse2(&self) -> f32 {
         self.whlspeed_rl_bremse2_raw()
     }
-    /// Get raw value of whlspeed_RL_Bremse2
+    /// Get raw value of 'whlspeed_RL_Bremse2'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1294,7 +1294,7 @@ impl Bremse2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of whlspeed_RL_Bremse2
+    /// Set value of 'whlspeed_RL_Bremse2'
     #[inline(always)]
     pub fn set_whlspeed_rl_bremse2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -1308,7 +1308,7 @@ impl Bremse2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// whlspeed_RR_Bremse2
+    /// Get value of 'whlspeed_RR_Bremse2'
     ///
     /// Radgeschwindigkeit / wheel speed direct RR
     ///
@@ -1320,7 +1320,7 @@ impl Bremse2 {
     pub fn whlspeed_rr_bremse2(&self) -> f32 {
         self.whlspeed_rr_bremse2_raw()
     }
-    /// Get raw value of whlspeed_RR_Bremse2
+    /// Get raw value of 'whlspeed_RR_Bremse2'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -1335,7 +1335,7 @@ impl Bremse2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of whlspeed_RR_Bremse2
+    /// Set value of 'whlspeed_RR_Bremse2'
     #[inline(always)]
     pub fn set_whlspeed_rr_bremse2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -1412,7 +1412,7 @@ impl AbsSwitch {
     pub const MESSAGE_SIZE: usize = 8;
     pub const ABS_SWITCHPOSITION_MIN: u8 = 0_u8;
     pub const ABS_SWITCHPOSITION_MAX: u8 = 11_u8;
-    /// Construct new ABS_Switch from values
+    /// Construct new 'ABS_Switch' from values
     pub fn new(abs_switchposition: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_abs_switchposition(abs_switchposition)?;
@@ -1422,7 +1422,7 @@ impl AbsSwitch {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// ABS_Switchposition
+    /// Get value of 'ABS_Switchposition'
     ///
     /// Channel to send the swich position via CAN to the ABS.
     ///
@@ -1434,7 +1434,7 @@ impl AbsSwitch {
     pub fn abs_switchposition(&self) -> u8 {
         self.abs_switchposition_raw()
     }
-    /// Get raw value of ABS_Switchposition
+    /// Get raw value of 'ABS_Switchposition'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -1448,7 +1448,7 @@ impl AbsSwitch {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ABS_Switchposition
+    /// Set value of 'ABS_Switchposition'
     #[inline(always)]
     pub fn set_abs_switchposition(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 11_u8 < value {
@@ -1528,7 +1528,7 @@ impl Bremse30 {
         StandardId::new_unchecked(0x340)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new BREMSE_30 from values
+    /// Construct new 'BREMSE_30' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -1601,7 +1601,7 @@ impl Bremse31 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const IDLE_TIME_MIN: u16 = 0_u16;
     pub const IDLE_TIME_MAX: u16 = 0_u16;
-    /// Construct new BREMSE_31 from values
+    /// Construct new 'BREMSE_31' from values
     pub fn new(idle_time: u16) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_idle_time(idle_time)?;
@@ -1611,7 +1611,7 @@ impl Bremse31 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Idle_Time
+    /// Get value of 'Idle_Time'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1621,7 +1621,7 @@ impl Bremse31 {
     pub fn idle_time(&self) -> u16 {
         self.idle_time_raw()
     }
-    /// Get raw value of Idle_Time
+    /// Get raw value of 'Idle_Time'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1635,7 +1635,7 @@ impl Bremse31 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Idle_Time
+    /// Set value of 'Idle_Time'
     #[inline(always)]
     pub fn set_idle_time(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1727,7 +1727,7 @@ impl Bremse32 {
     pub const WHEEL_QUALITY_RL_MAX: u8 = 32_u8;
     pub const WHEEL_QUALITY_RR_MIN: u8 = 0_u8;
     pub const WHEEL_QUALITY_RR_MAX: u8 = 32_u8;
-    /// Construct new BREMSE_32 from values
+    /// Construct new 'BREMSE_32' from values
     pub fn new(
         acc_fa: f32,
         acc_ra: f32,
@@ -1749,7 +1749,7 @@ impl Bremse32 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// acc_FA
+    /// Get value of 'acc_FA'
     ///
     /// Fill level of the fluid reservoir of the front axle.
     ///
@@ -1761,7 +1761,7 @@ impl Bremse32 {
     pub fn acc_fa(&self) -> f32 {
         self.acc_fa_raw()
     }
-    /// Get raw value of acc_FA
+    /// Get raw value of 'acc_FA'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -1776,7 +1776,7 @@ impl Bremse32 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of acc_FA
+    /// Set value of 'acc_FA'
     #[inline(always)]
     pub fn set_acc_fa(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 10_f32 < value {
@@ -1790,7 +1790,7 @@ impl Bremse32 {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// acc_RA
+    /// Get value of 'acc_RA'
     ///
     /// Fill level of the fluid reservoir of the rear axle.
     ///
@@ -1802,7 +1802,7 @@ impl Bremse32 {
     pub fn acc_ra(&self) -> f32 {
         self.acc_ra_raw()
     }
-    /// Get raw value of acc_RA
+    /// Get raw value of 'acc_RA'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -1817,7 +1817,7 @@ impl Bremse32 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of acc_RA
+    /// Set value of 'acc_RA'
     #[inline(always)]
     pub fn set_acc_ra(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 10_f32 < value {
@@ -1831,7 +1831,7 @@ impl Bremse32 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// WheelQuality_FL
+    /// Get value of 'WheelQuality_FL'
     ///
     /// Bit matrix
     /// Bit0 ( 1) Signal Reduced Monitored
@@ -1851,7 +1851,7 @@ impl Bremse32 {
     pub fn wheel_quality_fl(&self) -> u8 {
         self.wheel_quality_fl_raw()
     }
-    /// Get raw value of WheelQuality_FL
+    /// Get raw value of 'WheelQuality_FL'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -1865,7 +1865,7 @@ impl Bremse32 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of WheelQuality_FL
+    /// Set value of 'WheelQuality_FL'
     #[inline(always)]
     pub fn set_wheel_quality_fl(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 32_u8 < value {
@@ -1883,7 +1883,7 @@ impl Bremse32 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// WheelQuality_FR
+    /// Get value of 'WheelQuality_FR'
     ///
     /// Bit matrix
     /// Bit0 ( 1) Signal Reduced Monitored
@@ -1903,7 +1903,7 @@ impl Bremse32 {
     pub fn wheel_quality_fr(&self) -> u8 {
         self.wheel_quality_fr_raw()
     }
-    /// Get raw value of WheelQuality_FR
+    /// Get raw value of 'WheelQuality_FR'
     ///
     /// - Start bit: 40
     /// - Signal size: 8 bits
@@ -1917,7 +1917,7 @@ impl Bremse32 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of WheelQuality_FR
+    /// Set value of 'WheelQuality_FR'
     #[inline(always)]
     pub fn set_wheel_quality_fr(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 32_u8 < value {
@@ -1935,7 +1935,7 @@ impl Bremse32 {
         self.raw.view_bits_mut::<Lsb0>()[40..48].store_le(value);
         Ok(())
     }
-    /// WheelQuality_RL
+    /// Get value of 'WheelQuality_RL'
     ///
     /// Bit matrix
     /// Bit0 ( 1) Signal Reduced Monitored
@@ -1955,7 +1955,7 @@ impl Bremse32 {
     pub fn wheel_quality_rl(&self) -> u8 {
         self.wheel_quality_rl_raw()
     }
-    /// Get raw value of WheelQuality_RL
+    /// Get raw value of 'WheelQuality_RL'
     ///
     /// - Start bit: 48
     /// - Signal size: 8 bits
@@ -1969,7 +1969,7 @@ impl Bremse32 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of WheelQuality_RL
+    /// Set value of 'WheelQuality_RL'
     #[inline(always)]
     pub fn set_wheel_quality_rl(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 32_u8 < value {
@@ -1987,7 +1987,7 @@ impl Bremse32 {
         self.raw.view_bits_mut::<Lsb0>()[48..56].store_le(value);
         Ok(())
     }
-    /// WheelQuality_RR
+    /// Get value of 'WheelQuality_RR'
     ///
     /// Bit matrix
     /// Bit0 ( 1) Signal Reduced Monitored
@@ -2007,7 +2007,7 @@ impl Bremse32 {
     pub fn wheel_quality_rr(&self) -> u8 {
         self.wheel_quality_rr_raw()
     }
-    /// Get raw value of WheelQuality_RR
+    /// Get raw value of 'WheelQuality_RR'
     ///
     /// - Start bit: 56
     /// - Signal size: 8 bits
@@ -2021,7 +2021,7 @@ impl Bremse32 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of WheelQuality_RR
+    /// Set value of 'WheelQuality_RR'
     #[inline(always)]
     pub fn set_wheel_quality_rr(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 32_u8 < value {
@@ -2111,7 +2111,7 @@ impl Bremse51 {
     pub const IF_REVISION_MAX: u8 = 63_u8;
     pub const IF_CHKSUM_MIN: u8 = 0_u8;
     pub const IF_CHKSUM_MAX: u8 = 15_u8;
-    /// Construct new BREMSE_51 from values
+    /// Construct new 'BREMSE_51' from values
     pub fn new(
         ax1_abs_int: f32,
         ay1_abs_int: f32,
@@ -2131,7 +2131,7 @@ impl Bremse51 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// AX1_ABS_int
+    /// Get value of 'AX1_ABS_int'
     ///
     /// Used longitudional acceleration value in the ABS.
     ///
@@ -2143,7 +2143,7 @@ impl Bremse51 {
     pub fn ax1_abs_int(&self) -> f32 {
         self.ax1_abs_int_raw()
     }
-    /// Get raw value of AX1_ABS_int
+    /// Get raw value of 'AX1_ABS_int'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -2158,7 +2158,7 @@ impl Bremse51 {
         let offset = -4.1768_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AX1_ABS_int
+    /// Set value of 'AX1_ABS_int'
     #[inline(always)]
     pub fn set_ax1_abs_int(&mut self, value: f32) -> Result<(), CanError> {
         if value < -4.1768_f32 || 4.1736697_f32 < value {
@@ -2172,7 +2172,7 @@ impl Bremse51 {
         self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
         Ok(())
     }
-    /// AY1_ABS_int
+    /// Get value of 'AY1_ABS_int'
     ///
     /// Used lateral acceleration value in the ABS.
     ///
@@ -2184,7 +2184,7 @@ impl Bremse51 {
     pub fn ay1_abs_int(&self) -> f32 {
         self.ay1_abs_int_raw()
     }
-    /// Get raw value of AY1_ABS_int
+    /// Get raw value of 'AY1_ABS_int'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2199,7 +2199,7 @@ impl Bremse51 {
         let offset = -4.1768_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AY1_ABS_int
+    /// Set value of 'AY1_ABS_int'
     #[inline(always)]
     pub fn set_ay1_abs_int(&mut self, value: f32) -> Result<(), CanError> {
         if value < -4.1768_f32 || 4.1765_f32 < value {
@@ -2213,7 +2213,7 @@ impl Bremse51 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// IF_variant
+    /// Get value of 'IF_variant'
     ///
     /// external info to e.g. MS6 which dbc has to be used. This index increments on changes that make the MS6 interface incompatible to the predecessor CAN interface implementation
     ///
@@ -2225,7 +2225,7 @@ impl Bremse51 {
     pub fn if_variant(&self) -> u8 {
         self.if_variant_raw()
     }
-    /// Get raw value of IF_variant
+    /// Get raw value of 'IF_variant'
     ///
     /// - Start bit: 48
     /// - Signal size: 6 bits
@@ -2239,7 +2239,7 @@ impl Bremse51 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IF_variant
+    /// Set value of 'IF_variant'
     #[inline(always)]
     pub fn set_if_variant(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 63_u8 < value {
@@ -2257,7 +2257,7 @@ impl Bremse51 {
         self.raw.view_bits_mut::<Lsb0>()[48..54].store_le(value);
         Ok(())
     }
-    /// IF_revision
+    /// Get value of 'IF_revision'
     ///
     /// external info to e.g. MS6 which dbc has to be used. This index increments with added features (rest of MS6 interface stays intact.)
     ///
@@ -2269,7 +2269,7 @@ impl Bremse51 {
     pub fn if_revision(&self) -> u8 {
         self.if_revision_raw()
     }
-    /// Get raw value of IF_revision
+    /// Get raw value of 'IF_revision'
     ///
     /// - Start bit: 54
     /// - Signal size: 6 bits
@@ -2283,7 +2283,7 @@ impl Bremse51 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IF_revision
+    /// Set value of 'IF_revision'
     #[inline(always)]
     pub fn set_if_revision(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 63_u8 < value {
@@ -2301,7 +2301,7 @@ impl Bremse51 {
         self.raw.view_bits_mut::<Lsb0>()[54..60].store_le(value);
         Ok(())
     }
-    /// IF_chksum
+    /// Get value of 'IF_chksum'
     ///
     /// external info to e.g. MS6 which dbc has to be used. Checksum
     ///
@@ -2313,7 +2313,7 @@ impl Bremse51 {
     pub fn if_chksum(&self) -> u8 {
         self.if_chksum_raw()
     }
-    /// Get raw value of IF_chksum
+    /// Get raw value of 'IF_chksum'
     ///
     /// - Start bit: 60
     /// - Signal size: 4 bits
@@ -2327,7 +2327,7 @@ impl Bremse51 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IF_chksum
+    /// Set value of 'IF_chksum'
     #[inline(always)]
     pub fn set_if_chksum(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {
@@ -2485,7 +2485,7 @@ impl Bremse52 {
     pub const HU_DATE_DAY_MAX: u8 = 31_u8;
     pub const ECU_SERIAL_MIN: u32 = 0_u32;
     pub const ECU_SERIAL_MAX: u32 = 99999_u32;
-    /// Construct new BREMSE_52 from values
+    /// Construct new 'BREMSE_52' from values
     pub fn new(mplx_sw_info: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_mplx_sw_info(mplx_sw_info)?;
@@ -2495,7 +2495,7 @@ impl Bremse52 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Mplx_SW_Info
+    /// Get raw value of 'Mplx_SW_Info'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -2568,7 +2568,7 @@ impl Bremse52 {
             }
         }
     }
-    /// Set value of Mplx_SW_Info
+    /// Set value of 'Mplx_SW_Info'
     #[inline(always)]
     fn set_mplx_sw_info(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -2586,7 +2586,7 @@ impl Bremse52 {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Set value of Mplx_SW_Info
+    /// Set value of 'Mplx_SW_Info'
     #[inline(always)]
     pub fn set_m1(&mut self, value: Bremse52MplxSwInfoM1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -2595,7 +2595,7 @@ impl Bremse52 {
         self.set_mplx_sw_info(1)?;
         Ok(())
     }
-    /// Set value of Mplx_SW_Info
+    /// Set value of 'Mplx_SW_Info'
     #[inline(always)]
     pub fn set_m2(&mut self, value: Bremse52MplxSwInfoM2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -2604,7 +2604,7 @@ impl Bremse52 {
         self.set_mplx_sw_info(2)?;
         Ok(())
     }
-    /// Set value of Mplx_SW_Info
+    /// Set value of 'Mplx_SW_Info'
     #[inline(always)]
     pub fn set_m3(&mut self, value: Bremse52MplxSwInfoM3) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -2613,7 +2613,7 @@ impl Bremse52 {
         self.set_mplx_sw_info(3)?;
         Ok(())
     }
-    /// Set value of Mplx_SW_Info
+    /// Set value of 'Mplx_SW_Info'
     #[inline(always)]
     pub fn set_m4(&mut self, value: Bremse52MplxSwInfoM4) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -2622,7 +2622,7 @@ impl Bremse52 {
         self.set_mplx_sw_info(4)?;
         Ok(())
     }
-    /// Set value of Mplx_SW_Info
+    /// Set value of 'Mplx_SW_Info'
     #[inline(always)]
     pub fn set_m5(&mut self, value: Bremse52MplxSwInfoM5) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -2631,7 +2631,7 @@ impl Bremse52 {
         self.set_mplx_sw_info(5)?;
         Ok(())
     }
-    /// Set value of Mplx_SW_Info
+    /// Set value of 'Mplx_SW_Info'
     #[inline(always)]
     pub fn set_m6(&mut self, value: Bremse52MplxSwInfoM6) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -2640,7 +2640,7 @@ impl Bremse52 {
         self.set_mplx_sw_info(6)?;
         Ok(())
     }
-    /// Set value of Mplx_SW_Info
+    /// Set value of 'Mplx_SW_Info'
     #[inline(always)]
     pub fn set_m7(&mut self, value: Bremse52MplxSwInfoM7) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -2733,7 +2733,7 @@ impl Bremse52MplxSwInfoM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SW_version_High_upper
+    /// Get value of 'SW_version_High_upper'
     ///
     /// version 1.0 as 0x01(upper), version 100.20 as 0x64(upper)
     ///
@@ -2745,7 +2745,7 @@ impl Bremse52MplxSwInfoM1 {
     pub fn sw_version_high_upper(&self) -> u8 {
         self.sw_version_high_upper_raw()
     }
-    /// Get raw value of SW_version_High_upper
+    /// Get raw value of 'SW_version_High_upper'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -2759,7 +2759,7 @@ impl Bremse52MplxSwInfoM1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SW_version_High_upper
+    /// Set value of 'SW_version_High_upper'
     #[inline(always)]
     pub fn set_sw_version_high_upper(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -2777,7 +2777,7 @@ impl Bremse52MplxSwInfoM1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// SW_version_High_lower
+    /// Get value of 'SW_version_High_lower'
     ///
     /// version 1.0 as 0x00(lower), version 100.20 as 0x14(lower)
     ///
@@ -2789,7 +2789,7 @@ impl Bremse52MplxSwInfoM1 {
     pub fn sw_version_high_lower(&self) -> u8 {
         self.sw_version_high_lower_raw()
     }
-    /// Get raw value of SW_version_High_lower
+    /// Get raw value of 'SW_version_High_lower'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -2803,7 +2803,7 @@ impl Bremse52MplxSwInfoM1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SW_version_High_lower
+    /// Set value of 'SW_version_High_lower'
     #[inline(always)]
     pub fn set_sw_version_high_lower(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -2821,7 +2821,7 @@ impl Bremse52MplxSwInfoM1 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// SW_version_Mid_upper
+    /// Get value of 'SW_version_Mid_upper'
     ///
     /// version 1.0 as 0x01(upper), version 100.20 as 0x64(upper)
     ///
@@ -2833,7 +2833,7 @@ impl Bremse52MplxSwInfoM1 {
     pub fn sw_version_mid_upper(&self) -> u8 {
         self.sw_version_mid_upper_raw()
     }
-    /// Get raw value of SW_version_Mid_upper
+    /// Get raw value of 'SW_version_Mid_upper'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -2847,7 +2847,7 @@ impl Bremse52MplxSwInfoM1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SW_version_Mid_upper
+    /// Set value of 'SW_version_Mid_upper'
     #[inline(always)]
     pub fn set_sw_version_mid_upper(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -2865,7 +2865,7 @@ impl Bremse52MplxSwInfoM1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// SW_version_Mid_lower
+    /// Get value of 'SW_version_Mid_lower'
     ///
     /// version 1.0 as 0x00(lower), version 100.20 as 0x14(lower)
     ///
@@ -2877,7 +2877,7 @@ impl Bremse52MplxSwInfoM1 {
     pub fn sw_version_mid_lower(&self) -> u8 {
         self.sw_version_mid_lower_raw()
     }
-    /// Get raw value of SW_version_Mid_lower
+    /// Get raw value of 'SW_version_Mid_lower'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -2891,7 +2891,7 @@ impl Bremse52MplxSwInfoM1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SW_version_Mid_lower
+    /// Set value of 'SW_version_Mid_lower'
     #[inline(always)]
     pub fn set_sw_version_mid_lower(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -2909,7 +2909,7 @@ impl Bremse52MplxSwInfoM1 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// SW_version_Low_upper
+    /// Get value of 'SW_version_Low_upper'
     ///
     /// version 1.0 as 0x01(upper), version 100.20 as 0x64(upper)
     ///
@@ -2921,7 +2921,7 @@ impl Bremse52MplxSwInfoM1 {
     pub fn sw_version_low_upper(&self) -> u8 {
         self.sw_version_low_upper_raw()
     }
-    /// Get raw value of SW_version_Low_upper
+    /// Get raw value of 'SW_version_Low_upper'
     ///
     /// - Start bit: 40
     /// - Signal size: 8 bits
@@ -2935,7 +2935,7 @@ impl Bremse52MplxSwInfoM1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SW_version_Low_upper
+    /// Set value of 'SW_version_Low_upper'
     #[inline(always)]
     pub fn set_sw_version_low_upper(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -2953,7 +2953,7 @@ impl Bremse52MplxSwInfoM1 {
         self.raw.view_bits_mut::<Lsb0>()[40..48].store_le(value);
         Ok(())
     }
-    /// SW_version_Low_lower
+    /// Get value of 'SW_version_Low_lower'
     ///
     /// version 1.0 as 0x00(lower), version 100.20 as 0x14(lower)
     ///
@@ -2965,7 +2965,7 @@ impl Bremse52MplxSwInfoM1 {
     pub fn sw_version_low_lower(&self) -> u8 {
         self.sw_version_low_lower_raw()
     }
-    /// Get raw value of SW_version_Low_lower
+    /// Get raw value of 'SW_version_Low_lower'
     ///
     /// - Start bit: 48
     /// - Signal size: 8 bits
@@ -2979,7 +2979,7 @@ impl Bremse52MplxSwInfoM1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SW_version_Low_lower
+    /// Set value of 'SW_version_Low_lower'
     #[inline(always)]
     pub fn set_sw_version_low_lower(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3024,7 +3024,7 @@ impl Bremse52MplxSwInfoM2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BB_dig1
+    /// Get value of 'BB_dig1'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3034,7 +3034,7 @@ impl Bremse52MplxSwInfoM2 {
     pub fn bb_dig1(&self) -> u8 {
         self.bb_dig1_raw()
     }
-    /// Get raw value of BB_dig1
+    /// Get raw value of 'BB_dig1'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -3048,7 +3048,7 @@ impl Bremse52MplxSwInfoM2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BB_dig1
+    /// Set value of 'BB_dig1'
     #[inline(always)]
     pub fn set_bb_dig1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3066,7 +3066,7 @@ impl Bremse52MplxSwInfoM2 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// BB_dig2
+    /// Get value of 'BB_dig2'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3076,7 +3076,7 @@ impl Bremse52MplxSwInfoM2 {
     pub fn bb_dig2(&self) -> u8 {
         self.bb_dig2_raw()
     }
-    /// Get raw value of BB_dig2
+    /// Get raw value of 'BB_dig2'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -3090,7 +3090,7 @@ impl Bremse52MplxSwInfoM2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BB_dig2
+    /// Set value of 'BB_dig2'
     #[inline(always)]
     pub fn set_bb_dig2(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3108,7 +3108,7 @@ impl Bremse52MplxSwInfoM2 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// BB_dig3
+    /// Get value of 'BB_dig3'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3118,7 +3118,7 @@ impl Bremse52MplxSwInfoM2 {
     pub fn bb_dig3(&self) -> u8 {
         self.bb_dig3_raw()
     }
-    /// Get raw value of BB_dig3
+    /// Get raw value of 'BB_dig3'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -3132,7 +3132,7 @@ impl Bremse52MplxSwInfoM2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BB_dig3
+    /// Set value of 'BB_dig3'
     #[inline(always)]
     pub fn set_bb_dig3(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3150,7 +3150,7 @@ impl Bremse52MplxSwInfoM2 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// BB_dig4
+    /// Get value of 'BB_dig4'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3160,7 +3160,7 @@ impl Bremse52MplxSwInfoM2 {
     pub fn bb_dig4(&self) -> u8 {
         self.bb_dig4_raw()
     }
-    /// Get raw value of BB_dig4
+    /// Get raw value of 'BB_dig4'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -3174,7 +3174,7 @@ impl Bremse52MplxSwInfoM2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BB_dig4
+    /// Set value of 'BB_dig4'
     #[inline(always)]
     pub fn set_bb_dig4(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3192,7 +3192,7 @@ impl Bremse52MplxSwInfoM2 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// BB_dig5
+    /// Get value of 'BB_dig5'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3202,7 +3202,7 @@ impl Bremse52MplxSwInfoM2 {
     pub fn bb_dig5(&self) -> u8 {
         self.bb_dig5_raw()
     }
-    /// Get raw value of BB_dig5
+    /// Get raw value of 'BB_dig5'
     ///
     /// - Start bit: 40
     /// - Signal size: 8 bits
@@ -3216,7 +3216,7 @@ impl Bremse52MplxSwInfoM2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BB_dig5
+    /// Set value of 'BB_dig5'
     #[inline(always)]
     pub fn set_bb_dig5(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3234,7 +3234,7 @@ impl Bremse52MplxSwInfoM2 {
         self.raw.view_bits_mut::<Lsb0>()[40..48].store_le(value);
         Ok(())
     }
-    /// BB_dig6
+    /// Get value of 'BB_dig6'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3244,7 +3244,7 @@ impl Bremse52MplxSwInfoM2 {
     pub fn bb_dig6(&self) -> u8 {
         self.bb_dig6_raw()
     }
-    /// Get raw value of BB_dig6
+    /// Get raw value of 'BB_dig6'
     ///
     /// - Start bit: 48
     /// - Signal size: 8 bits
@@ -3258,7 +3258,7 @@ impl Bremse52MplxSwInfoM2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BB_dig6
+    /// Set value of 'BB_dig6'
     #[inline(always)]
     pub fn set_bb_dig6(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3276,7 +3276,7 @@ impl Bremse52MplxSwInfoM2 {
         self.raw.view_bits_mut::<Lsb0>()[48..56].store_le(value);
         Ok(())
     }
-    /// BB_dig7
+    /// Get value of 'BB_dig7'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3286,7 +3286,7 @@ impl Bremse52MplxSwInfoM2 {
     pub fn bb_dig7(&self) -> u8 {
         self.bb_dig7_raw()
     }
-    /// Get raw value of BB_dig7
+    /// Get raw value of 'BB_dig7'
     ///
     /// - Start bit: 56
     /// - Signal size: 8 bits
@@ -3300,7 +3300,7 @@ impl Bremse52MplxSwInfoM2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BB_dig7
+    /// Set value of 'BB_dig7'
     #[inline(always)]
     pub fn set_bb_dig7(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3345,7 +3345,7 @@ impl Bremse52MplxSwInfoM3 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Appl_Id_01
+    /// Get value of 'Appl_Id_01'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3355,7 +3355,7 @@ impl Bremse52MplxSwInfoM3 {
     pub fn appl_id_01(&self) -> u8 {
         self.appl_id_01_raw()
     }
-    /// Get raw value of Appl_Id_01
+    /// Get raw value of 'Appl_Id_01'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -3369,7 +3369,7 @@ impl Bremse52MplxSwInfoM3 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_01
+    /// Set value of 'Appl_Id_01'
     #[inline(always)]
     pub fn set_appl_id_01(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3387,7 +3387,7 @@ impl Bremse52MplxSwInfoM3 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Appl_Id_02
+    /// Get value of 'Appl_Id_02'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3397,7 +3397,7 @@ impl Bremse52MplxSwInfoM3 {
     pub fn appl_id_02(&self) -> u8 {
         self.appl_id_02_raw()
     }
-    /// Get raw value of Appl_Id_02
+    /// Get raw value of 'Appl_Id_02'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -3411,7 +3411,7 @@ impl Bremse52MplxSwInfoM3 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_02
+    /// Set value of 'Appl_Id_02'
     #[inline(always)]
     pub fn set_appl_id_02(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3429,7 +3429,7 @@ impl Bremse52MplxSwInfoM3 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Appl_Id_03
+    /// Get value of 'Appl_Id_03'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3439,7 +3439,7 @@ impl Bremse52MplxSwInfoM3 {
     pub fn appl_id_03(&self) -> u8 {
         self.appl_id_03_raw()
     }
-    /// Get raw value of Appl_Id_03
+    /// Get raw value of 'Appl_Id_03'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -3453,7 +3453,7 @@ impl Bremse52MplxSwInfoM3 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_03
+    /// Set value of 'Appl_Id_03'
     #[inline(always)]
     pub fn set_appl_id_03(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3471,7 +3471,7 @@ impl Bremse52MplxSwInfoM3 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Appl_Id_04
+    /// Get value of 'Appl_Id_04'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3481,7 +3481,7 @@ impl Bremse52MplxSwInfoM3 {
     pub fn appl_id_04(&self) -> u8 {
         self.appl_id_04_raw()
     }
-    /// Get raw value of Appl_Id_04
+    /// Get raw value of 'Appl_Id_04'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -3495,7 +3495,7 @@ impl Bremse52MplxSwInfoM3 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_04
+    /// Set value of 'Appl_Id_04'
     #[inline(always)]
     pub fn set_appl_id_04(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3513,7 +3513,7 @@ impl Bremse52MplxSwInfoM3 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// Appl_Id_05
+    /// Get value of 'Appl_Id_05'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3523,7 +3523,7 @@ impl Bremse52MplxSwInfoM3 {
     pub fn appl_id_05(&self) -> u8 {
         self.appl_id_05_raw()
     }
-    /// Get raw value of Appl_Id_05
+    /// Get raw value of 'Appl_Id_05'
     ///
     /// - Start bit: 40
     /// - Signal size: 8 bits
@@ -3537,7 +3537,7 @@ impl Bremse52MplxSwInfoM3 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_05
+    /// Set value of 'Appl_Id_05'
     #[inline(always)]
     pub fn set_appl_id_05(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3555,7 +3555,7 @@ impl Bremse52MplxSwInfoM3 {
         self.raw.view_bits_mut::<Lsb0>()[40..48].store_le(value);
         Ok(())
     }
-    /// Appl_Id_06
+    /// Get value of 'Appl_Id_06'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3565,7 +3565,7 @@ impl Bremse52MplxSwInfoM3 {
     pub fn appl_id_06(&self) -> u8 {
         self.appl_id_06_raw()
     }
-    /// Get raw value of Appl_Id_06
+    /// Get raw value of 'Appl_Id_06'
     ///
     /// - Start bit: 48
     /// - Signal size: 8 bits
@@ -3579,7 +3579,7 @@ impl Bremse52MplxSwInfoM3 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_06
+    /// Set value of 'Appl_Id_06'
     #[inline(always)]
     pub fn set_appl_id_06(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3597,7 +3597,7 @@ impl Bremse52MplxSwInfoM3 {
         self.raw.view_bits_mut::<Lsb0>()[48..56].store_le(value);
         Ok(())
     }
-    /// Appl_Id_07
+    /// Get value of 'Appl_Id_07'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3607,7 +3607,7 @@ impl Bremse52MplxSwInfoM3 {
     pub fn appl_id_07(&self) -> u8 {
         self.appl_id_07_raw()
     }
-    /// Get raw value of Appl_Id_07
+    /// Get raw value of 'Appl_Id_07'
     ///
     /// - Start bit: 56
     /// - Signal size: 8 bits
@@ -3621,7 +3621,7 @@ impl Bremse52MplxSwInfoM3 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_07
+    /// Set value of 'Appl_Id_07'
     #[inline(always)]
     pub fn set_appl_id_07(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3666,7 +3666,7 @@ impl Bremse52MplxSwInfoM4 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Appl_Id_08
+    /// Get value of 'Appl_Id_08'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3676,7 +3676,7 @@ impl Bremse52MplxSwInfoM4 {
     pub fn appl_id_08(&self) -> u8 {
         self.appl_id_08_raw()
     }
-    /// Get raw value of Appl_Id_08
+    /// Get raw value of 'Appl_Id_08'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -3690,7 +3690,7 @@ impl Bremse52MplxSwInfoM4 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_08
+    /// Set value of 'Appl_Id_08'
     #[inline(always)]
     pub fn set_appl_id_08(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3708,7 +3708,7 @@ impl Bremse52MplxSwInfoM4 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Appl_Id_09
+    /// Get value of 'Appl_Id_09'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3718,7 +3718,7 @@ impl Bremse52MplxSwInfoM4 {
     pub fn appl_id_09(&self) -> u8 {
         self.appl_id_09_raw()
     }
-    /// Get raw value of Appl_Id_09
+    /// Get raw value of 'Appl_Id_09'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -3732,7 +3732,7 @@ impl Bremse52MplxSwInfoM4 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_09
+    /// Set value of 'Appl_Id_09'
     #[inline(always)]
     pub fn set_appl_id_09(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3750,7 +3750,7 @@ impl Bremse52MplxSwInfoM4 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Appl_Id_10
+    /// Get value of 'Appl_Id_10'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3760,7 +3760,7 @@ impl Bremse52MplxSwInfoM4 {
     pub fn appl_id_10(&self) -> u8 {
         self.appl_id_10_raw()
     }
-    /// Get raw value of Appl_Id_10
+    /// Get raw value of 'Appl_Id_10'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -3774,7 +3774,7 @@ impl Bremse52MplxSwInfoM4 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_10
+    /// Set value of 'Appl_Id_10'
     #[inline(always)]
     pub fn set_appl_id_10(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3792,7 +3792,7 @@ impl Bremse52MplxSwInfoM4 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Appl_Id_11
+    /// Get value of 'Appl_Id_11'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3802,7 +3802,7 @@ impl Bremse52MplxSwInfoM4 {
     pub fn appl_id_11(&self) -> u8 {
         self.appl_id_11_raw()
     }
-    /// Get raw value of Appl_Id_11
+    /// Get raw value of 'Appl_Id_11'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -3816,7 +3816,7 @@ impl Bremse52MplxSwInfoM4 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_11
+    /// Set value of 'Appl_Id_11'
     #[inline(always)]
     pub fn set_appl_id_11(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3834,7 +3834,7 @@ impl Bremse52MplxSwInfoM4 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// Appl_Id_12
+    /// Get value of 'Appl_Id_12'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3844,7 +3844,7 @@ impl Bremse52MplxSwInfoM4 {
     pub fn appl_id_12(&self) -> u8 {
         self.appl_id_12_raw()
     }
-    /// Get raw value of Appl_Id_12
+    /// Get raw value of 'Appl_Id_12'
     ///
     /// - Start bit: 40
     /// - Signal size: 8 bits
@@ -3858,7 +3858,7 @@ impl Bremse52MplxSwInfoM4 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_12
+    /// Set value of 'Appl_Id_12'
     #[inline(always)]
     pub fn set_appl_id_12(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3876,7 +3876,7 @@ impl Bremse52MplxSwInfoM4 {
         self.raw.view_bits_mut::<Lsb0>()[40..48].store_le(value);
         Ok(())
     }
-    /// Appl_Id_13
+    /// Get value of 'Appl_Id_13'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3886,7 +3886,7 @@ impl Bremse52MplxSwInfoM4 {
     pub fn appl_id_13(&self) -> u8 {
         self.appl_id_13_raw()
     }
-    /// Get raw value of Appl_Id_13
+    /// Get raw value of 'Appl_Id_13'
     ///
     /// - Start bit: 48
     /// - Signal size: 8 bits
@@ -3900,7 +3900,7 @@ impl Bremse52MplxSwInfoM4 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_13
+    /// Set value of 'Appl_Id_13'
     #[inline(always)]
     pub fn set_appl_id_13(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3918,7 +3918,7 @@ impl Bremse52MplxSwInfoM4 {
         self.raw.view_bits_mut::<Lsb0>()[48..56].store_le(value);
         Ok(())
     }
-    /// Appl_Id_14
+    /// Get value of 'Appl_Id_14'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -3928,7 +3928,7 @@ impl Bremse52MplxSwInfoM4 {
     pub fn appl_id_14(&self) -> u8 {
         self.appl_id_14_raw()
     }
-    /// Get raw value of Appl_Id_14
+    /// Get raw value of 'Appl_Id_14'
     ///
     /// - Start bit: 56
     /// - Signal size: 8 bits
@@ -3942,7 +3942,7 @@ impl Bremse52MplxSwInfoM4 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_Id_14
+    /// Set value of 'Appl_Id_14'
     #[inline(always)]
     pub fn set_appl_id_14(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -3987,7 +3987,7 @@ impl Bremse52MplxSwInfoM5 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Appl_date_01
+    /// Get value of 'Appl_date_01'
     ///
     /// year
     ///
@@ -3999,7 +3999,7 @@ impl Bremse52MplxSwInfoM5 {
     pub fn appl_date_01(&self) -> u8 {
         self.appl_date_01_raw()
     }
-    /// Get raw value of Appl_date_01
+    /// Get raw value of 'Appl_date_01'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -4013,7 +4013,7 @@ impl Bremse52MplxSwInfoM5 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_date_01
+    /// Set value of 'Appl_date_01'
     #[inline(always)]
     pub fn set_appl_date_01(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 99_u8 < value {
@@ -4031,7 +4031,7 @@ impl Bremse52MplxSwInfoM5 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Appl_date_02
+    /// Get value of 'Appl_date_02'
     ///
     /// month
     ///
@@ -4043,7 +4043,7 @@ impl Bremse52MplxSwInfoM5 {
     pub fn appl_date_02(&self) -> u8 {
         self.appl_date_02_raw()
     }
-    /// Get raw value of Appl_date_02
+    /// Get raw value of 'Appl_date_02'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -4057,7 +4057,7 @@ impl Bremse52MplxSwInfoM5 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_date_02
+    /// Set value of 'Appl_date_02'
     #[inline(always)]
     pub fn set_appl_date_02(&mut self, value: u8) -> Result<(), CanError> {
         if value < 1_u8 || 12_u8 < value {
@@ -4075,7 +4075,7 @@ impl Bremse52MplxSwInfoM5 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Appl_date_03
+    /// Get value of 'Appl_date_03'
     ///
     /// day
     ///
@@ -4087,7 +4087,7 @@ impl Bremse52MplxSwInfoM5 {
     pub fn appl_date_03(&self) -> u8 {
         self.appl_date_03_raw()
     }
-    /// Get raw value of Appl_date_03
+    /// Get raw value of 'Appl_date_03'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -4101,7 +4101,7 @@ impl Bremse52MplxSwInfoM5 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_date_03
+    /// Set value of 'Appl_date_03'
     #[inline(always)]
     pub fn set_appl_date_03(&mut self, value: u8) -> Result<(), CanError> {
         if value < 1_u8 || 31_u8 < value {
@@ -4119,7 +4119,7 @@ impl Bremse52MplxSwInfoM5 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Appl_date_04
+    /// Get value of 'Appl_date_04'
     ///
     /// hour
     ///
@@ -4131,7 +4131,7 @@ impl Bremse52MplxSwInfoM5 {
     pub fn appl_date_04(&self) -> u8 {
         self.appl_date_04_raw()
     }
-    /// Get raw value of Appl_date_04
+    /// Get raw value of 'Appl_date_04'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -4145,7 +4145,7 @@ impl Bremse52MplxSwInfoM5 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_date_04
+    /// Set value of 'Appl_date_04'
     #[inline(always)]
     pub fn set_appl_date_04(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 24_u8 < value {
@@ -4163,7 +4163,7 @@ impl Bremse52MplxSwInfoM5 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// Appl_date_05
+    /// Get value of 'Appl_date_05'
     ///
     /// minute
     ///
@@ -4175,7 +4175,7 @@ impl Bremse52MplxSwInfoM5 {
     pub fn appl_date_05(&self) -> u8 {
         self.appl_date_05_raw()
     }
-    /// Get raw value of Appl_date_05
+    /// Get raw value of 'Appl_date_05'
     ///
     /// - Start bit: 40
     /// - Signal size: 8 bits
@@ -4189,7 +4189,7 @@ impl Bremse52MplxSwInfoM5 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_date_05
+    /// Set value of 'Appl_date_05'
     #[inline(always)]
     pub fn set_appl_date_05(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 59_u8 < value {
@@ -4207,7 +4207,7 @@ impl Bremse52MplxSwInfoM5 {
         self.raw.view_bits_mut::<Lsb0>()[40..48].store_le(value);
         Ok(())
     }
-    /// Appl_date_06
+    /// Get value of 'Appl_date_06'
     ///
     /// seconds
     ///
@@ -4219,7 +4219,7 @@ impl Bremse52MplxSwInfoM5 {
     pub fn appl_date_06(&self) -> u8 {
         self.appl_date_06_raw()
     }
-    /// Get raw value of Appl_date_06
+    /// Get raw value of 'Appl_date_06'
     ///
     /// - Start bit: 48
     /// - Signal size: 8 bits
@@ -4233,7 +4233,7 @@ impl Bremse52MplxSwInfoM5 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Appl_date_06
+    /// Set value of 'Appl_date_06'
     #[inline(always)]
     pub fn set_appl_date_06(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 59_u8 < value {
@@ -4278,7 +4278,7 @@ impl Bremse52MplxSwInfoM6 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SW_CAN_ident
+    /// Get value of 'SW_CAN_ident'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -4288,7 +4288,7 @@ impl Bremse52MplxSwInfoM6 {
     pub fn sw_can_ident(&self) -> u8 {
         self.sw_can_ident_raw()
     }
-    /// Get raw value of SW_CAN_ident
+    /// Get raw value of 'SW_CAN_ident'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -4302,7 +4302,7 @@ impl Bremse52MplxSwInfoM6 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SW_CAN_ident
+    /// Set value of 'SW_CAN_ident'
     #[inline(always)]
     pub fn set_sw_can_ident(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -4347,7 +4347,7 @@ impl Bremse52MplxSwInfoM7 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// HU_date_year
+    /// Get value of 'HU_date_year'
     ///
     /// - Min: 0
     /// - Max: 99
@@ -4357,7 +4357,7 @@ impl Bremse52MplxSwInfoM7 {
     pub fn hu_date_year(&self) -> u8 {
         self.hu_date_year_raw()
     }
-    /// Get raw value of HU_date_year
+    /// Get raw value of 'HU_date_year'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -4371,7 +4371,7 @@ impl Bremse52MplxSwInfoM7 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of HU_date_year
+    /// Set value of 'HU_date_year'
     #[inline(always)]
     pub fn set_hu_date_year(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 99_u8 < value {
@@ -4389,7 +4389,7 @@ impl Bremse52MplxSwInfoM7 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// HU_date_month
+    /// Get value of 'HU_date_month'
     ///
     /// - Min: 1
     /// - Max: 12
@@ -4399,7 +4399,7 @@ impl Bremse52MplxSwInfoM7 {
     pub fn hu_date_month(&self) -> u8 {
         self.hu_date_month_raw()
     }
-    /// Get raw value of HU_date_month
+    /// Get raw value of 'HU_date_month'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -4413,7 +4413,7 @@ impl Bremse52MplxSwInfoM7 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of HU_date_month
+    /// Set value of 'HU_date_month'
     #[inline(always)]
     pub fn set_hu_date_month(&mut self, value: u8) -> Result<(), CanError> {
         if value < 1_u8 || 12_u8 < value {
@@ -4431,7 +4431,7 @@ impl Bremse52MplxSwInfoM7 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// HU_date_day
+    /// Get value of 'HU_date_day'
     ///
     /// - Min: 1
     /// - Max: 31
@@ -4441,7 +4441,7 @@ impl Bremse52MplxSwInfoM7 {
     pub fn hu_date_day(&self) -> u8 {
         self.hu_date_day_raw()
     }
-    /// Get raw value of HU_date_day
+    /// Get raw value of 'HU_date_day'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -4455,7 +4455,7 @@ impl Bremse52MplxSwInfoM7 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of HU_date_day
+    /// Set value of 'HU_date_day'
     #[inline(always)]
     pub fn set_hu_date_day(&mut self, value: u8) -> Result<(), CanError> {
         if value < 1_u8 || 31_u8 < value {
@@ -4473,7 +4473,7 @@ impl Bremse52MplxSwInfoM7 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Ecu_serial
+    /// Get value of 'Ecu_serial'
     ///
     /// - Min: 0
     /// - Max: 99999
@@ -4483,7 +4483,7 @@ impl Bremse52MplxSwInfoM7 {
     pub fn ecu_serial(&self) -> u32 {
         self.ecu_serial_raw()
     }
-    /// Get raw value of Ecu_serial
+    /// Get raw value of 'Ecu_serial'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -4497,7 +4497,7 @@ impl Bremse52MplxSwInfoM7 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Ecu_serial
+    /// Set value of 'Ecu_serial'
     #[inline(always)]
     pub fn set_ecu_serial(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 99999_u32 < value {
@@ -4547,7 +4547,7 @@ impl Bremse50 {
     pub const BRAKE_BAL_PCT_MAX: f32 = 100_f32;
     pub const BRAKE_BAL_PCT_ADVICE_MIN: u8 = 0_u8;
     pub const BRAKE_BAL_PCT_ADVICE_MAX: u8 = 100_u8;
-    /// Construct new BREMSE_50 from values
+    /// Construct new 'BREMSE_50' from values
     pub fn new(
         brake_bal_at50: f32,
         brake_bal_at50_advice: u8,
@@ -4565,7 +4565,7 @@ impl Bremse50 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Brake_bal_at50
+    /// Get value of 'Brake_bal_at50'
     ///
     /// Calculated rear axle brake pressure if the front pressure is at 50 bar.
     ///
@@ -4577,7 +4577,7 @@ impl Bremse50 {
     pub fn brake_bal_at50(&self) -> f32 {
         self.brake_bal_at50_raw()
     }
-    /// Get raw value of Brake_bal_at50
+    /// Get raw value of 'Brake_bal_at50'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4592,7 +4592,7 @@ impl Bremse50 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Brake_bal_at50
+    /// Set value of 'Brake_bal_at50'
     #[inline(always)]
     pub fn set_brake_bal_at50(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -4606,7 +4606,7 @@ impl Bremse50 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Brake_bal_at50_advice
+    /// Get value of 'Brake_bal_at50_advice'
     ///
     /// Recommended rear axle brake pressure if the front pressure is at 50 bar.
     ///
@@ -4618,7 +4618,7 @@ impl Bremse50 {
     pub fn brake_bal_at50_advice(&self) -> u8 {
         self.brake_bal_at50_advice_raw()
     }
-    /// Get raw value of Brake_bal_at50_advice
+    /// Get raw value of 'Brake_bal_at50_advice'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -4632,7 +4632,7 @@ impl Bremse50 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Brake_bal_at50_advice
+    /// Set value of 'Brake_bal_at50_advice'
     #[inline(always)]
     pub fn set_brake_bal_at50_advice(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 100_u8 < value {
@@ -4650,7 +4650,7 @@ impl Bremse50 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// Brake_bal_pct
+    /// Get value of 'Brake_bal_pct'
     ///
     /// Percental brake balance on the front axle.
     ///
@@ -4662,7 +4662,7 @@ impl Bremse50 {
     pub fn brake_bal_pct(&self) -> f32 {
         self.brake_bal_pct_raw()
     }
-    /// Get raw value of Brake_bal_pct
+    /// Get raw value of 'Brake_bal_pct'
     ///
     /// - Start bit: 40
     /// - Signal size: 16 bits
@@ -4677,7 +4677,7 @@ impl Bremse50 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Brake_bal_pct
+    /// Set value of 'Brake_bal_pct'
     #[inline(always)]
     pub fn set_brake_bal_pct(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -4691,7 +4691,7 @@ impl Bremse50 {
         self.raw.view_bits_mut::<Lsb0>()[40..56].store_le(value);
         Ok(())
     }
-    /// Brake_bal_pct_advice
+    /// Get value of 'Brake_bal_pct_advice'
     ///
     /// Recommended percental brake balance on the front axle.
     ///
@@ -4703,7 +4703,7 @@ impl Bremse50 {
     pub fn brake_bal_pct_advice(&self) -> u8 {
         self.brake_bal_pct_advice_raw()
     }
-    /// Get raw value of Brake_bal_pct_advice
+    /// Get raw value of 'Brake_bal_pct_advice'
     ///
     /// - Start bit: 56
     /// - Signal size: 8 bits
@@ -4717,7 +4717,7 @@ impl Bremse50 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Brake_bal_pct_advice
+    /// Set value of 'Brake_bal_pct_advice'
     #[inline(always)]
     pub fn set_brake_bal_pct_advice(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 100_u8 < value {
@@ -4815,7 +4815,7 @@ impl Bremse53 {
     pub const ABS_FAULT_INFO_MAX: u8 = 3_u8;
     pub const P_RA_MIN: f32 = -42.5_f32;
     pub const P_RA_MAX: f32 = 425_f32;
-    /// Construct new BREMSE_53 from values
+    /// Construct new 'BREMSE_53' from values
     pub fn new(
         switch_position: u8,
         p_fa: f32,
@@ -4825,17 +4825,17 @@ impl Bremse53 {
         abs_active: bool,
         ebd_lamp: bool,
         abs_lamp: bool,
-        diag_fl: u8,
-        diag_fr: u8,
-        diag_rl: u8,
-        diag_rr: u8,
+        diag_fl: Bremse53DiagFl,
+        diag_fr: Bremse53DiagFr,
+        diag_rl: Bremse53DiagRl,
+        diag_rr: Bremse53DiagRr,
         diag_abs_unit: bool,
         diag_fuse_valve: bool,
         diag_fuse_pump: bool,
         diag_p_fa: bool,
         diag_p_ra: bool,
         diag_yrs: bool,
-        abs_fault_info: u8,
+        abs_fault_info: Bremse53AbsFaultInfo,
         p_ra: f32,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
@@ -4865,7 +4865,7 @@ impl Bremse53 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SwitchPosition
+    /// Get value of 'SwitchPosition'
     ///
     /// Used switch position of the ABS.
     ///
@@ -4877,7 +4877,7 @@ impl Bremse53 {
     pub fn switch_position(&self) -> u8 {
         self.switch_position_raw()
     }
-    /// Get raw value of SwitchPosition
+    /// Get raw value of 'SwitchPosition'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -4891,7 +4891,7 @@ impl Bremse53 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SwitchPosition
+    /// Set value of 'SwitchPosition'
     #[inline(always)]
     pub fn set_switch_position(&mut self, value: u8) -> Result<(), CanError> {
         if value < 1_u8 || 12_u8 < value {
@@ -4909,7 +4909,7 @@ impl Bremse53 {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// P_FA
+    /// Get value of 'P_FA'
     ///
     /// Brake pressure on the front axle.
     ///
@@ -4921,7 +4921,7 @@ impl Bremse53 {
     pub fn p_fa(&self) -> f32 {
         self.p_fa_raw()
     }
-    /// Get raw value of P_FA
+    /// Get raw value of 'P_FA'
     ///
     /// - Start bit: 8
     /// - Signal size: 16 bits
@@ -4936,7 +4936,7 @@ impl Bremse53 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of P_FA
+    /// Set value of 'P_FA'
     #[inline(always)]
     pub fn set_p_fa(&mut self, value: f32) -> Result<(), CanError> {
         if value < -42.5_f32 || 425_f32 < value {
@@ -4951,7 +4951,7 @@ impl Bremse53 {
         self.raw.view_bits_mut::<Lsb0>()[8..24].store_le(value);
         Ok(())
     }
-    /// BLS
+    /// Get value of 'BLS'
     ///
     /// Bit for the brake light switch.
     ///
@@ -4963,7 +4963,7 @@ impl Bremse53 {
     pub fn bls(&self) -> bool {
         self.bls_raw()
     }
-    /// Get raw value of BLS
+    /// Get raw value of 'BLS'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -4976,14 +4976,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BLS
+    /// Set value of 'BLS'
     #[inline(always)]
     pub fn set_bls(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// Bremse_53_cnt
+    /// Get value of 'Bremse_53_cnt'
     ///
     /// - Min: 0
     /// - Max: 3
@@ -4993,7 +4993,7 @@ impl Bremse53 {
     pub fn bremse_53_cnt(&self) -> u8 {
         self.bremse_53_cnt_raw()
     }
-    /// Get raw value of Bremse_53_cnt
+    /// Get raw value of 'Bremse_53_cnt'
     ///
     /// - Start bit: 26
     /// - Signal size: 2 bits
@@ -5007,7 +5007,7 @@ impl Bremse53 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Bremse_53_cnt
+    /// Set value of 'Bremse_53_cnt'
     #[inline(always)]
     pub fn set_bremse_53_cnt(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
@@ -5025,7 +5025,7 @@ impl Bremse53 {
         self.raw.view_bits_mut::<Lsb0>()[26..28].store_le(value);
         Ok(())
     }
-    /// ABS_Malfunction
+    /// Get value of 'ABS_Malfunction'
     ///
     /// Bit will jump to 1, if the ABS control is deactivated by a fault.
     ///
@@ -5037,7 +5037,7 @@ impl Bremse53 {
     pub fn abs_malfunction(&self) -> bool {
         self.abs_malfunction_raw()
     }
-    /// Get raw value of ABS_Malfunction
+    /// Get raw value of 'ABS_Malfunction'
     ///
     /// - Start bit: 28
     /// - Signal size: 1 bits
@@ -5050,14 +5050,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[28..29].load_le::<u8>();
         signal == 1
     }
-    /// Set value of ABS_Malfunction
+    /// Set value of 'ABS_Malfunction'
     #[inline(always)]
     pub fn set_abs_malfunction(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[28..29].store_le(value);
         Ok(())
     }
-    /// ABS_Active
+    /// Get value of 'ABS_Active'
     ///
     /// Bit will jump to 1, when the ABS control is active.
     ///
@@ -5069,7 +5069,7 @@ impl Bremse53 {
     pub fn abs_active(&self) -> bool {
         self.abs_active_raw()
     }
-    /// Get raw value of ABS_Active
+    /// Get raw value of 'ABS_Active'
     ///
     /// - Start bit: 29
     /// - Signal size: 1 bits
@@ -5082,14 +5082,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[29..30].load_le::<u8>();
         signal == 1
     }
-    /// Set value of ABS_Active
+    /// Set value of 'ABS_Active'
     #[inline(always)]
     pub fn set_abs_active(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[29..30].store_le(value);
         Ok(())
     }
-    /// EBD_Lamp
+    /// Get value of 'EBD_Lamp'
     ///
     /// Bit will jump to 1, when the EBD is deactivated due to a fault.
     ///
@@ -5101,7 +5101,7 @@ impl Bremse53 {
     pub fn ebd_lamp(&self) -> bool {
         self.ebd_lamp_raw()
     }
-    /// Get raw value of EBD_Lamp
+    /// Get raw value of 'EBD_Lamp'
     ///
     /// - Start bit: 30
     /// - Signal size: 1 bits
@@ -5114,14 +5114,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[30..31].load_le::<u8>();
         signal == 1
     }
-    /// Set value of EBD_Lamp
+    /// Set value of 'EBD_Lamp'
     #[inline(always)]
     pub fn set_ebd_lamp(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[30..31].store_le(value);
         Ok(())
     }
-    /// ABS_Lamp
+    /// Get value of 'ABS_Lamp'
     ///
     /// Bit will jump to 1, when the ABS control is deactivated due to a fault, switch to the off position or while working with RaceABS.
     ///
@@ -5133,7 +5133,7 @@ impl Bremse53 {
     pub fn abs_lamp(&self) -> bool {
         self.abs_lamp_raw()
     }
-    /// Get raw value of ABS_Lamp
+    /// Get raw value of 'ABS_Lamp'
     ///
     /// - Start bit: 31
     /// - Signal size: 1 bits
@@ -5146,14 +5146,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[31..32].load_le::<u8>();
         signal == 1
     }
-    /// Set value of ABS_Lamp
+    /// Set value of 'ABS_Lamp'
     #[inline(always)]
     pub fn set_abs_lamp(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[31..32].store_le(value);
         Ok(())
     }
-    /// Diag_FL
+    /// Get value of 'Diag_FL'
     ///
     /// Value to show faults related to the wheel speed sensor.
     /// 0 - Signal ok, 1 - Wiring related fault, 2 - Signal related fault
@@ -5172,7 +5172,7 @@ impl Bremse53 {
             _ => Bremse53DiagFl::_Other(self.diag_fl_raw()),
         }
     }
-    /// Get raw value of Diag_FL
+    /// Get raw value of 'Diag_FL'
     ///
     /// - Start bit: 32
     /// - Signal size: 2 bits
@@ -5186,9 +5186,14 @@ impl Bremse53 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Diag_FL
+    /// Set value of 'Diag_FL'
     #[inline(always)]
-    pub fn set_diag_fl(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_diag_fl(&mut self, value: Bremse53DiagFl) -> Result<(), CanError> {
+        self.set_diag_fl_raw(u8::from(value))
+    }
+    /// Set raw value of 'Diag_FL'
+    #[inline(always)]
+    pub fn set_diag_fl_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,
@@ -5204,7 +5209,7 @@ impl Bremse53 {
         self.raw.view_bits_mut::<Lsb0>()[32..34].store_le(value);
         Ok(())
     }
-    /// Diag_FR
+    /// Get value of 'Diag_FR'
     ///
     /// Value to show faults related to the wheel speed sensor.
     /// 0 - Signal ok, 1 - Wiring related fault, 2 - Signal related fault
@@ -5223,7 +5228,7 @@ impl Bremse53 {
             _ => Bremse53DiagFr::_Other(self.diag_fr_raw()),
         }
     }
-    /// Get raw value of Diag_FR
+    /// Get raw value of 'Diag_FR'
     ///
     /// - Start bit: 34
     /// - Signal size: 2 bits
@@ -5237,9 +5242,14 @@ impl Bremse53 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Diag_FR
+    /// Set value of 'Diag_FR'
     #[inline(always)]
-    pub fn set_diag_fr(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_diag_fr(&mut self, value: Bremse53DiagFr) -> Result<(), CanError> {
+        self.set_diag_fr_raw(u8::from(value))
+    }
+    /// Set raw value of 'Diag_FR'
+    #[inline(always)]
+    pub fn set_diag_fr_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,
@@ -5255,7 +5265,7 @@ impl Bremse53 {
         self.raw.view_bits_mut::<Lsb0>()[34..36].store_le(value);
         Ok(())
     }
-    /// Diag_RL
+    /// Get value of 'Diag_RL'
     ///
     /// Value to show faults related to the wheel speed sensor.
     /// 0 - Signal ok, 1 - Wiring related fault, 2 - Signal related fault
@@ -5274,7 +5284,7 @@ impl Bremse53 {
             _ => Bremse53DiagRl::_Other(self.diag_rl_raw()),
         }
     }
-    /// Get raw value of Diag_RL
+    /// Get raw value of 'Diag_RL'
     ///
     /// - Start bit: 36
     /// - Signal size: 2 bits
@@ -5288,9 +5298,14 @@ impl Bremse53 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Diag_RL
+    /// Set value of 'Diag_RL'
     #[inline(always)]
-    pub fn set_diag_rl(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_diag_rl(&mut self, value: Bremse53DiagRl) -> Result<(), CanError> {
+        self.set_diag_rl_raw(u8::from(value))
+    }
+    /// Set raw value of 'Diag_RL'
+    #[inline(always)]
+    pub fn set_diag_rl_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,
@@ -5306,7 +5321,7 @@ impl Bremse53 {
         self.raw.view_bits_mut::<Lsb0>()[36..38].store_le(value);
         Ok(())
     }
-    /// Diag_RR
+    /// Get value of 'Diag_RR'
     ///
     /// Value to show faults related to the wheel speed sensor.
     /// 0 - Signal ok, 1 - Wiring related fault, 2 - Signal related fault
@@ -5325,7 +5340,7 @@ impl Bremse53 {
             _ => Bremse53DiagRr::_Other(self.diag_rr_raw()),
         }
     }
-    /// Get raw value of Diag_RR
+    /// Get raw value of 'Diag_RR'
     ///
     /// - Start bit: 38
     /// - Signal size: 2 bits
@@ -5339,9 +5354,14 @@ impl Bremse53 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Diag_RR
+    /// Set value of 'Diag_RR'
     #[inline(always)]
-    pub fn set_diag_rr(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_diag_rr(&mut self, value: Bremse53DiagRr) -> Result<(), CanError> {
+        self.set_diag_rr_raw(u8::from(value))
+    }
+    /// Set raw value of 'Diag_RR'
+    #[inline(always)]
+    pub fn set_diag_rr_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,
@@ -5357,7 +5377,7 @@ impl Bremse53 {
         self.raw.view_bits_mut::<Lsb0>()[38..40].store_le(value);
         Ok(())
     }
-    /// Diag_ABSUnit
+    /// Get value of 'Diag_ABSUnit'
     ///
     /// Bit to show, if a ABS error related to the hydraulic unit is present
     ///
@@ -5369,7 +5389,7 @@ impl Bremse53 {
     pub fn diag_abs_unit(&self) -> bool {
         self.diag_abs_unit_raw()
     }
-    /// Get raw value of Diag_ABSUnit
+    /// Get raw value of 'Diag_ABSUnit'
     ///
     /// - Start bit: 40
     /// - Signal size: 1 bits
@@ -5382,14 +5402,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[40..41].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Diag_ABSUnit
+    /// Set value of 'Diag_ABSUnit'
     #[inline(always)]
     pub fn set_diag_abs_unit(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[40..41].store_le(value);
         Ok(())
     }
-    /// Diag_FuseValve
+    /// Get value of 'Diag_FuseValve'
     ///
     /// Bit to show, if a ABS error related to the fuse or power supply of the ABS valves is present.
     ///
@@ -5401,7 +5421,7 @@ impl Bremse53 {
     pub fn diag_fuse_valve(&self) -> bool {
         self.diag_fuse_valve_raw()
     }
-    /// Get raw value of Diag_FuseValve
+    /// Get raw value of 'Diag_FuseValve'
     ///
     /// - Start bit: 41
     /// - Signal size: 1 bits
@@ -5414,14 +5434,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[41..42].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Diag_FuseValve
+    /// Set value of 'Diag_FuseValve'
     #[inline(always)]
     pub fn set_diag_fuse_valve(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[41..42].store_le(value);
         Ok(())
     }
-    /// Diag_FusePump
+    /// Get value of 'Diag_FusePump'
     ///
     /// Bit to show, if a ABS error related to the fuse or power supply of the ABS pump is present.
     ///
@@ -5433,7 +5453,7 @@ impl Bremse53 {
     pub fn diag_fuse_pump(&self) -> bool {
         self.diag_fuse_pump_raw()
     }
-    /// Get raw value of Diag_FusePump
+    /// Get raw value of 'Diag_FusePump'
     ///
     /// - Start bit: 42
     /// - Signal size: 1 bits
@@ -5446,14 +5466,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[42..43].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Diag_FusePump
+    /// Set value of 'Diag_FusePump'
     #[inline(always)]
     pub fn set_diag_fuse_pump(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[42..43].store_le(value);
         Ok(())
     }
-    /// Diag_P_FA
+    /// Get value of 'Diag_P_FA'
     ///
     /// Bit to show, if the pressure sensor FA is working properly. An error is pressent, if the bit is 1.
     ///
@@ -5465,7 +5485,7 @@ impl Bremse53 {
     pub fn diag_p_fa(&self) -> bool {
         self.diag_p_fa_raw()
     }
-    /// Get raw value of Diag_P_FA
+    /// Get raw value of 'Diag_P_FA'
     ///
     /// - Start bit: 43
     /// - Signal size: 1 bits
@@ -5478,14 +5498,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[43..44].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Diag_P_FA
+    /// Set value of 'Diag_P_FA'
     #[inline(always)]
     pub fn set_diag_p_fa(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[43..44].store_le(value);
         Ok(())
     }
-    /// Diag_P_RA
+    /// Get value of 'Diag_P_RA'
     ///
     /// Bit to show, if the pressure sensor RA is working properly. An error is pressent, if the bit is 1.
     ///
@@ -5497,7 +5517,7 @@ impl Bremse53 {
     pub fn diag_p_ra(&self) -> bool {
         self.diag_p_ra_raw()
     }
-    /// Get raw value of Diag_P_RA
+    /// Get raw value of 'Diag_P_RA'
     ///
     /// - Start bit: 44
     /// - Signal size: 1 bits
@@ -5510,14 +5530,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[44..45].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Diag_P_RA
+    /// Set value of 'Diag_P_RA'
     #[inline(always)]
     pub fn set_diag_p_ra(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[44..45].store_le(value);
         Ok(())
     }
-    /// Diag_YRS
+    /// Get value of 'Diag_YRS'
     ///
     /// Bit to show, if the yaw rate sensor is working properly. An error is pressent, if the bit is 1.
     ///
@@ -5529,7 +5549,7 @@ impl Bremse53 {
     pub fn diag_yrs(&self) -> bool {
         self.diag_yrs_raw()
     }
-    /// Get raw value of Diag_YRS
+    /// Get raw value of 'Diag_YRS'
     ///
     /// - Start bit: 45
     /// - Signal size: 1 bits
@@ -5542,14 +5562,14 @@ impl Bremse53 {
         let signal = self.raw.view_bits::<Lsb0>()[45..46].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Diag_YRS
+    /// Set value of 'Diag_YRS'
     #[inline(always)]
     pub fn set_diag_yrs(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[45..46].store_le(value);
         Ok(())
     }
-    /// ABS_fault_info
+    /// Get value of 'ABS_fault_info'
     ///
     /// Bit matrix to show if a fault or a active fault is stored in the ABS. Bit will also show minor errors which do  not shut down the ABS controller.
     ///
@@ -5567,7 +5587,7 @@ impl Bremse53 {
             _ => Bremse53AbsFaultInfo::_Other(self.abs_fault_info_raw()),
         }
     }
-    /// Get raw value of ABS_fault_info
+    /// Get raw value of 'ABS_fault_info'
     ///
     /// - Start bit: 46
     /// - Signal size: 2 bits
@@ -5581,9 +5601,17 @@ impl Bremse53 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ABS_fault_info
+    /// Set value of 'ABS_fault_info'
     #[inline(always)]
-    pub fn set_abs_fault_info(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_abs_fault_info(
+        &mut self,
+        value: Bremse53AbsFaultInfo,
+    ) -> Result<(), CanError> {
+        self.set_abs_fault_info_raw(u8::from(value))
+    }
+    /// Set raw value of 'ABS_fault_info'
+    #[inline(always)]
+    pub fn set_abs_fault_info_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Bremse53::MESSAGE_ID,
@@ -5599,7 +5627,7 @@ impl Bremse53 {
         self.raw.view_bits_mut::<Lsb0>()[46..48].store_le(value);
         Ok(())
     }
-    /// P_RA
+    /// Get value of 'P_RA'
     ///
     /// Brake pressure on the rear axle.
     ///
@@ -5611,7 +5639,7 @@ impl Bremse53 {
     pub fn p_ra(&self) -> f32 {
         self.p_ra_raw()
     }
-    /// Get raw value of P_RA
+    /// Get raw value of 'P_RA'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -5626,7 +5654,7 @@ impl Bremse53 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of P_RA
+    /// Set value of 'P_RA'
     #[inline(always)]
     pub fn set_p_ra(&mut self, value: f32) -> Result<(), CanError> {
         if value < -42.5_f32 || 425_f32 < value {

--- a/tests-snapshots/dbc-cantools/add_two_dbc_files_1.snap.rs
+++ b/tests-snapshots/dbc-cantools/add_two_dbc_files_1.snap.rs
@@ -71,7 +71,7 @@ impl M1 {
         StandardId::new_unchecked(0x1)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new M1 from values
+    /// Construct new 'M1' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -142,7 +142,7 @@ impl M2 {
         StandardId::new_unchecked(0x2)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new M2 from values
+    /// Construct new 'M2' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)

--- a/tests-snapshots/dbc-cantools/add_two_dbc_files_2.snap.rs
+++ b/tests-snapshots/dbc-cantools/add_two_dbc_files_2.snap.rs
@@ -68,7 +68,7 @@ impl M1 {
         StandardId::new_unchecked(0x2)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new M1 from values
+    /// Construct new 'M1' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)

--- a/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
+++ b/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
@@ -73,7 +73,7 @@ impl Inv2EventMsg1 {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 0;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
-    /// Construct new INV2EventMsg1 from values
+    /// Construct new 'INV2EventMsg1' from values
     pub fn new(the_signal: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_the_signal(the_signal)?;
@@ -83,7 +83,7 @@ impl Inv2EventMsg1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TheSignal
+    /// Get value of 'TheSignal'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -93,7 +93,7 @@ impl Inv2EventMsg1 {
     pub fn the_signal(&self) -> i8 {
         self.the_signal_raw()
     }
-    /// Get raw value of TheSignal
+    /// Get raw value of 'TheSignal'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -108,7 +108,7 @@ impl Inv2EventMsg1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TheSignal
+    /// Set value of 'TheSignal'
     #[inline(always)]
     pub fn set_the_signal(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/attributes.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes.snap.rs
@@ -77,7 +77,7 @@ impl TheMessage {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
-    /// Construct new TheMessage from values
+    /// Construct new 'TheMessage' from values
     pub fn new(the_signal: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_the_signal(the_signal)?;
@@ -87,7 +87,7 @@ impl TheMessage {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TheSignal
+    /// Get value of 'TheSignal'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -97,7 +97,7 @@ impl TheMessage {
     pub fn the_signal(&self) -> i8 {
         self.the_signal_raw()
     }
-    /// Get raw value of TheSignal
+    /// Get raw value of 'TheSignal'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -112,7 +112,7 @@ impl TheMessage {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TheSignal
+    /// Set value of 'TheSignal'
     #[inline(always)]
     pub fn set_the_signal(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -194,7 +194,7 @@ impl TheOtherMessage {
     pub const MESSAGE_SIZE: usize = 8;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
-    /// Construct new TheOtherMessage from values
+    /// Construct new 'TheOtherMessage' from values
     pub fn new(the_signal: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_the_signal(the_signal)?;
@@ -204,7 +204,7 @@ impl TheOtherMessage {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TheSignal
+    /// Get value of 'TheSignal'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -214,7 +214,7 @@ impl TheOtherMessage {
     pub fn the_signal(&self) -> i8 {
         self.the_signal_raw()
     }
-    /// Get raw value of TheSignal
+    /// Get raw value of 'TheSignal'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -229,7 +229,7 @@ impl TheOtherMessage {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TheSignal
+    /// Set value of 'TheSignal'
     #[inline(always)]
     pub fn set_the_signal(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
@@ -74,7 +74,7 @@ impl Message2 {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 50;
     pub const SIGNAL_2_MIN: i8 = 0_i8;
     pub const SIGNAL_2_MAX: i8 = 0_i8;
-    /// Construct new Message_2 from values
+    /// Construct new 'Message_2' from values
     pub fn new(signal_2: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal_2(signal_2)?;
@@ -84,7 +84,7 @@ impl Message2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// signal_2
+    /// Get value of 'signal_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -94,7 +94,7 @@ impl Message2 {
     pub fn signal_2(&self) -> i8 {
         self.signal_2_raw()
     }
-    /// Get raw value of signal_2
+    /// Get raw value of 'signal_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -109,7 +109,7 @@ impl Message2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of signal_2
+    /// Set value of 'signal_2'
     #[inline(always)]
     pub fn set_signal_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -192,7 +192,7 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL_1_MIN: i8 = 0_i8;
     pub const SIGNAL_1_MAX: i8 = 0_i8;
-    /// Construct new Message_1 from values
+    /// Construct new 'Message_1' from values
     pub fn new(signal_1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal_1(signal_1)?;
@@ -202,7 +202,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// signal_1
+    /// Get value of 'signal_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -212,7 +212,7 @@ impl Message1 {
     pub fn signal_1(&self) -> i8 {
         self.signal_1_raw()
     }
-    /// Get raw value of signal_1
+    /// Get raw value of 'signal_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -227,7 +227,7 @@ impl Message1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of signal_1
+    /// Set value of 'signal_1'
     #[inline(always)]
     pub fn set_signal_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/big_numbers.snap.rs
+++ b/tests-snapshots/dbc-cantools/big_numbers.snap.rs
@@ -77,7 +77,7 @@ impl TheMessage {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
-    /// Construct new TheMessage from values
+    /// Construct new 'TheMessage' from values
     pub fn new(the_signal: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_the_signal(the_signal)?;
@@ -87,7 +87,7 @@ impl TheMessage {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TheSignal
+    /// Get value of 'TheSignal'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -97,7 +97,7 @@ impl TheMessage {
     pub fn the_signal(&self) -> i8 {
         self.the_signal_raw()
     }
-    /// Get raw value of TheSignal
+    /// Get raw value of 'TheSignal'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -112,7 +112,7 @@ impl TheMessage {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TheSignal
+    /// Set value of 'TheSignal'
     #[inline(always)]
     pub fn set_the_signal(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -194,7 +194,7 @@ impl TheOtherMessage {
     pub const MESSAGE_SIZE: usize = 8;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
-    /// Construct new TheOtherMessage from values
+    /// Construct new 'TheOtherMessage' from values
     pub fn new(the_signal: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_the_signal(the_signal)?;
@@ -204,7 +204,7 @@ impl TheOtherMessage {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TheSignal
+    /// Get value of 'TheSignal'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -214,7 +214,7 @@ impl TheOtherMessage {
     pub fn the_signal(&self) -> i8 {
         self.the_signal_raw()
     }
-    /// Get raw value of TheSignal
+    /// Get raw value of 'TheSignal'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -229,7 +229,7 @@ impl TheOtherMessage {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TheSignal
+    /// Set value of 'TheSignal'
     #[inline(always)]
     pub fn set_the_signal(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/bus_comment.snap.rs
+++ b/tests-snapshots/dbc-cantools/bus_comment.snap.rs
@@ -69,7 +69,7 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new(multiplexor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_multiplexor(multiplexor)?;
@@ -79,7 +79,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Multiplexor
+    /// Get raw value of 'Multiplexor'
     ///
     /// - Start bit: 2
     /// - Signal size: 6 bits
@@ -117,7 +117,7 @@ impl Message1 {
             }
         }
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     fn set_multiplexor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -135,7 +135,7 @@ impl Message1 {
         self.raw.view_bits_mut::<Lsb0>()[2..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m8(&mut self, value: Message1MultiplexorM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -144,7 +144,7 @@ impl Message1 {
         self.set_multiplexor(8)?;
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m24(&mut self, value: Message1MultiplexorM24) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -232,7 +232,7 @@ impl Message1MultiplexorM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_L
+    /// Get value of 'BIT_L'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -242,7 +242,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_l(&self) -> bool {
         self.bit_l_raw()
     }
-    /// Get raw value of BIT_L
+    /// Get raw value of 'BIT_L'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -255,14 +255,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_L
+    /// Set value of 'BIT_L'
     #[inline(always)]
     pub fn set_bit_l(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// BIT_G
+    /// Get value of 'BIT_G'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -272,7 +272,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_g(&self) -> bool {
         self.bit_g_raw()
     }
-    /// Get raw value of BIT_G
+    /// Get raw value of 'BIT_G'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -285,14 +285,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_G
+    /// Set value of 'BIT_G'
     #[inline(always)]
     pub fn set_bit_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// BIT_C
+    /// Get value of 'BIT_C'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -302,7 +302,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_c(&self) -> bool {
         self.bit_c_raw()
     }
-    /// Get raw value of BIT_C
+    /// Get raw value of 'BIT_C'
     ///
     /// - Start bit: 19
     /// - Signal size: 1 bits
@@ -315,14 +315,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[19..20].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_C
+    /// Set value of 'BIT_C'
     #[inline(always)]
     pub fn set_bit_c(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[19..20].store_le(value);
         Ok(())
     }
-    /// BIT_J
+    /// Get value of 'BIT_J'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -332,7 +332,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_j(&self) -> bool {
         self.bit_j_raw()
     }
-    /// Get raw value of BIT_J
+    /// Get raw value of 'BIT_J'
     ///
     /// - Start bit: 18
     /// - Signal size: 1 bits
@@ -345,7 +345,7 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[18..19].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_J
+    /// Set value of 'BIT_J'
     #[inline(always)]
     pub fn set_bit_j(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -379,7 +379,7 @@ impl Message1MultiplexorM24 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_F
+    /// Get value of 'BIT_F'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -389,7 +389,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_f(&self) -> bool {
         self.bit_f_raw()
     }
-    /// Get raw value of BIT_F
+    /// Get raw value of 'BIT_F'
     ///
     /// - Start bit: 39
     /// - Signal size: 1 bits
@@ -402,14 +402,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[39..40].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_F
+    /// Set value of 'BIT_F'
     #[inline(always)]
     pub fn set_bit_f(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[39..40].store_le(value);
         Ok(())
     }
-    /// BIT_H
+    /// Get value of 'BIT_H'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -419,7 +419,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_h(&self) -> bool {
         self.bit_h_raw()
     }
-    /// Get raw value of BIT_H
+    /// Get raw value of 'BIT_H'
     ///
     /// - Start bit: 38
     /// - Signal size: 1 bits
@@ -432,14 +432,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[38..39].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_H
+    /// Set value of 'BIT_H'
     #[inline(always)]
     pub fn set_bit_h(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[38..39].store_le(value);
         Ok(())
     }
-    /// BIT_B
+    /// Get value of 'BIT_B'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -449,7 +449,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_b(&self) -> bool {
         self.bit_b_raw()
     }
-    /// Get raw value of BIT_B
+    /// Get raw value of 'BIT_B'
     ///
     /// - Start bit: 33
     /// - Signal size: 1 bits
@@ -462,14 +462,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[33..34].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_B
+    /// Set value of 'BIT_B'
     #[inline(always)]
     pub fn set_bit_b(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[33..34].store_le(value);
         Ok(())
     }
-    /// BIT_D
+    /// Get value of 'BIT_D'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -479,7 +479,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_d(&self) -> bool {
         self.bit_d_raw()
     }
-    /// Get raw value of BIT_D
+    /// Get raw value of 'BIT_D'
     ///
     /// - Start bit: 32
     /// - Signal size: 1 bits
@@ -492,14 +492,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[32..33].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_D
+    /// Set value of 'BIT_D'
     #[inline(always)]
     pub fn set_bit_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[32..33].store_le(value);
         Ok(())
     }
-    /// BIT_E
+    /// Get value of 'BIT_E'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -509,7 +509,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_e(&self) -> bool {
         self.bit_e_raw()
     }
-    /// Get raw value of BIT_E
+    /// Get raw value of 'BIT_E'
     ///
     /// - Start bit: 29
     /// - Signal size: 1 bits
@@ -522,14 +522,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[29..30].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_E
+    /// Set value of 'BIT_E'
     #[inline(always)]
     pub fn set_bit_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[29..30].store_le(value);
         Ok(())
     }
-    /// BIT_K
+    /// Get value of 'BIT_K'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -539,7 +539,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_k(&self) -> bool {
         self.bit_k_raw()
     }
-    /// Get raw value of BIT_K
+    /// Get raw value of 'BIT_K'
     ///
     /// - Start bit: 28
     /// - Signal size: 1 bits
@@ -552,14 +552,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[28..29].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_K
+    /// Set value of 'BIT_K'
     #[inline(always)]
     pub fn set_bit_k(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[28..29].store_le(value);
         Ok(())
     }
-    /// BIT_A
+    /// Get value of 'BIT_A'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -569,7 +569,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_a(&self) -> bool {
         self.bit_a_raw()
     }
-    /// Get raw value of BIT_A
+    /// Get raw value of 'BIT_A'
     ///
     /// - Start bit: 26
     /// - Signal size: 1 bits
@@ -582,7 +582,7 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[26..27].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_A
+    /// Set value of 'BIT_A'
     #[inline(always)]
     pub fn set_bit_a(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;

--- a/tests-snapshots/dbc-cantools/choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices.snap.rs
@@ -118,11 +118,7 @@ impl Foo {
     /// Set value of 'Foo'
     #[inline(always)]
     pub fn set_foo(&mut self, value: FooFoo) -> Result<(), CanError> {
-        self.set_foo_raw(i8::from(value))
-    }
-    /// Set raw value of 'Foo'
-    #[inline(always)]
-    pub fn set_foo_raw(&mut self, value: i8) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < -128_i8 || 127_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Foo::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices.snap.rs
@@ -69,8 +69,8 @@ impl Foo {
     pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: i8 = -128_i8;
     pub const FOO_MAX: i8 = 127_i8;
-    /// Construct new Foo from values
-    pub fn new(foo: i8) -> Result<Self, CanError> {
+    /// Construct new 'Foo' from values
+    pub fn new(foo: FooFoo) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_foo(foo)?;
         Ok(res)
@@ -79,7 +79,7 @@ impl Foo {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Foo
+    /// Get value of 'Foo'
     ///
     /// - Min: -128
     /// - Max: 127
@@ -100,7 +100,7 @@ impl Foo {
             _ => FooFoo::_Other(self.foo_raw()),
         }
     }
-    /// Get raw value of Foo
+    /// Get raw value of 'Foo'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -115,9 +115,14 @@ impl Foo {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Foo
+    /// Set value of 'Foo'
     #[inline(always)]
-    pub fn set_foo(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_foo(&mut self, value: FooFoo) -> Result<(), CanError> {
+        self.set_foo_raw(i8::from(value))
+    }
+    /// Set raw value of 'Foo'
+    #[inline(always)]
+    pub fn set_foo_raw(&mut self, value: i8) -> Result<(), CanError> {
         if value < -128_i8 || 127_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Foo::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
@@ -115,11 +115,7 @@ impl TestMessage {
         &mut self,
         value: TestMessageSignalWithChoices,
     ) -> Result<(), CanError> {
-        self.set_signal_with_choices_raw(bool::from(value))
-    }
-    /// Set raw value of 'SignalWithChoices'
-    #[inline(always)]
-    pub fn set_signal_with_choices_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[0..1].store_le(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
+++ b/tests-snapshots/dbc-cantools/choices_issue_with_name.snap.rs
@@ -69,8 +69,10 @@ impl TestMessage {
         ExtendedId::new_unchecked(0x90000)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    /// Construct new TestMessage from values
-    pub fn new(signal_with_choices: bool) -> Result<Self, CanError> {
+    /// Construct new 'TestMessage' from values
+    pub fn new(
+        signal_with_choices: TestMessageSignalWithChoices,
+    ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_signal_with_choices(signal_with_choices)?;
         Ok(res)
@@ -79,7 +81,7 @@ impl TestMessage {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// SignalWithChoices
+    /// Get value of 'SignalWithChoices'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -94,7 +96,7 @@ impl TestMessage {
             _ => TestMessageSignalWithChoices::_Other(self.signal_with_choices_raw()),
         }
     }
-    /// Get raw value of SignalWithChoices
+    /// Get raw value of 'SignalWithChoices'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -107,9 +109,17 @@ impl TestMessage {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of SignalWithChoices
+    /// Set value of 'SignalWithChoices'
     #[inline(always)]
-    pub fn set_signal_with_choices(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_signal_with_choices(
+        &mut self,
+        value: TestMessageSignalWithChoices,
+    ) -> Result<(), CanError> {
+        self.set_signal_with_choices_raw(bool::from(value))
+    }
+    /// Set raw value of 'SignalWithChoices'
+    #[inline(always)]
+    pub fn set_signal_with_choices_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[0..1].store_le(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
+++ b/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
@@ -445,11 +445,7 @@ impl Msg2 {
     /// Set value of 'Test7'
     #[inline(always)]
     pub fn set_test7(&mut self, value: Msg2Test7) -> Result<(), CanError> {
-        self.set_test7_raw(u8::from(value))
-    }
-    /// Set raw value of 'Test7'
-    #[inline(always)]
-    pub fn set_test7_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Msg2::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
+++ b/tests-snapshots/dbc-cantools/comments_hex_and_motorola_converted_from_sym.snap.rs
@@ -77,7 +77,7 @@ impl Msg1 {
     pub const SIG12_MAX: u8 = 1_u8;
     pub const SIG1_MIN: u8 = 0_u8;
     pub const SIG1_MAX: u8 = 0_u8;
-    /// Construct new Msg1 from values
+    /// Construct new 'Msg1' from values
     pub fn new(sig1: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_sig1(sig1)?;
@@ -87,7 +87,7 @@ impl Msg1 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Get raw value of sig1
+    /// Get raw value of 'sig1'
     ///
     /// - Start bit: 7
     /// - Signal size: 8 bits
@@ -113,7 +113,7 @@ impl Msg1 {
             }
         }
     }
-    /// Set value of sig1
+    /// Set value of 'sig1'
     #[inline(always)]
     fn set_sig1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -131,7 +131,7 @@ impl Msg1 {
         self.raw.view_bits_mut::<Msb0>()[0..8].store_be(value);
         Ok(())
     }
-    /// Set value of sig1
+    /// Set value of 'sig1'
     #[inline(always)]
     pub fn set_m1(&mut self, value: Msg1Sig1M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -140,7 +140,7 @@ impl Msg1 {
         self.set_sig1(1)?;
         Ok(())
     }
-    /// Set value of sig1
+    /// Set value of 'sig1'
     #[inline(always)]
     pub fn set_m2(&mut self, value: Msg1Sig1M2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -228,7 +228,7 @@ impl Msg1Sig1M1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 2] }
     }
-    /// sig12
+    /// Get value of 'sig12'
     ///
     /// another comment for sig1=1
     ///
@@ -240,7 +240,7 @@ impl Msg1Sig1M1 {
     pub fn sig12(&self) -> u8 {
         self.sig12_raw()
     }
-    /// Get raw value of sig12
+    /// Get raw value of 'sig12'
     ///
     /// - Start bit: 15
     /// - Signal size: 8 bits
@@ -254,7 +254,7 @@ impl Msg1Sig1M1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of sig12
+    /// Set value of 'sig12'
     #[inline(always)]
     pub fn set_sig12(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 1_u8 < value {
@@ -299,7 +299,7 @@ impl Msg1Sig1M2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 2] }
     }
-    /// sig22
+    /// Get value of 'sig22'
     ///
     /// another comment for sig1=2
     ///
@@ -311,7 +311,7 @@ impl Msg1Sig1M2 {
     pub fn sig22(&self) -> u8 {
         self.sig22_raw()
     }
-    /// Get raw value of sig22
+    /// Get raw value of 'sig22'
     ///
     /// - Start bit: 15
     /// - Signal size: 8 bits
@@ -325,7 +325,7 @@ impl Msg1Sig1M2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of sig22
+    /// Set value of 'sig22'
     #[inline(always)]
     pub fn set_sig22(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 1_u8 < value {
@@ -385,9 +385,9 @@ impl Msg2 {
     pub const TEST1_MAX: u8 = 0_u8;
     pub const TEST0_MIN: u8 = 0_u8;
     pub const TEST0_MAX: u8 = 0_u8;
-    /// Construct new Msg2 from values
+    /// Construct new 'Msg2' from values
     pub fn new(
-        test7: u8,
+        test7: Msg2Test7,
         test6: u8,
         test5: u8,
         test4: u8,
@@ -411,7 +411,7 @@ impl Msg2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Test7
+    /// Get value of 'Test7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -428,7 +428,7 @@ impl Msg2 {
             _ => Msg2Test7::_Other(self.test7_raw()),
         }
     }
-    /// Get raw value of Test7
+    /// Get raw value of 'Test7'
     ///
     /// - Start bit: 63
     /// - Signal size: 8 bits
@@ -442,9 +442,14 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Test7
+    /// Set value of 'Test7'
     #[inline(always)]
-    pub fn set_test7(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_test7(&mut self, value: Msg2Test7) -> Result<(), CanError> {
+        self.set_test7_raw(u8::from(value))
+    }
+    /// Set raw value of 'Test7'
+    #[inline(always)]
+    pub fn set_test7_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Msg2::MESSAGE_ID,
@@ -460,7 +465,7 @@ impl Msg2 {
         self.raw.view_bits_mut::<Msb0>()[56..64].store_be(value);
         Ok(())
     }
-    /// Test6
+    /// Get value of 'Test6'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -470,7 +475,7 @@ impl Msg2 {
     pub fn test6(&self) -> u8 {
         self.test6_raw()
     }
-    /// Get raw value of Test6
+    /// Get raw value of 'Test6'
     ///
     /// - Start bit: 55
     /// - Signal size: 8 bits
@@ -484,7 +489,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Test6
+    /// Set value of 'Test6'
     #[inline(always)]
     pub fn set_test6(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -502,7 +507,7 @@ impl Msg2 {
         self.raw.view_bits_mut::<Msb0>()[48..56].store_be(value);
         Ok(())
     }
-    /// Test5
+    /// Get value of 'Test5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -512,7 +517,7 @@ impl Msg2 {
     pub fn test5(&self) -> u8 {
         self.test5_raw()
     }
-    /// Get raw value of Test5
+    /// Get raw value of 'Test5'
     ///
     /// - Start bit: 47
     /// - Signal size: 8 bits
@@ -526,7 +531,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Test5
+    /// Set value of 'Test5'
     #[inline(always)]
     pub fn set_test5(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -544,7 +549,7 @@ impl Msg2 {
         self.raw.view_bits_mut::<Msb0>()[40..48].store_be(value);
         Ok(())
     }
-    /// Test4
+    /// Get value of 'Test4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -554,7 +559,7 @@ impl Msg2 {
     pub fn test4(&self) -> u8 {
         self.test4_raw()
     }
-    /// Get raw value of Test4
+    /// Get raw value of 'Test4'
     ///
     /// - Start bit: 39
     /// - Signal size: 8 bits
@@ -568,7 +573,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Test4
+    /// Set value of 'Test4'
     #[inline(always)]
     pub fn set_test4(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -586,7 +591,7 @@ impl Msg2 {
         self.raw.view_bits_mut::<Msb0>()[32..40].store_be(value);
         Ok(())
     }
-    /// Test3
+    /// Get value of 'Test3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -596,7 +601,7 @@ impl Msg2 {
     pub fn test3(&self) -> u8 {
         self.test3_raw()
     }
-    /// Get raw value of Test3
+    /// Get raw value of 'Test3'
     ///
     /// - Start bit: 31
     /// - Signal size: 8 bits
@@ -610,7 +615,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Test3
+    /// Set value of 'Test3'
     #[inline(always)]
     pub fn set_test3(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -628,7 +633,7 @@ impl Msg2 {
         self.raw.view_bits_mut::<Msb0>()[24..32].store_be(value);
         Ok(())
     }
-    /// Test2
+    /// Get value of 'Test2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -638,7 +643,7 @@ impl Msg2 {
     pub fn test2(&self) -> u8 {
         self.test2_raw()
     }
-    /// Get raw value of Test2
+    /// Get raw value of 'Test2'
     ///
     /// - Start bit: 23
     /// - Signal size: 8 bits
@@ -652,7 +657,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Test2
+    /// Set value of 'Test2'
     #[inline(always)]
     pub fn set_test2(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -670,7 +675,7 @@ impl Msg2 {
         self.raw.view_bits_mut::<Msb0>()[16..24].store_be(value);
         Ok(())
     }
-    /// Test1
+    /// Get value of 'Test1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -680,7 +685,7 @@ impl Msg2 {
     pub fn test1(&self) -> u8 {
         self.test1_raw()
     }
-    /// Get raw value of Test1
+    /// Get raw value of 'Test1'
     ///
     /// - Start bit: 15
     /// - Signal size: 8 bits
@@ -694,7 +699,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Test1
+    /// Set value of 'Test1'
     #[inline(always)]
     pub fn set_test1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -712,7 +717,7 @@ impl Msg2 {
         self.raw.view_bits_mut::<Msb0>()[8..16].store_be(value);
         Ok(())
     }
-    /// Test0
+    /// Get value of 'Test0'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -722,7 +727,7 @@ impl Msg2 {
     pub fn test0(&self) -> u8 {
         self.test0_raw()
     }
-    /// Get raw value of Test0
+    /// Get raw value of 'Test0'
     ///
     /// - Start bit: 7
     /// - Signal size: 8 bits
@@ -736,7 +741,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Test0
+    /// Set value of 'Test0'
     #[inline(always)]
     pub fn set_test0(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {

--- a/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
@@ -120,11 +120,7 @@ impl Message0 {
     /// Set value of 'FooSignal'
     #[inline(always)]
     pub fn set_foo_signal(&mut self, value: Message0FooSignal) -> Result<(), CanError> {
-        self.set_foo_signal_raw(u8::from(value))
-    }
-    /// Set raw value of 'FooSignal'
-    #[inline(always)]
-    pub fn set_foo_signal_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Message0::MESSAGE_ID,
@@ -178,11 +174,7 @@ impl Message0 {
     /// Set value of 'BarSignal'
     #[inline(always)]
     pub fn set_bar_signal(&mut self, value: Message0BarSignal) -> Result<(), CanError> {
-        self.set_bar_signal_raw(u8::from(value))
-    }
-    /// Set raw value of 'BarSignal'
-    #[inline(always)]
-    pub fn set_bar_signal_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Message0::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/dump_signal_choices.snap.rs
@@ -72,8 +72,11 @@ impl Message0 {
     pub const FOO_SIGNAL_MAX: u8 = 0_u8;
     pub const BAR_SIGNAL_MIN: u8 = 0_u8;
     pub const BAR_SIGNAL_MAX: u8 = 0_u8;
-    /// Construct new Message0 from values
-    pub fn new(foo_signal: u8, bar_signal: u8) -> Result<Self, CanError> {
+    /// Construct new 'Message0' from values
+    pub fn new(
+        foo_signal: Message0FooSignal,
+        bar_signal: Message0BarSignal,
+    ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_foo_signal(foo_signal)?;
         res.set_bar_signal(bar_signal)?;
@@ -83,7 +86,7 @@ impl Message0 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// FooSignal
+    /// Get value of 'FooSignal'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -100,7 +103,7 @@ impl Message0 {
             _ => Message0FooSignal::_Other(self.foo_signal_raw()),
         }
     }
-    /// Get raw value of FooSignal
+    /// Get raw value of 'FooSignal'
     ///
     /// - Start bit: 0
     /// - Signal size: 2 bits
@@ -114,9 +117,14 @@ impl Message0 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of FooSignal
+    /// Set value of 'FooSignal'
     #[inline(always)]
-    pub fn set_foo_signal(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_foo_signal(&mut self, value: Message0FooSignal) -> Result<(), CanError> {
+        self.set_foo_signal_raw(u8::from(value))
+    }
+    /// Set raw value of 'FooSignal'
+    #[inline(always)]
+    pub fn set_foo_signal_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Message0::MESSAGE_ID,
@@ -132,7 +140,7 @@ impl Message0 {
         self.raw.view_bits_mut::<Lsb0>()[0..2].store_le(value);
         Ok(())
     }
-    /// BarSignal
+    /// Get value of 'BarSignal'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -153,7 +161,7 @@ impl Message0 {
             _ => Message0BarSignal::_Other(self.bar_signal_raw()),
         }
     }
-    /// Get raw value of BarSignal
+    /// Get raw value of 'BarSignal'
     ///
     /// - Start bit: 2
     /// - Signal size: 3 bits
@@ -167,9 +175,14 @@ impl Message0 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BarSignal
+    /// Set value of 'BarSignal'
     #[inline(always)]
-    pub fn set_bar_signal(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_bar_signal(&mut self, value: Message0BarSignal) -> Result<(), CanError> {
+        self.set_bar_signal_raw(u8::from(value))
+    }
+    /// Set raw value of 'BarSignal'
+    #[inline(always)]
+    pub fn set_bar_signal_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Message0::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/emc32.snap.rs
+++ b/tests-snapshots/dbc-cantools/emc32.snap.rs
@@ -68,7 +68,7 @@ impl EmvStati {
         StandardId::new_unchecked(0x222)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new EMV_Stati from values
+    /// Construct new 'EMV_Stati' from values
     pub fn new(
         emv_aktion_status_5: bool,
         emv_aktion_status_4: bool,
@@ -88,7 +88,7 @@ impl EmvStati {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// EMV_Aktion_Status_5
+    /// Get value of 'EMV_Aktion_Status_5'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -98,7 +98,7 @@ impl EmvStati {
     pub fn emv_aktion_status_5(&self) -> bool {
         self.emv_aktion_status_5_raw()
     }
-    /// Get raw value of EMV_Aktion_Status_5
+    /// Get raw value of 'EMV_Aktion_Status_5'
     ///
     /// - Start bit: 4
     /// - Signal size: 1 bits
@@ -111,14 +111,14 @@ impl EmvStati {
         let signal = self.raw.view_bits::<Lsb0>()[4..5].load_le::<u8>();
         signal == 1
     }
-    /// Set value of EMV_Aktion_Status_5
+    /// Set value of 'EMV_Aktion_Status_5'
     #[inline(always)]
     pub fn set_emv_aktion_status_5(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[4..5].store_le(value);
         Ok(())
     }
-    /// EMV_Aktion_Status_4
+    /// Get value of 'EMV_Aktion_Status_4'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -128,7 +128,7 @@ impl EmvStati {
     pub fn emv_aktion_status_4(&self) -> bool {
         self.emv_aktion_status_4_raw()
     }
-    /// Get raw value of EMV_Aktion_Status_4
+    /// Get raw value of 'EMV_Aktion_Status_4'
     ///
     /// - Start bit: 3
     /// - Signal size: 1 bits
@@ -141,14 +141,14 @@ impl EmvStati {
         let signal = self.raw.view_bits::<Lsb0>()[3..4].load_le::<u8>();
         signal == 1
     }
-    /// Set value of EMV_Aktion_Status_4
+    /// Set value of 'EMV_Aktion_Status_4'
     #[inline(always)]
     pub fn set_emv_aktion_status_4(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[3..4].store_le(value);
         Ok(())
     }
-    /// EMV_Aktion_Status_3
+    /// Get value of 'EMV_Aktion_Status_3'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -158,7 +158,7 @@ impl EmvStati {
     pub fn emv_aktion_status_3(&self) -> bool {
         self.emv_aktion_status_3_raw()
     }
-    /// Get raw value of EMV_Aktion_Status_3
+    /// Get raw value of 'EMV_Aktion_Status_3'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -171,14 +171,14 @@ impl EmvStati {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of EMV_Aktion_Status_3
+    /// Set value of 'EMV_Aktion_Status_3'
     #[inline(always)]
     pub fn set_emv_aktion_status_3(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// EMV_Aktion_Status_2
+    /// Get value of 'EMV_Aktion_Status_2'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -188,7 +188,7 @@ impl EmvStati {
     pub fn emv_aktion_status_2(&self) -> bool {
         self.emv_aktion_status_2_raw()
     }
-    /// Get raw value of EMV_Aktion_Status_2
+    /// Get raw value of 'EMV_Aktion_Status_2'
     ///
     /// - Start bit: 6
     /// - Signal size: 1 bits
@@ -201,14 +201,14 @@ impl EmvStati {
         let signal = self.raw.view_bits::<Lsb0>()[6..7].load_le::<u8>();
         signal == 1
     }
-    /// Set value of EMV_Aktion_Status_2
+    /// Set value of 'EMV_Aktion_Status_2'
     #[inline(always)]
     pub fn set_emv_aktion_status_2(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[6..7].store_le(value);
         Ok(())
     }
-    /// EMV_Aktion_Status_1
+    /// Get value of 'EMV_Aktion_Status_1'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -218,7 +218,7 @@ impl EmvStati {
     pub fn emv_aktion_status_1(&self) -> bool {
         self.emv_aktion_status_1_raw()
     }
-    /// Get raw value of EMV_Aktion_Status_1
+    /// Get raw value of 'EMV_Aktion_Status_1'
     ///
     /// - Start bit: 5
     /// - Signal size: 1 bits
@@ -231,7 +231,7 @@ impl EmvStati {
         let signal = self.raw.view_bits::<Lsb0>()[5..6].load_le::<u8>();
         signal == 1
     }
-    /// Set value of EMV_Aktion_Status_1
+    /// Set value of 'EMV_Aktion_Status_1'
     #[inline(always)]
     pub fn set_emv_aktion_status_1(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;

--- a/tests-snapshots/dbc-cantools/empty_choice.snap.rs
+++ b/tests-snapshots/dbc-cantools/empty_choice.snap.rs
@@ -170,11 +170,7 @@ impl ExampleMessage {
         &mut self,
         value: ExampleMessageEmptyChoice,
     ) -> Result<(), CanError> {
-        self.set_empty_choice_raw(i8::from(value))
-    }
-    /// Set raw value of 'empty_choice'
-    #[inline(always)]
-    pub fn set_empty_choice_raw(&mut self, value: i8) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: ExampleMessage::MESSAGE_ID,
@@ -227,11 +223,7 @@ impl ExampleMessage {
         &mut self,
         value: ExampleMessageNonEmptyChoice,
     ) -> Result<(), CanError> {
-        self.set_non_empty_choice_raw(i8::from(value))
-    }
-    /// Set raw value of 'non_empty_choice'
-    #[inline(always)]
-    pub fn set_non_empty_choice_raw(&mut self, value: i8) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: ExampleMessage::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/empty_choice.snap.rs
+++ b/tests-snapshots/dbc-cantools/empty_choice.snap.rs
@@ -76,11 +76,11 @@ impl ExampleMessage {
     pub const EMPTY_CHOICE_MAX: i8 = 0_i8;
     pub const NON_EMPTY_CHOICE_MIN: i8 = 0_i8;
     pub const NON_EMPTY_CHOICE_MAX: i8 = 0_i8;
-    /// Construct new example_message from values
+    /// Construct new 'example_message' from values
     pub fn new(
         no_choice: i8,
-        empty_choice: i8,
-        non_empty_choice: i8,
+        empty_choice: ExampleMessageEmptyChoice,
+        non_empty_choice: ExampleMessageNonEmptyChoice,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_no_choice(no_choice)?;
@@ -92,7 +92,7 @@ impl ExampleMessage {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// no_choice
+    /// Get value of 'no_choice'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -102,7 +102,7 @@ impl ExampleMessage {
     pub fn no_choice(&self) -> i8 {
         self.no_choice_raw()
     }
-    /// Get raw value of no_choice
+    /// Get raw value of 'no_choice'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -117,7 +117,7 @@ impl ExampleMessage {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of no_choice
+    /// Set value of 'no_choice'
     #[inline(always)]
     pub fn set_no_choice(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -136,7 +136,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// empty_choice
+    /// Get value of 'empty_choice'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -149,7 +149,7 @@ impl ExampleMessage {
             _ => ExampleMessageEmptyChoice::_Other(self.empty_choice_raw()),
         }
     }
-    /// Get raw value of empty_choice
+    /// Get raw value of 'empty_choice'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -164,9 +164,17 @@ impl ExampleMessage {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of empty_choice
+    /// Set value of 'empty_choice'
     #[inline(always)]
-    pub fn set_empty_choice(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_empty_choice(
+        &mut self,
+        value: ExampleMessageEmptyChoice,
+    ) -> Result<(), CanError> {
+        self.set_empty_choice_raw(i8::from(value))
+    }
+    /// Set raw value of 'empty_choice'
+    #[inline(always)]
+    pub fn set_empty_choice_raw(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: ExampleMessage::MESSAGE_ID,
@@ -183,7 +191,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// non_empty_choice
+    /// Get value of 'non_empty_choice'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -198,7 +206,7 @@ impl ExampleMessage {
             _ => ExampleMessageNonEmptyChoice::_Other(self.non_empty_choice_raw()),
         }
     }
-    /// Get raw value of non_empty_choice
+    /// Get raw value of 'non_empty_choice'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -213,9 +221,17 @@ impl ExampleMessage {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of non_empty_choice
+    /// Set value of 'non_empty_choice'
     #[inline(always)]
-    pub fn set_non_empty_choice(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_non_empty_choice(
+        &mut self,
+        value: ExampleMessageNonEmptyChoice,
+    ) -> Result<(), CanError> {
+        self.set_non_empty_choice_raw(i8::from(value))
+    }
+    /// Set raw value of 'non_empty_choice'
+    #[inline(always)]
+    pub fn set_non_empty_choice_raw(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: ExampleMessage::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/empty_choice.snap.stderr
+++ b/tests-snapshots/dbc-cantools/empty_choice.snap.stderr
@@ -1,7 +1,7 @@
 error: literal out of range for `i8`
-   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:330:59
+   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:322:59
     |
-330 |             ExampleMessageNonEmptyChoice::NotAvailable => 255,
+322 |             ExampleMessageNonEmptyChoice::NotAvailable => 255,
     |                                                           ^^^
     |
     = note: the literal `255` does not fit into the type `i8` whose range is `-128..=127`
@@ -9,9 +9,9 @@ error: literal out of range for `i8`
     = note: `#[deny(overflowing_literals)]` on by default
 
 error: literal out of range for `i8`
-   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:331:52
+   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:323:52
     |
-331 |             ExampleMessageNonEmptyChoice::Error => 254,
+323 |             ExampleMessageNonEmptyChoice::Error => 254,
     |                                                    ^^^
     |
     = note: the literal `254` does not fit into the type `i8` whose range is `-128..=127`

--- a/tests-snapshots/dbc-cantools/empty_choice.snap.stderr
+++ b/tests-snapshots/dbc-cantools/empty_choice.snap.stderr
@@ -1,7 +1,7 @@
 error: literal out of range for `i8`
-   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:314:59
+   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:330:59
     |
-314 |             ExampleMessageNonEmptyChoice::NotAvailable => 255,
+330 |             ExampleMessageNonEmptyChoice::NotAvailable => 255,
     |                                                           ^^^
     |
     = note: the literal `255` does not fit into the type `i8` whose range is `-128..=127`
@@ -9,9 +9,9 @@ error: literal out of range for `i8`
     = note: `#[deny(overflowing_literals)]` on by default
 
 error: literal out of range for `i8`
-   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:315:52
+   --> tests-snapshots/dbc-cantools/empty_choice.snap.rs:331:52
     |
-315 |             ExampleMessageNonEmptyChoice::Error => 254,
+331 |             ExampleMessageNonEmptyChoice::Error => 254,
     |                                                    ^^^
     |
     = note: the literal `254` does not fit into the type `i8` whose range is `-128..=127`

--- a/tests-snapshots/dbc-cantools/fd_test.snap.rs
+++ b/tests-snapshots/dbc-cantools/fd_test.snap.rs
@@ -84,7 +84,7 @@ impl TestMsgEx {
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_COPY_1_MIN: i8 = 0_i8;
     pub const TEST_SIG_COPY_1_MAX: i8 = 0_i8;
-    /// Construct new TestMsg_Ex from values
+    /// Construct new 'TestMsg_Ex' from values
     pub fn new(test_sig_copy_1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_test_sig_copy_1(test_sig_copy_1)?;
@@ -94,7 +94,7 @@ impl TestMsgEx {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TestSig_Copy_1
+    /// Get value of 'TestSig_Copy_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -104,7 +104,7 @@ impl TestMsgEx {
     pub fn test_sig_copy_1(&self) -> i8 {
         self.test_sig_copy_1_raw()
     }
-    /// Get raw value of TestSig_Copy_1
+    /// Get raw value of 'TestSig_Copy_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -119,7 +119,7 @@ impl TestMsgEx {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TestSig_Copy_1
+    /// Set value of 'TestSig_Copy_1'
     #[inline(always)]
     pub fn set_test_sig_copy_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -201,7 +201,7 @@ impl TestMsgStd {
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_COPY_3_MIN: i8 = 0_i8;
     pub const TEST_SIG_COPY_3_MAX: i8 = 0_i8;
-    /// Construct new TestMsg_Std from values
+    /// Construct new 'TestMsg_Std' from values
     pub fn new(test_sig_copy_3: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_test_sig_copy_3(test_sig_copy_3)?;
@@ -211,7 +211,7 @@ impl TestMsgStd {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TestSig_Copy_3
+    /// Get value of 'TestSig_Copy_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -221,7 +221,7 @@ impl TestMsgStd {
     pub fn test_sig_copy_3(&self) -> i8 {
         self.test_sig_copy_3_raw()
     }
-    /// Get raw value of TestSig_Copy_3
+    /// Get raw value of 'TestSig_Copy_3'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -236,7 +236,7 @@ impl TestMsgStd {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TestSig_Copy_3
+    /// Set value of 'TestSig_Copy_3'
     #[inline(always)]
     pub fn set_test_sig_copy_3(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -318,7 +318,7 @@ impl TestMsgFdStd {
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_COPY_2_MIN: i8 = 0_i8;
     pub const TEST_SIG_COPY_2_MAX: i8 = 0_i8;
-    /// Construct new TestMsg_FDStd from values
+    /// Construct new 'TestMsg_FDStd' from values
     pub fn new(test_sig_copy_2: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_test_sig_copy_2(test_sig_copy_2)?;
@@ -328,7 +328,7 @@ impl TestMsgFdStd {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TestSig_Copy_2
+    /// Get value of 'TestSig_Copy_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -338,7 +338,7 @@ impl TestMsgFdStd {
     pub fn test_sig_copy_2(&self) -> i8 {
         self.test_sig_copy_2_raw()
     }
-    /// Get raw value of TestSig_Copy_2
+    /// Get raw value of 'TestSig_Copy_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -353,7 +353,7 @@ impl TestMsgFdStd {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TestSig_Copy_2
+    /// Set value of 'TestSig_Copy_2'
     #[inline(always)]
     pub fn set_test_sig_copy_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -435,7 +435,7 @@ impl TestMsgFdEx {
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
-    /// Construct new TestMsg_FDEx from values
+    /// Construct new 'TestMsg_FDEx' from values
     pub fn new(test_sig: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_test_sig(test_sig)?;
@@ -445,7 +445,7 @@ impl TestMsgFdEx {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TestSig
+    /// Get value of 'TestSig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -455,7 +455,7 @@ impl TestMsgFdEx {
     pub fn test_sig(&self) -> i8 {
         self.test_sig_raw()
     }
-    /// Get raw value of TestSig
+    /// Get raw value of 'TestSig'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -470,7 +470,7 @@ impl TestMsgFdEx {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TestSig
+    /// Set value of 'TestSig'
     #[inline(always)]
     pub fn set_test_sig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/floating_point.snap.rs
+++ b/tests-snapshots/dbc-cantools/floating_point.snap.rs
@@ -73,7 +73,7 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i64 = 0_i64;
     pub const SIGNAL1_MAX: i64 = 0_i64;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new(signal1: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal1(signal1)?;
@@ -83,7 +83,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Signal1
+    /// Get value of 'Signal1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -93,7 +93,7 @@ impl Message1 {
     pub fn signal1(&self) -> i64 {
         self.signal1_raw()
     }
-    /// Get raw value of Signal1
+    /// Get raw value of 'Signal1'
     ///
     /// - Start bit: 0
     /// - Signal size: 64 bits
@@ -108,7 +108,7 @@ impl Message1 {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal1
+    /// Set value of 'Signal1'
     #[inline(always)]
     pub fn set_signal1(&mut self, value: i64) -> Result<(), CanError> {
         if value < 0_i64 || 0_i64 < value {
@@ -193,7 +193,7 @@ impl Message2 {
     pub const SIGNAL2_MAX: i32 = 0_i32;
     pub const SIGNAL1_MIN: i32 = 0_i32;
     pub const SIGNAL1_MAX: i32 = 0_i32;
-    /// Construct new Message2 from values
+    /// Construct new 'Message2' from values
     pub fn new(signal2: i32, signal1: i32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal2(signal2)?;
@@ -204,7 +204,7 @@ impl Message2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Signal2
+    /// Get value of 'Signal2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -214,7 +214,7 @@ impl Message2 {
     pub fn signal2(&self) -> i32 {
         self.signal2_raw()
     }
-    /// Get raw value of Signal2
+    /// Get raw value of 'Signal2'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -229,7 +229,7 @@ impl Message2 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal2
+    /// Set value of 'Signal2'
     #[inline(always)]
     pub fn set_signal2(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -248,7 +248,7 @@ impl Message2 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Signal1
+    /// Get value of 'Signal1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -258,7 +258,7 @@ impl Message2 {
     pub fn signal1(&self) -> i32 {
         self.signal1_raw()
     }
-    /// Get raw value of Signal1
+    /// Get raw value of 'Signal1'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -273,7 +273,7 @@ impl Message2 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal1
+    /// Set value of 'Signal1'
     #[inline(always)]
     pub fn set_signal1(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {

--- a/tests-snapshots/dbc-cantools/floating_point_use_float.snap.rs
+++ b/tests-snapshots/dbc-cantools/floating_point_use_float.snap.rs
@@ -76,7 +76,7 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i64 = 0_i64;
     pub const SIGNAL1_MAX: i64 = 0_i64;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new(signal1: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal1(signal1)?;
@@ -86,7 +86,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Signal1
+    /// Get value of 'Signal1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -96,7 +96,7 @@ impl Message1 {
     pub fn signal1(&self) -> i64 {
         self.signal1_raw()
     }
-    /// Get raw value of Signal1
+    /// Get raw value of 'Signal1'
     ///
     /// - Start bit: 0
     /// - Signal size: 64 bits
@@ -111,7 +111,7 @@ impl Message1 {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal1
+    /// Set value of 'Signal1'
     #[inline(always)]
     pub fn set_signal1(&mut self, value: i64) -> Result<(), CanError> {
         if value < 0_i64 || 0_i64 < value {
@@ -196,7 +196,7 @@ impl Message2 {
     pub const SIGNAL2_MAX: i32 = 0_i32;
     pub const SIGNAL1_MIN: i32 = 0_i32;
     pub const SIGNAL1_MAX: i32 = 0_i32;
-    /// Construct new Message2 from values
+    /// Construct new 'Message2' from values
     pub fn new(signal2: i32, signal1: i32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal2(signal2)?;
@@ -207,7 +207,7 @@ impl Message2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Signal2
+    /// Get value of 'Signal2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -217,7 +217,7 @@ impl Message2 {
     pub fn signal2(&self) -> i32 {
         self.signal2_raw()
     }
-    /// Get raw value of Signal2
+    /// Get raw value of 'Signal2'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -232,7 +232,7 @@ impl Message2 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal2
+    /// Set value of 'Signal2'
     #[inline(always)]
     pub fn set_signal2(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -251,7 +251,7 @@ impl Message2 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Signal1
+    /// Get value of 'Signal1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -261,7 +261,7 @@ impl Message2 {
     pub fn signal1(&self) -> i32 {
         self.signal1_raw()
     }
-    /// Get raw value of Signal1
+    /// Get raw value of 'Signal1'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -276,7 +276,7 @@ impl Message2 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal1
+    /// Set value of 'Signal1'
     #[inline(always)]
     pub fn set_signal1(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -358,7 +358,7 @@ impl Message3 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL3_MIN: f32 = 0_f32;
     pub const SIGNAL3_MAX: f32 = 0_f32;
-    /// Construct new Message3 from values
+    /// Construct new 'Message3' from values
     pub fn new(signal3: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal3(signal3)?;
@@ -368,7 +368,7 @@ impl Message3 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Signal3
+    /// Get value of 'Signal3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -378,7 +378,7 @@ impl Message3 {
     pub fn signal3(&self) -> f32 {
         self.signal3_raw()
     }
-    /// Get raw value of Signal3
+    /// Get raw value of 'Signal3'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -393,7 +393,7 @@ impl Message3 {
         let offset = -0.125_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Signal3
+    /// Set value of 'Signal3'
     #[inline(always)]
     pub fn set_signal3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {

--- a/tests-snapshots/dbc-cantools/foobar.snap.rs
+++ b/tests-snapshots/dbc-cantools/foobar.snap.rs
@@ -334,11 +334,7 @@ impl Fum {
     /// Set value of 'Fam'
     #[inline(always)]
     pub fn set_fam(&mut self, value: FumFam) -> Result<(), CanError> {
-        self.set_fam_raw(i16::from(value))
-    }
-    /// Set raw value of 'Fam'
-    #[inline(always)]
-    pub fn set_fam_raw(&mut self, value: i16) -> Result<(), CanError> {
+        let value = i16::from(value);
         if value < 0_i16 || 8_i16 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Fum::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/foobar.snap.rs
+++ b/tests-snapshots/dbc-cantools/foobar.snap.rs
@@ -86,7 +86,7 @@ impl Foo {
     pub const FOO_MAX: f32 = 270.47_f32;
     pub const BAR_MIN: f32 = 0_f32;
     pub const BAR_MAX: f32 = 5_f32;
-    /// Construct new Foo from values
+    /// Construct new 'Foo' from values
     pub fn new(foo: f32, bar: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_foo(foo)?;
@@ -97,7 +97,7 @@ impl Foo {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Foo
+    /// Get value of 'Foo'
     ///
     /// - Min: 229.53
     /// - Max: 270.47
@@ -107,7 +107,7 @@ impl Foo {
     pub fn foo(&self) -> f32 {
         self.foo_raw()
     }
-    /// Get raw value of Foo
+    /// Get raw value of 'Foo'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -122,7 +122,7 @@ impl Foo {
         let offset = 250_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Foo
+    /// Set value of 'Foo'
     #[inline(always)]
     pub fn set_foo(&mut self, value: f32) -> Result<(), CanError> {
         if value < 229.53_f32 || 270.47_f32 < value {
@@ -137,7 +137,7 @@ impl Foo {
         self.raw.view_bits_mut::<Msb0>()[7..19].store_be(value);
         Ok(())
     }
-    /// Bar
+    /// Get value of 'Bar'
     ///
     /// Bar.
     ///
@@ -149,7 +149,7 @@ impl Foo {
     pub fn bar(&self) -> f32 {
         self.bar_raw()
     }
-    /// Get raw value of Bar
+    /// Get raw value of 'Bar'
     ///
     /// - Start bit: 24
     /// - Signal size: 32 bits
@@ -164,7 +164,7 @@ impl Foo {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Bar
+    /// Set value of 'Bar'
     #[inline(always)]
     pub fn set_bar(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 5_f32 < value {
@@ -246,8 +246,8 @@ impl Fum {
     pub const FUM_MAX: i16 = 10_i16;
     pub const FAM_MIN: i16 = 0_i16;
     pub const FAM_MAX: i16 = 8_i16;
-    /// Construct new Fum from values
-    pub fn new(fum: i16, fam: i16) -> Result<Self, CanError> {
+    /// Construct new 'Fum' from values
+    pub fn new(fum: i16, fam: FumFam) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 5] };
         res.set_fum(fum)?;
         res.set_fam(fam)?;
@@ -257,7 +257,7 @@ impl Fum {
     pub fn raw(&self) -> &[u8; 5] {
         &self.raw
     }
-    /// Fum
+    /// Get value of 'Fum'
     ///
     /// - Min: 0
     /// - Max: 10
@@ -267,7 +267,7 @@ impl Fum {
     pub fn fum(&self) -> i16 {
         self.fum_raw()
     }
-    /// Get raw value of Fum
+    /// Get raw value of 'Fum'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -282,7 +282,7 @@ impl Fum {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Fum
+    /// Set value of 'Fum'
     #[inline(always)]
     pub fn set_fum(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 10_i16 < value {
@@ -301,7 +301,7 @@ impl Fum {
         self.raw.view_bits_mut::<Lsb0>()[0..12].store_le(value);
         Ok(())
     }
-    /// Fam
+    /// Get value of 'Fam'
     ///
     /// - Min: 0
     /// - Max: 8
@@ -316,7 +316,7 @@ impl Fum {
             _ => FumFam::_Other(self.fam_raw()),
         }
     }
-    /// Get raw value of Fam
+    /// Get raw value of 'Fam'
     ///
     /// - Start bit: 12
     /// - Signal size: 12 bits
@@ -331,9 +331,14 @@ impl Fum {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Fam
+    /// Set value of 'Fam'
     #[inline(always)]
-    pub fn set_fam(&mut self, value: i16) -> Result<(), CanError> {
+    pub fn set_fam(&mut self, value: FumFam) -> Result<(), CanError> {
+        self.set_fam_raw(i16::from(value))
+    }
+    /// Set raw value of 'Fam'
+    #[inline(always)]
+    pub fn set_fam_raw(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 8_i16 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Fum::MESSAGE_ID,
@@ -439,7 +444,7 @@ impl Bar {
     pub const MESSAGE_SIZE: usize = 4;
     pub const BINARY32_MIN: i32 = 0_i32;
     pub const BINARY32_MAX: i32 = 0_i32;
-    /// Construct new Bar from values
+    /// Construct new 'Bar' from values
     pub fn new(binary32: i32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 4] };
         res.set_binary32(binary32)?;
@@ -449,7 +454,7 @@ impl Bar {
     pub fn raw(&self) -> &[u8; 4] {
         &self.raw
     }
-    /// Binary32
+    /// Get value of 'Binary32'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -459,7 +464,7 @@ impl Bar {
     pub fn binary32(&self) -> i32 {
         self.binary32_raw()
     }
-    /// Get raw value of Binary32
+    /// Get raw value of 'Binary32'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -474,7 +479,7 @@ impl Bar {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Binary32
+    /// Set value of 'Binary32'
     #[inline(always)]
     pub fn set_binary32(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -559,7 +564,7 @@ impl CanFd {
     pub const FIE_MAX: u64 = 0_u64;
     pub const FAS_MIN: u64 = 0_u64;
     pub const FAS_MAX: u64 = 0_u64;
-    /// Construct new CanFd from values
+    /// Construct new 'CanFd' from values
     pub fn new(fie: u64, fas: u64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 64] };
         res.set_fie(fie)?;
@@ -570,7 +575,7 @@ impl CanFd {
     pub fn raw(&self) -> &[u8; 64] {
         &self.raw
     }
-    /// Fie
+    /// Get value of 'Fie'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -580,7 +585,7 @@ impl CanFd {
     pub fn fie(&self) -> u64 {
         self.fie_raw()
     }
-    /// Get raw value of Fie
+    /// Get raw value of 'Fie'
     ///
     /// - Start bit: 0
     /// - Signal size: 64 bits
@@ -594,7 +599,7 @@ impl CanFd {
         let factor = 1;
         u64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Fie
+    /// Set value of 'Fie'
     #[inline(always)]
     pub fn set_fie(&mut self, value: u64) -> Result<(), CanError> {
         if value < 0_u64 || 0_u64 < value {
@@ -612,7 +617,7 @@ impl CanFd {
         self.raw.view_bits_mut::<Lsb0>()[0..64].store_le(value);
         Ok(())
     }
-    /// Fas
+    /// Get value of 'Fas'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -622,7 +627,7 @@ impl CanFd {
     pub fn fas(&self) -> u64 {
         self.fas_raw()
     }
-    /// Get raw value of Fas
+    /// Get raw value of 'Fas'
     ///
     /// - Start bit: 64
     /// - Signal size: 64 bits
@@ -636,7 +641,7 @@ impl CanFd {
         let factor = 1;
         u64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Fas
+    /// Set value of 'Fas'
     #[inline(always)]
     pub fn set_fas(&mut self, value: u64) -> Result<(), CanError> {
         if value < 0_u64 || 0_u64 < value {
@@ -718,7 +723,7 @@ impl Foobar {
     pub const MESSAGE_SIZE: usize = 8;
     pub const ACC_02_CRC_MIN: i16 = 0_i16;
     pub const ACC_02_CRC_MAX: i16 = 1_i16;
-    /// Construct new FOOBAR from values
+    /// Construct new 'FOOBAR' from values
     pub fn new(acc_02_crc: i16) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_acc_02_crc(acc_02_crc)?;
@@ -728,7 +733,7 @@ impl Foobar {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// ACC_02_CRC
+    /// Get value of 'ACC_02_CRC'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -738,7 +743,7 @@ impl Foobar {
     pub fn acc_02_crc(&self) -> i16 {
         self.acc_02_crc_raw()
     }
-    /// Get raw value of ACC_02_CRC
+    /// Get raw value of 'ACC_02_CRC'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -753,7 +758,7 @@ impl Foobar {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ACC_02_CRC
+    /// Set value of 'ACC_02_CRC'
     #[inline(always)]
     pub fn set_acc_02_crc(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 1_i16 < value {

--- a/tests-snapshots/dbc-cantools/issue_163_newline.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_163_newline.snap.rs
@@ -68,7 +68,7 @@ impl DummyMsg {
         StandardId::new_unchecked(0x0)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new dummy_msg from values
+    /// Construct new 'dummy_msg' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)

--- a/tests-snapshots/dbc-cantools/issue_168.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_168.snap.rs
@@ -334,11 +334,7 @@ impl Fum {
     /// Set value of 'Fam'
     #[inline(always)]
     pub fn set_fam(&mut self, value: FumFam) -> Result<(), CanError> {
-        self.set_fam_raw(i16::from(value))
-    }
-    /// Set raw value of 'Fam'
-    #[inline(always)]
-    pub fn set_fam_raw(&mut self, value: i16) -> Result<(), CanError> {
+        let value = i16::from(value);
         if value < 0_i16 || 8_i16 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Fum::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/issue_168.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_168.snap.rs
@@ -86,7 +86,7 @@ impl Foo {
     pub const FOO_MAX: f32 = 270.47_f32;
     pub const BAR_MIN: f32 = 0_f32;
     pub const BAR_MAX: f32 = 5_f32;
-    /// Construct new Foo from values
+    /// Construct new 'Foo' from values
     pub fn new(foo: f32, bar: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_foo(foo)?;
@@ -97,7 +97,7 @@ impl Foo {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Foo
+    /// Get value of 'Foo'
     ///
     /// - Min: 229.53
     /// - Max: 270.47
@@ -107,7 +107,7 @@ impl Foo {
     pub fn foo(&self) -> f32 {
         self.foo_raw()
     }
-    /// Get raw value of Foo
+    /// Get raw value of 'Foo'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -122,7 +122,7 @@ impl Foo {
         let offset = 250_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Foo
+    /// Set value of 'Foo'
     #[inline(always)]
     pub fn set_foo(&mut self, value: f32) -> Result<(), CanError> {
         if value < 229.53_f32 || 270.47_f32 < value {
@@ -137,7 +137,7 @@ impl Foo {
         self.raw.view_bits_mut::<Msb0>()[7..19].store_be(value);
         Ok(())
     }
-    /// Bar
+    /// Get value of 'Bar'
     ///
     /// Bar.
     ///
@@ -149,7 +149,7 @@ impl Foo {
     pub fn bar(&self) -> f32 {
         self.bar_raw()
     }
-    /// Get raw value of Bar
+    /// Get raw value of 'Bar'
     ///
     /// - Start bit: 24
     /// - Signal size: 32 bits
@@ -164,7 +164,7 @@ impl Foo {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Bar
+    /// Set value of 'Bar'
     #[inline(always)]
     pub fn set_bar(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 5_f32 < value {
@@ -246,8 +246,8 @@ impl Fum {
     pub const FUM_MAX: i16 = 10_i16;
     pub const FAM_MIN: i16 = 0_i16;
     pub const FAM_MAX: i16 = 8_i16;
-    /// Construct new Fum from values
-    pub fn new(fum: i16, fam: i16) -> Result<Self, CanError> {
+    /// Construct new 'Fum' from values
+    pub fn new(fum: i16, fam: FumFam) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 5] };
         res.set_fum(fum)?;
         res.set_fam(fam)?;
@@ -257,7 +257,7 @@ impl Fum {
     pub fn raw(&self) -> &[u8; 5] {
         &self.raw
     }
-    /// Fum
+    /// Get value of 'Fum'
     ///
     /// - Min: 0
     /// - Max: 10
@@ -267,7 +267,7 @@ impl Fum {
     pub fn fum(&self) -> i16 {
         self.fum_raw()
     }
-    /// Get raw value of Fum
+    /// Get raw value of 'Fum'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -282,7 +282,7 @@ impl Fum {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Fum
+    /// Set value of 'Fum'
     #[inline(always)]
     pub fn set_fum(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 10_i16 < value {
@@ -301,7 +301,7 @@ impl Fum {
         self.raw.view_bits_mut::<Lsb0>()[0..12].store_le(value);
         Ok(())
     }
-    /// Fam
+    /// Get value of 'Fam'
     ///
     /// - Min: 0
     /// - Max: 8
@@ -316,7 +316,7 @@ impl Fum {
             _ => FumFam::_Other(self.fam_raw()),
         }
     }
-    /// Get raw value of Fam
+    /// Get raw value of 'Fam'
     ///
     /// - Start bit: 12
     /// - Signal size: 12 bits
@@ -331,9 +331,14 @@ impl Fum {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Fam
+    /// Set value of 'Fam'
     #[inline(always)]
-    pub fn set_fam(&mut self, value: i16) -> Result<(), CanError> {
+    pub fn set_fam(&mut self, value: FumFam) -> Result<(), CanError> {
+        self.set_fam_raw(i16::from(value))
+    }
+    /// Set raw value of 'Fam'
+    #[inline(always)]
+    pub fn set_fam_raw(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 8_i16 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Fum::MESSAGE_ID,
@@ -439,7 +444,7 @@ impl Bar {
     pub const MESSAGE_SIZE: usize = 4;
     pub const BINARY32_MIN: i32 = 0_i32;
     pub const BINARY32_MAX: i32 = 0_i32;
-    /// Construct new Bar from values
+    /// Construct new 'Bar' from values
     pub fn new(binary32: i32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 4] };
         res.set_binary32(binary32)?;
@@ -449,7 +454,7 @@ impl Bar {
     pub fn raw(&self) -> &[u8; 4] {
         &self.raw
     }
-    /// Binary32
+    /// Get value of 'Binary32'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -459,7 +464,7 @@ impl Bar {
     pub fn binary32(&self) -> i32 {
         self.binary32_raw()
     }
-    /// Get raw value of Binary32
+    /// Get raw value of 'Binary32'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -474,7 +479,7 @@ impl Bar {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Binary32
+    /// Set value of 'Binary32'
     #[inline(always)]
     pub fn set_binary32(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -559,7 +564,7 @@ impl CanFd {
     pub const FIE_MAX: u64 = 0_u64;
     pub const FAS_MIN: u64 = 0_u64;
     pub const FAS_MAX: u64 = 0_u64;
-    /// Construct new CanFd from values
+    /// Construct new 'CanFd' from values
     pub fn new(fie: u64, fas: u64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 64] };
         res.set_fie(fie)?;
@@ -570,7 +575,7 @@ impl CanFd {
     pub fn raw(&self) -> &[u8; 64] {
         &self.raw
     }
-    /// Fie
+    /// Get value of 'Fie'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -580,7 +585,7 @@ impl CanFd {
     pub fn fie(&self) -> u64 {
         self.fie_raw()
     }
-    /// Get raw value of Fie
+    /// Get raw value of 'Fie'
     ///
     /// - Start bit: 0
     /// - Signal size: 64 bits
@@ -594,7 +599,7 @@ impl CanFd {
         let factor = 1;
         u64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Fie
+    /// Set value of 'Fie'
     #[inline(always)]
     pub fn set_fie(&mut self, value: u64) -> Result<(), CanError> {
         if value < 0_u64 || 0_u64 < value {
@@ -612,7 +617,7 @@ impl CanFd {
         self.raw.view_bits_mut::<Lsb0>()[0..64].store_le(value);
         Ok(())
     }
-    /// Fas
+    /// Get value of 'Fas'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -622,7 +627,7 @@ impl CanFd {
     pub fn fas(&self) -> u64 {
         self.fas_raw()
     }
-    /// Get raw value of Fas
+    /// Get raw value of 'Fas'
     ///
     /// - Start bit: 64
     /// - Signal size: 64 bits
@@ -636,7 +641,7 @@ impl CanFd {
         let factor = 1;
         u64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Fas
+    /// Set value of 'Fas'
     #[inline(always)]
     pub fn set_fas(&mut self, value: u64) -> Result<(), CanError> {
         if value < 0_u64 || 0_u64 < value {
@@ -718,7 +723,7 @@ impl Foobar {
     pub const MESSAGE_SIZE: usize = 8;
     pub const ACC_02_CRC_MIN: i16 = 0_i16;
     pub const ACC_02_CRC_MAX: i16 = 1_i16;
-    /// Construct new FOOBAR from values
+    /// Construct new 'FOOBAR' from values
     pub fn new(acc_02_crc: i16) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_acc_02_crc(acc_02_crc)?;
@@ -728,7 +733,7 @@ impl Foobar {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// ACC_02_CRC
+    /// Get value of 'ACC_02_CRC'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -738,7 +743,7 @@ impl Foobar {
     pub fn acc_02_crc(&self) -> i16 {
         self.acc_02_crc_raw()
     }
-    /// Get raw value of ACC_02_CRC
+    /// Get raw value of 'ACC_02_CRC'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -753,7 +758,7 @@ impl Foobar {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ACC_02_CRC
+    /// Set value of 'ACC_02_CRC'
     #[inline(always)]
     pub fn set_acc_02_crc(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 1_i16 < value {

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded.snap.rs
@@ -79,7 +79,7 @@ impl ExtMuxCascaded {
     pub const MUXED_A_1_MAX: i8 = 0_i8;
     pub const MUX_A_MIN: i8 = 0_i8;
     pub const MUX_A_MAX: i8 = 0_i8;
-    /// Construct new ext_MUX_cascaded from values
+    /// Construct new 'ext_MUX_cascaded' from values
     pub fn new(mux_a: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_mux_a(mux_a)?;
@@ -89,7 +89,7 @@ impl ExtMuxCascaded {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of MUX_A
+    /// Get raw value of 'MUX_A'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -128,7 +128,7 @@ impl ExtMuxCascaded {
             }
         }
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     fn set_mux_a(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -147,7 +147,7 @@ impl ExtMuxCascaded {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -156,7 +156,7 @@ impl ExtMuxCascaded {
         self.set_mux_a(0)?;
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -244,7 +244,7 @@ impl ExtMuxCascadedMuxAM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_B_0
+    /// Get value of 'muxed_B_0'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -254,7 +254,7 @@ impl ExtMuxCascadedMuxAM0 {
     pub fn muxed_b_0(&self) -> i8 {
         self.muxed_b_0_raw()
     }
-    /// Get raw value of muxed_B_0
+    /// Get raw value of 'muxed_B_0'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -269,7 +269,7 @@ impl ExtMuxCascadedMuxAM0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_B_0
+    /// Set value of 'muxed_B_0'
     #[inline(always)]
     pub fn set_muxed_b_0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -315,7 +315,7 @@ impl ExtMuxCascadedMuxAM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_B_1
+    /// Get value of 'muxed_B_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -325,7 +325,7 @@ impl ExtMuxCascadedMuxAM1 {
     pub fn muxed_b_1(&self) -> i8 {
         self.muxed_b_1_raw()
     }
-    /// Get raw value of muxed_B_1
+    /// Get raw value of 'muxed_B_1'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -340,7 +340,7 @@ impl ExtMuxCascadedMuxAM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_B_1
+    /// Set value of 'muxed_B_1'
     #[inline(always)]
     pub fn set_muxed_b_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -359,7 +359,7 @@ impl ExtMuxCascadedMuxAM1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// muxed_A_1
+    /// Get value of 'muxed_A_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -369,7 +369,7 @@ impl ExtMuxCascadedMuxAM1 {
     pub fn muxed_a_1(&self) -> i8 {
         self.muxed_a_1_raw()
     }
-    /// Get raw value of muxed_A_1
+    /// Get raw value of 'muxed_A_1'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -384,7 +384,7 @@ impl ExtMuxCascadedMuxAM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_A_1
+    /// Set value of 'muxed_A_1'
     #[inline(always)]
     pub fn set_muxed_a_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs
@@ -79,7 +79,7 @@ impl ExtMuxCascaded {
     pub const MUXED_A_2_MUX_B_MAX: i8 = 0_i8;
     pub const MUX_A_MIN: i8 = 0_i8;
     pub const MUX_A_MAX: i8 = 0_i8;
-    /// Construct new ext_MUX_cascaded from values
+    /// Construct new 'ext_MUX_cascaded' from values
     pub fn new(muxed_a_2_mux_b: i8, mux_a: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_muxed_a_2_mux_b(muxed_a_2_mux_b)?;
@@ -90,7 +90,7 @@ impl ExtMuxCascaded {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of muxed_A_2_MUX_B
+    /// Get raw value of 'muxed_A_2_MUX_B'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -131,7 +131,7 @@ impl ExtMuxCascaded {
             }
         }
     }
-    /// Set value of muxed_A_2_MUX_B
+    /// Set value of 'muxed_A_2_MUX_B'
     #[inline(always)]
     fn set_muxed_a_2_mux_b(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -150,7 +150,7 @@ impl ExtMuxCascaded {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Set value of muxed_A_2_MUX_B
+    /// Set value of 'muxed_A_2_MUX_B'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -162,7 +162,7 @@ impl ExtMuxCascaded {
         self.set_muxed_a_2_mux_b(0)?;
         Ok(())
     }
-    /// Set value of muxed_A_2_MUX_B
+    /// Set value of 'muxed_A_2_MUX_B'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -174,7 +174,7 @@ impl ExtMuxCascaded {
         self.set_muxed_a_2_mux_b(1)?;
         Ok(())
     }
-    /// Get raw value of MUX_A
+    /// Get raw value of 'MUX_A'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -213,7 +213,7 @@ impl ExtMuxCascaded {
             }
         }
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     fn set_mux_a(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -232,7 +232,7 @@ impl ExtMuxCascaded {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -241,7 +241,7 @@ impl ExtMuxCascaded {
         self.set_mux_a(0)?;
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -329,7 +329,7 @@ impl ExtMuxCascadedMuxedA2MuxBM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_B_0
+    /// Get value of 'muxed_B_0'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -339,7 +339,7 @@ impl ExtMuxCascadedMuxedA2MuxBM0 {
     pub fn muxed_b_0(&self) -> i8 {
         self.muxed_b_0_raw()
     }
-    /// Get raw value of muxed_B_0
+    /// Get raw value of 'muxed_B_0'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -354,7 +354,7 @@ impl ExtMuxCascadedMuxedA2MuxBM0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_B_0
+    /// Set value of 'muxed_B_0'
     #[inline(always)]
     pub fn set_muxed_b_0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -400,7 +400,7 @@ impl ExtMuxCascadedMuxedA2MuxBM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_B_1
+    /// Get value of 'muxed_B_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -410,7 +410,7 @@ impl ExtMuxCascadedMuxedA2MuxBM1 {
     pub fn muxed_b_1(&self) -> i8 {
         self.muxed_b_1_raw()
     }
-    /// Get raw value of muxed_B_1
+    /// Get raw value of 'muxed_B_1'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -425,7 +425,7 @@ impl ExtMuxCascadedMuxedA2MuxBM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_B_1
+    /// Set value of 'muxed_B_1'
     #[inline(always)]
     pub fn set_muxed_b_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -444,7 +444,7 @@ impl ExtMuxCascadedMuxedA2MuxBM1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// muxed_A_1
+    /// Get value of 'muxed_A_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -454,7 +454,7 @@ impl ExtMuxCascadedMuxedA2MuxBM1 {
     pub fn muxed_a_1(&self) -> i8 {
         self.muxed_a_1_raw()
     }
-    /// Get raw value of muxed_A_1
+    /// Get raw value of 'muxed_A_1'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -469,7 +469,7 @@ impl ExtMuxCascadedMuxedA2MuxBM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_A_1
+    /// Set value of 'muxed_A_1'
     #[inline(always)]
     pub fn set_muxed_a_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
@@ -24,13 +24,7 @@ error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM0` i
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
 196 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-    |                                                 ^^^^^^^^^^^^^^^^^^^^
-    |
-help: a struct with a similar name exists
-    |
-196 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-196 +                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascaded {
-    |
+    |                                                 ^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxCascaded`
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:203:49
@@ -39,13 +33,7 @@ error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM1` i
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
 203 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-    |                                                 ^^^^^^^^^^^^^^^^^^^^
-    |
-help: a struct with a similar name exists
-    |
-203 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-203 +                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascaded {
-    |
+    |                                                 ^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxCascaded`
 
 error[E0425]: cannot find type `ExtMuxCascadedMuxAM0` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:237:37
@@ -54,13 +42,7 @@ error[E0425]: cannot find type `ExtMuxCascadedMuxAM0` in this scope
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
 237 |     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^^^^^^^^^
-    |
-help: a struct with a similar name exists
-    |
-237 -     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
-237 +     pub fn set_m0(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
-    |
+    |                                     ^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxCascaded`
 
 error[E0425]: cannot find type `ExtMuxCascadedMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:246:37
@@ -69,13 +51,7 @@ error[E0425]: cannot find type `ExtMuxCascadedMuxAM1` in this scope
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
 246 |     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^^^^^^^^^
-    |
-help: a struct with a similar name exists
-    |
-246 -     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
-246 +     pub fn set_m1(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
-    |
+    |                                     ^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxCascaded`
 
 error[E0592]: duplicate definitions with name `set_m0`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:237:5
@@ -101,26 +77,20 @@ error[E0592]: duplicate definitions with name `set_m1`
 246 |       pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m1`
 
-error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtMuxCascadedMuxAIndex`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:196:21
     |
 196 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-196 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-196 +                     ExtMuxCascadedMuxedA2MuxBIndex::M0(ExtMuxCascadedMuxAM0 {
-    |
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtMuxCascadedMuxAIndex`
+    |                     help: an enum with a similar name exists: `ExtMuxCascadedMuxedA2MuxBIndex`
 
-error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtMuxCascadedMuxAIndex`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:203:21
     |
 203 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-203 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-203 +                     ExtMuxCascadedMuxedA2MuxBIndex::M1(ExtMuxCascadedMuxAM1 {
-    |
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtMuxCascadedMuxAIndex`
+    |                     help: an enum with a similar name exists: `ExtMuxCascadedMuxedA2MuxBIndex`

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
@@ -24,7 +24,13 @@ error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM0` i
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
 196 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-    |                                                 ^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxCascaded`
+    |                                                 ^^^^^^^^^^^^^^^^^^^^
+    |
+help: a struct with a similar name exists
+    |
+196 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+196 +                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascaded {
+    |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:203:49
@@ -33,7 +39,13 @@ error[E0422]: cannot find struct, variant or union type `ExtMuxCascadedMuxAM1` i
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
 203 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-    |                                                 ^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxCascaded`
+    |                                                 ^^^^^^^^^^^^^^^^^^^^
+    |
+help: a struct with a similar name exists
+    |
+203 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+203 +                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascaded {
+    |
 
 error[E0425]: cannot find type `ExtMuxCascadedMuxAM0` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:237:37
@@ -42,7 +54,13 @@ error[E0425]: cannot find type `ExtMuxCascadedMuxAM0` in this scope
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
 237 |     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxCascaded`
+    |                                     ^^^^^^^^^^^^^^^^^^^^
+    |
+help: a struct with a similar name exists
+    |
+237 -     pub fn set_m0(&mut self, value: ExtMuxCascadedMuxAM0) -> Result<(), CanError> {
+237 +     pub fn set_m0(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
+    |
 
 error[E0425]: cannot find type `ExtMuxCascadedMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:246:37
@@ -51,7 +69,13 @@ error[E0425]: cannot find type `ExtMuxCascadedMuxAM1` in this scope
     | ------------------------- similarly named struct `ExtMuxCascaded` defined here
 ...
 246 |     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxCascaded`
+    |                                     ^^^^^^^^^^^^^^^^^^^^
+    |
+help: a struct with a similar name exists
+    |
+246 -     pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
+246 +     pub fn set_m1(&mut self, value: ExtMuxCascaded) -> Result<(), CanError> {
+    |
 
 error[E0592]: duplicate definitions with name `set_m0`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:237:5
@@ -77,20 +101,26 @@ error[E0592]: duplicate definitions with name `set_m1`
 246 |       pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m1`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxCascadedMuxAIndex`
+error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:196:21
     |
 196 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtMuxCascadedMuxAIndex`
-    |                     help: an enum with a similar name exists: `ExtMuxCascadedMuxedA2MuxBIndex`
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+196 -                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
+196 +                     ExtMuxCascadedMuxedA2MuxBIndex::M0(ExtMuxCascadedMuxAM0 {
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxCascadedMuxAIndex`
+error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:203:21
     |
 203 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtMuxCascadedMuxAIndex`
-    |                     help: an enum with a similar name exists: `ExtMuxCascadedMuxedA2MuxBIndex`
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxCascadedMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+203 -                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {
+203 +                     ExtMuxCascadedMuxedA2MuxBIndex::M1(ExtMuxCascadedMuxAM1 {
+    |

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs
@@ -83,7 +83,7 @@ impl ExtMuxIndepMultiplexors {
     pub const MUXED_A_0_MAX: i8 = 0_i8;
     pub const MUX_A_MIN: i8 = 0_i8;
     pub const MUX_A_MAX: i8 = 0_i8;
-    /// Construct new ext_MUX_indep_multiplexors from values
+    /// Construct new 'ext_MUX_indep_multiplexors' from values
     pub fn new(mux_b: i8, mux_a: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_mux_b(mux_b)?;
@@ -94,7 +94,7 @@ impl ExtMuxIndepMultiplexors {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of MUX_B
+    /// Get raw value of 'MUX_B'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -140,7 +140,7 @@ impl ExtMuxIndepMultiplexors {
             }
         }
     }
-    /// Set value of MUX_B
+    /// Set value of 'MUX_B'
     #[inline(always)]
     fn set_mux_b(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -159,7 +159,7 @@ impl ExtMuxIndepMultiplexors {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Set value of MUX_B
+    /// Set value of 'MUX_B'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -171,7 +171,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_b(0)?;
         Ok(())
     }
-    /// Set value of MUX_B
+    /// Set value of 'MUX_B'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -183,7 +183,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_b(1)?;
         Ok(())
     }
-    /// Set value of MUX_B
+    /// Set value of 'MUX_B'
     #[inline(always)]
     pub fn set_m2(
         &mut self,
@@ -195,7 +195,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_b(2)?;
         Ok(())
     }
-    /// Get raw value of MUX_A
+    /// Get raw value of 'MUX_A'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -241,7 +241,7 @@ impl ExtMuxIndepMultiplexors {
             }
         }
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     fn set_mux_a(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -260,7 +260,7 @@ impl ExtMuxIndepMultiplexors {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -272,7 +272,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_a(0)?;
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -284,7 +284,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_a(1)?;
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m2(
         &mut self,
@@ -376,7 +376,7 @@ impl ExtMuxIndepMultiplexorsMuxBM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_A_0
+    /// Get value of 'muxed_A_0'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -386,7 +386,7 @@ impl ExtMuxIndepMultiplexorsMuxBM0 {
     pub fn muxed_a_0(&self) -> i8 {
         self.muxed_a_0_raw()
     }
-    /// Get raw value of muxed_A_0
+    /// Get raw value of 'muxed_A_0'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -401,7 +401,7 @@ impl ExtMuxIndepMultiplexorsMuxBM0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_A_0
+    /// Set value of 'muxed_A_0'
     #[inline(always)]
     pub fn set_muxed_a_0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -447,7 +447,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_B_1
+    /// Get value of 'muxed_B_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -457,7 +457,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
     pub fn muxed_b_1(&self) -> i8 {
         self.muxed_b_1_raw()
     }
-    /// Get raw value of muxed_B_1
+    /// Get raw value of 'muxed_B_1'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -472,7 +472,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_B_1
+    /// Set value of 'muxed_B_1'
     #[inline(always)]
     pub fn set_muxed_b_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -491,7 +491,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// muxed_A_1
+    /// Get value of 'muxed_A_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -501,7 +501,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
     pub fn muxed_a_1(&self) -> i8 {
         self.muxed_a_1_raw()
     }
-    /// Get raw value of muxed_A_1
+    /// Get raw value of 'muxed_A_1'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -516,7 +516,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_A_1
+    /// Set value of 'muxed_A_1'
     #[inline(always)]
     pub fn set_muxed_a_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -562,7 +562,7 @@ impl ExtMuxIndepMultiplexorsMuxBM2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_B_2
+    /// Get value of 'muxed_B_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -572,7 +572,7 @@ impl ExtMuxIndepMultiplexorsMuxBM2 {
     pub fn muxed_b_2(&self) -> i8 {
         self.muxed_b_2_raw()
     }
-    /// Get raw value of muxed_B_2
+    /// Get raw value of 'muxed_B_2'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -587,7 +587,7 @@ impl ExtMuxIndepMultiplexorsMuxBM2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_B_2
+    /// Set value of 'muxed_B_2'
     #[inline(always)]
     pub fn set_muxed_b_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
@@ -21,91 +21,55 @@ error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexors
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:217:58
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM0`
 ...
 363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
-    |
-help: a struct with a similar name exists
-    |
-217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-217 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
-    |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:224:58
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM1`
 ...
 434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
-    |
-help: a struct with a similar name exists
-    |
-224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-224 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
-    |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:231:58
     |
 231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM2`
 ...
 549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
-    |
-help: a struct with a similar name exists
-    |
-231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-231 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
-    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:267:16
     |
 267 |         value: ExtMuxIndepMultiplexorsMuxAM0,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM0`
 ...
 363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
-    |
-help: a struct with a similar name exists
-    |
-267 -         value: ExtMuxIndepMultiplexorsMuxAM0,
-267 +         value: ExtMuxIndepMultiplexorsMuxBM0,
-    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:279:16
     |
 279 |         value: ExtMuxIndepMultiplexorsMuxAM1,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM1`
 ...
 434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
-    |
-help: a struct with a similar name exists
-    |
-279 -         value: ExtMuxIndepMultiplexorsMuxAM1,
-279 +         value: ExtMuxIndepMultiplexorsMuxBM1,
-    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:291:16
     |
 291 |         value: ExtMuxIndepMultiplexorsMuxAM2,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM2`
 ...
 549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
-    |
-help: a struct with a similar name exists
-    |
-291 -         value: ExtMuxIndepMultiplexorsMuxAM2,
-291 +         value: ExtMuxIndepMultiplexorsMuxBM2,
-    |
 
 error[E0592]: duplicate definitions with name `set_m0`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:265:5
@@ -152,38 +116,29 @@ error[E0592]: duplicate definitions with name `set_m2`
 292 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:217:21
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
 
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:224:21
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
 
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:231:21
     |
 231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-231 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
@@ -21,55 +21,91 @@ error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexors
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:217:58
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM0`
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
+    |
+help: a struct with a similar name exists
+    |
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
+    |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:224:58
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM1`
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
+    |
+help: a struct with a similar name exists
+    |
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
+    |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:231:58
     |
 231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM2`
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
+    |
+help: a struct with a similar name exists
+    |
+231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
+    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:267:16
     |
 267 |         value: ExtMuxIndepMultiplexorsMuxAM0,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM0`
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
+    |
+help: a struct with a similar name exists
+    |
+267 -         value: ExtMuxIndepMultiplexorsMuxAM0,
+267 +         value: ExtMuxIndepMultiplexorsMuxBM0,
+    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:279:16
     |
 279 |         value: ExtMuxIndepMultiplexorsMuxAM1,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM1`
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
+    |
+help: a struct with a similar name exists
+    |
+279 -         value: ExtMuxIndepMultiplexorsMuxAM1,
+279 +         value: ExtMuxIndepMultiplexorsMuxBM1,
+    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:291:16
     |
 291 |         value: ExtMuxIndepMultiplexorsMuxAM2,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM2`
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
+    |
+help: a struct with a similar name exists
+    |
+291 -         value: ExtMuxIndepMultiplexorsMuxAM2,
+291 +         value: ExtMuxIndepMultiplexorsMuxBM2,
+    |
 
 error[E0592]: duplicate definitions with name `set_m0`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:265:5
@@ -116,29 +152,38 @@ error[E0592]: duplicate definitions with name `set_m2`
 292 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:217:21
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:224:21
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:231:21
     |
 231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+    |

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs
@@ -83,7 +83,7 @@ impl ExtMuxIndepMultiplexors {
     pub const MUXED_A_1_MAX: i8 = 0_i8;
     pub const MUX_A_MIN: i8 = 0_i8;
     pub const MUX_A_MAX: i8 = 0_i8;
-    /// Construct new ext_MUX_indep_multiplexors from values
+    /// Construct new 'ext_MUX_indep_multiplexors' from values
     pub fn new(mux_b: i8, mux_a: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_mux_b(mux_b)?;
@@ -94,7 +94,7 @@ impl ExtMuxIndepMultiplexors {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of MUX_B
+    /// Get raw value of 'MUX_B'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -140,7 +140,7 @@ impl ExtMuxIndepMultiplexors {
             }
         }
     }
-    /// Set value of MUX_B
+    /// Set value of 'MUX_B'
     #[inline(always)]
     fn set_mux_b(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -159,7 +159,7 @@ impl ExtMuxIndepMultiplexors {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Set value of MUX_B
+    /// Set value of 'MUX_B'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -171,7 +171,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_b(0)?;
         Ok(())
     }
-    /// Set value of MUX_B
+    /// Set value of 'MUX_B'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -183,7 +183,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_b(1)?;
         Ok(())
     }
-    /// Set value of MUX_B
+    /// Set value of 'MUX_B'
     #[inline(always)]
     pub fn set_m2(
         &mut self,
@@ -195,7 +195,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_b(2)?;
         Ok(())
     }
-    /// Get raw value of MUX_A
+    /// Get raw value of 'MUX_A'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -241,7 +241,7 @@ impl ExtMuxIndepMultiplexors {
             }
         }
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     fn set_mux_a(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -260,7 +260,7 @@ impl ExtMuxIndepMultiplexors {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -272,7 +272,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_a(0)?;
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -284,7 +284,7 @@ impl ExtMuxIndepMultiplexors {
         self.set_mux_a(1)?;
         Ok(())
     }
-    /// Set value of MUX_A
+    /// Set value of 'MUX_A'
     #[inline(always)]
     pub fn set_m2(
         &mut self,
@@ -376,7 +376,7 @@ impl ExtMuxIndepMultiplexorsMuxBM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_A_0
+    /// Get value of 'muxed_A_0'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -386,7 +386,7 @@ impl ExtMuxIndepMultiplexorsMuxBM0 {
     pub fn muxed_a_0(&self) -> i8 {
         self.muxed_a_0_raw()
     }
-    /// Get raw value of muxed_A_0
+    /// Get raw value of 'muxed_A_0'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -401,7 +401,7 @@ impl ExtMuxIndepMultiplexorsMuxBM0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_A_0
+    /// Set value of 'muxed_A_0'
     #[inline(always)]
     pub fn set_muxed_a_0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -447,7 +447,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_B_1
+    /// Get value of 'muxed_B_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -457,7 +457,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
     pub fn muxed_b_1(&self) -> i8 {
         self.muxed_b_1_raw()
     }
-    /// Get raw value of muxed_B_1
+    /// Get raw value of 'muxed_B_1'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -472,7 +472,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_B_1
+    /// Set value of 'muxed_B_1'
     #[inline(always)]
     pub fn set_muxed_b_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -491,7 +491,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// muxed_A_1
+    /// Get value of 'muxed_A_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -501,7 +501,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
     pub fn muxed_a_1(&self) -> i8 {
         self.muxed_a_1_raw()
     }
-    /// Get raw value of muxed_A_1
+    /// Get raw value of 'muxed_A_1'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -516,7 +516,7 @@ impl ExtMuxIndepMultiplexorsMuxBM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_A_1
+    /// Set value of 'muxed_A_1'
     #[inline(always)]
     pub fn set_muxed_a_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -562,7 +562,7 @@ impl ExtMuxIndepMultiplexorsMuxBM2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_B_2
+    /// Get value of 'muxed_B_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -572,7 +572,7 @@ impl ExtMuxIndepMultiplexorsMuxBM2 {
     pub fn muxed_b_2(&self) -> i8 {
         self.muxed_b_2_raw()
     }
-    /// Get raw value of muxed_B_2
+    /// Get raw value of 'muxed_B_2'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -587,7 +587,7 @@ impl ExtMuxIndepMultiplexorsMuxBM2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_B_2
+    /// Set value of 'muxed_B_2'
     #[inline(always)]
     pub fn set_muxed_b_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
@@ -21,91 +21,55 @@ error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexors
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:217:58
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM0`
 ...
 363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
-    |
-help: a struct with a similar name exists
-    |
-217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-217 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
-    |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:224:58
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM1`
 ...
 434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
-    |
-help: a struct with a similar name exists
-    |
-224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-224 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
-    |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:231:58
     |
 231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM2`
 ...
 549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
-    |
-help: a struct with a similar name exists
-    |
-231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-231 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
-    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:267:16
     |
 267 |         value: ExtMuxIndepMultiplexorsMuxAM0,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM0`
 ...
 363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
-    |
-help: a struct with a similar name exists
-    |
-267 -         value: ExtMuxIndepMultiplexorsMuxAM0,
-267 +         value: ExtMuxIndepMultiplexorsMuxBM0,
-    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:279:16
     |
 279 |         value: ExtMuxIndepMultiplexorsMuxAM1,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM1`
 ...
 434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
-    |
-help: a struct with a similar name exists
-    |
-279 -         value: ExtMuxIndepMultiplexorsMuxAM1,
-279 +         value: ExtMuxIndepMultiplexorsMuxBM1,
-    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:291:16
     |
 291 |         value: ExtMuxIndepMultiplexorsMuxAM2,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM2`
 ...
 549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
-    |
-help: a struct with a similar name exists
-    |
-291 -         value: ExtMuxIndepMultiplexorsMuxAM2,
-291 +         value: ExtMuxIndepMultiplexorsMuxBM2,
-    |
 
 error[E0592]: duplicate definitions with name `set_m0`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:265:5
@@ -152,38 +116,29 @@ error[E0592]: duplicate definitions with name `set_m2`
 292 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:217:21
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
 
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:224:21
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
 
-error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:231:21
     |
 231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |
-help: an enum with a similar name exists
-    |
-231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-231 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
@@ -21,55 +21,91 @@ error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexors
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:217:58
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM0`
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
+    |
+help: a struct with a similar name exists
+    |
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxBM0 {
+    |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:224:58
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM1`
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
+    |
+help: a struct with a similar name exists
+    |
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxBM1 {
+    |
 
 error[E0422]: cannot find struct, variant or union type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:231:58
     |
 231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM2`
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
+    |
+help: a struct with a similar name exists
+    |
+231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 +                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxBM2 {
+    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM0` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:267:16
     |
 267 |         value: ExtMuxIndepMultiplexorsMuxAM0,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM0`
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 363 | pub struct ExtMuxIndepMultiplexorsMuxBM0 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM0` defined here
+    |
+help: a struct with a similar name exists
+    |
+267 -         value: ExtMuxIndepMultiplexorsMuxAM0,
+267 +         value: ExtMuxIndepMultiplexorsMuxBM0,
+    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM1` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:279:16
     |
 279 |         value: ExtMuxIndepMultiplexorsMuxAM1,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM1`
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 434 | pub struct ExtMuxIndepMultiplexorsMuxBM1 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM1` defined here
+    |
+help: a struct with a similar name exists
+    |
+279 -         value: ExtMuxIndepMultiplexorsMuxAM1,
+279 +         value: ExtMuxIndepMultiplexorsMuxBM1,
+    |
 
 error[E0425]: cannot find type `ExtMuxIndepMultiplexorsMuxAM2` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:291:16
     |
 291 |         value: ExtMuxIndepMultiplexorsMuxAM2,
-    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtMuxIndepMultiplexorsMuxBM2`
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 549 | pub struct ExtMuxIndepMultiplexorsMuxBM2 {
     | ---------------------------------------- similarly named struct `ExtMuxIndepMultiplexorsMuxBM2` defined here
+    |
+help: a struct with a similar name exists
+    |
+291 -         value: ExtMuxIndepMultiplexorsMuxAM2,
+291 +         value: ExtMuxIndepMultiplexorsMuxBM2,
+    |
 
 error[E0592]: duplicate definitions with name `set_m0`
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:265:5
@@ -116,29 +152,38 @@ error[E0592]: duplicate definitions with name `set_m2`
 292 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:217:21
     |
 217 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+217 -                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+217 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:224:21
     |
 224 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+224 -                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+224 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:231:21
     |
 231 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
-    |                     help: an enum with a similar name exists: `ExtMuxIndepMultiplexorsMuxBIndex`
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+    |
+help: an enum with a similar name exists
+    |
+231 -                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+231 +                     ExtMuxIndepMultiplexorsMuxBIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {
+    |

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values.snap.rs
@@ -77,7 +77,7 @@ impl ExtMuxMultipleValues {
     pub const MUXED_0_3_4_5_MAX: i8 = 0_i8;
     pub const MUX_MIN: i8 = 0_i8;
     pub const MUX_MAX: i8 = 0_i8;
-    /// Construct new ext_MUX_multiple_values from values
+    /// Construct new 'ext_MUX_multiple_values' from values
     pub fn new(mux: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_mux(mux)?;
@@ -87,7 +87,7 @@ impl ExtMuxMultipleValues {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of MUX
+    /// Get raw value of 'MUX'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -133,7 +133,7 @@ impl ExtMuxMultipleValues {
             }
         }
     }
-    /// Set value of MUX
+    /// Set value of 'MUX'
     #[inline(always)]
     fn set_mux(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -152,7 +152,7 @@ impl ExtMuxMultipleValues {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Set value of MUX
+    /// Set value of 'MUX'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtMuxMultipleValuesMuxM0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -161,7 +161,7 @@ impl ExtMuxMultipleValues {
         self.set_mux(0)?;
         Ok(())
     }
-    /// Set value of MUX
+    /// Set value of 'MUX'
     #[inline(always)]
     pub fn set_m1(&mut self, value: ExtMuxMultipleValuesMuxM1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -170,7 +170,7 @@ impl ExtMuxMultipleValues {
         self.set_mux(1)?;
         Ok(())
     }
-    /// Set value of MUX
+    /// Set value of 'MUX'
     #[inline(always)]
     pub fn set_m2(&mut self, value: ExtMuxMultipleValuesMuxM2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -259,7 +259,7 @@ impl ExtMuxMultipleValuesMuxM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_0_3_4_5
+    /// Get value of 'muxed_0_3_4_5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -269,7 +269,7 @@ impl ExtMuxMultipleValuesMuxM0 {
     pub fn muxed_0_3_4_5(&self) -> i8 {
         self.muxed_0_3_4_5_raw()
     }
-    /// Get raw value of muxed_0_3_4_5
+    /// Get raw value of 'muxed_0_3_4_5'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -284,7 +284,7 @@ impl ExtMuxMultipleValuesMuxM0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_0_3_4_5
+    /// Set value of 'muxed_0_3_4_5'
     #[inline(always)]
     pub fn set_muxed_0_3_4_5(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -330,7 +330,7 @@ impl ExtMuxMultipleValuesMuxM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_1
+    /// Get value of 'muxed_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -340,7 +340,7 @@ impl ExtMuxMultipleValuesMuxM1 {
     pub fn muxed_1(&self) -> i8 {
         self.muxed_1_raw()
     }
-    /// Get raw value of muxed_1
+    /// Get raw value of 'muxed_1'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -355,7 +355,7 @@ impl ExtMuxMultipleValuesMuxM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_1
+    /// Set value of 'muxed_1'
     #[inline(always)]
     pub fn set_muxed_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -401,7 +401,7 @@ impl ExtMuxMultipleValuesMuxM2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_2
+    /// Get value of 'muxed_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -411,7 +411,7 @@ impl ExtMuxMultipleValuesMuxM2 {
     pub fn muxed_2(&self) -> i8 {
         self.muxed_2_raw()
     }
-    /// Get raw value of muxed_2
+    /// Get raw value of 'muxed_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -426,7 +426,7 @@ impl ExtMuxMultipleValuesMuxM2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_2
+    /// Set value of 'muxed_2'
     #[inline(always)]
     pub fn set_muxed_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_multiple_values_dumped.snap.rs
@@ -77,7 +77,7 @@ impl ExtMuxMultipleValues {
     pub const MUXED_2_MAX: i8 = 0_i8;
     pub const MUX_MIN: i8 = 0_i8;
     pub const MUX_MAX: i8 = 0_i8;
-    /// Construct new ext_MUX_multiple_values from values
+    /// Construct new 'ext_MUX_multiple_values' from values
     pub fn new(mux: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_mux(mux)?;
@@ -87,7 +87,7 @@ impl ExtMuxMultipleValues {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of MUX
+    /// Get raw value of 'MUX'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -133,7 +133,7 @@ impl ExtMuxMultipleValues {
             }
         }
     }
-    /// Set value of MUX
+    /// Set value of 'MUX'
     #[inline(always)]
     fn set_mux(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -152,7 +152,7 @@ impl ExtMuxMultipleValues {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Set value of MUX
+    /// Set value of 'MUX'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtMuxMultipleValuesMuxM0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -161,7 +161,7 @@ impl ExtMuxMultipleValues {
         self.set_mux(0)?;
         Ok(())
     }
-    /// Set value of MUX
+    /// Set value of 'MUX'
     #[inline(always)]
     pub fn set_m1(&mut self, value: ExtMuxMultipleValuesMuxM1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -170,7 +170,7 @@ impl ExtMuxMultipleValues {
         self.set_mux(1)?;
         Ok(())
     }
-    /// Set value of MUX
+    /// Set value of 'MUX'
     #[inline(always)]
     pub fn set_m2(&mut self, value: ExtMuxMultipleValuesMuxM2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -259,7 +259,7 @@ impl ExtMuxMultipleValuesMuxM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_0_3_4_5
+    /// Get value of 'muxed_0_3_4_5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -269,7 +269,7 @@ impl ExtMuxMultipleValuesMuxM0 {
     pub fn muxed_0_3_4_5(&self) -> i8 {
         self.muxed_0_3_4_5_raw()
     }
-    /// Get raw value of muxed_0_3_4_5
+    /// Get raw value of 'muxed_0_3_4_5'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -284,7 +284,7 @@ impl ExtMuxMultipleValuesMuxM0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_0_3_4_5
+    /// Set value of 'muxed_0_3_4_5'
     #[inline(always)]
     pub fn set_muxed_0_3_4_5(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -330,7 +330,7 @@ impl ExtMuxMultipleValuesMuxM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_1
+    /// Get value of 'muxed_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -340,7 +340,7 @@ impl ExtMuxMultipleValuesMuxM1 {
     pub fn muxed_1(&self) -> i8 {
         self.muxed_1_raw()
     }
-    /// Get raw value of muxed_1
+    /// Get raw value of 'muxed_1'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -355,7 +355,7 @@ impl ExtMuxMultipleValuesMuxM1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_1
+    /// Set value of 'muxed_1'
     #[inline(always)]
     pub fn set_muxed_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -401,7 +401,7 @@ impl ExtMuxMultipleValuesMuxM2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// muxed_2
+    /// Get value of 'muxed_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -411,7 +411,7 @@ impl ExtMuxMultipleValuesMuxM2 {
     pub fn muxed_2(&self) -> i8 {
         self.muxed_2_raw()
     }
-    /// Get raw value of muxed_2
+    /// Get raw value of 'muxed_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -426,7 +426,7 @@ impl ExtMuxMultipleValuesMuxM2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of muxed_2
+    /// Set value of 'muxed_2'
     #[inline(always)]
     pub fn set_muxed_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/issue_199.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.rs
@@ -164,11 +164,7 @@ impl DriverDoorStatus {
         &mut self,
         value: DriverDoorStatusDriverDoorOpened,
     ) -> Result<(), CanError> {
-        self.set_driver_door_opened_raw(bool::from(value))
-    }
-    /// Set raw value of 'DriverDoorOpened'
-    #[inline(always)]
-    pub fn set_driver_door_opened_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[7..8].store_be(value);
         Ok(())
@@ -637,11 +633,7 @@ impl BlinkerStatus {
         &mut self,
         value: BlinkerStatusRightBlinker,
     ) -> Result<(), CanError> {
-        self.set_right_blinker_raw(bool::from(value))
-    }
-    /// Set raw value of 'RightBlinker'
-    #[inline(always)]
-    pub fn set_right_blinker_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[1..2].store_be(value);
         Ok(())
@@ -680,11 +672,7 @@ impl BlinkerStatus {
         &mut self,
         value: BlinkerStatusLeftBlinker,
     ) -> Result<(), CanError> {
-        self.set_left_blinker_raw(bool::from(value))
-    }
-    /// Set raw value of 'LeftBlinker'
-    #[inline(always)]
-    pub fn set_left_blinker_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())
@@ -723,11 +711,7 @@ impl BlinkerStatus {
         &mut self,
         value: BlinkerStatusBlinkerLight,
     ) -> Result<(), CanError> {
-        self.set_blinker_light_raw(bool::from(value))
-    }
-    /// Set raw value of 'BlinkerLight'
-    #[inline(always)]
-    pub fn set_blinker_light_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[30..31].store_be(value);
         Ok(())
@@ -1055,11 +1039,7 @@ impl GearShifter {
         &mut self,
         value: GearShifterGearShifter,
     ) -> Result<(), CanError> {
-        self.set_gear_shifter_raw(u8::from(value))
-    }
-    /// Set raw value of 'GearShifter'
-    #[inline(always)]
-    pub fn set_gear_shifter_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: GearShifter::MESSAGE_ID,
@@ -1272,14 +1252,7 @@ impl GasPedalRegenCruise {
         &mut self,
         value: GasPedalRegenCruiseCruiseControlActive,
     ) -> Result<(), CanError> {
-        self.set_cruise_control_active_raw(bool::from(value))
-    }
-    /// Set raw value of 'CruiseControlActive'
-    #[inline(always)]
-    pub fn set_cruise_control_active_raw(
-        &mut self,
-        value: bool,
-    ) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[63..64].store_be(value);
         Ok(())
@@ -2145,11 +2118,7 @@ impl CruiseButtons {
         &mut self,
         value: CruiseButtonsCruiseButtons,
     ) -> Result<(), CanError> {
-        self.set_cruise_buttons_raw(u8::from(value))
-    }
-    /// Set raw value of 'CruiseButtons'
-    #[inline(always)]
-    pub fn set_cruise_buttons_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 12_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CruiseButtons::MESSAGE_ID,
@@ -2275,11 +2244,7 @@ impl CruiseButtons2 {
         &mut self,
         value: CruiseButtons2LkaGapButton,
     ) -> Result<(), CanError> {
-        self.set_lka_gap_button_raw(u8::from(value))
-    }
-    /// Set raw value of 'LKAGapButton'
-    #[inline(always)]
-    pub fn set_lka_gap_button_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 2_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CruiseButtons2::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/issue_199.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.rs
@@ -118,8 +118,10 @@ impl DriverDoorStatus {
         StandardId::new_unchecked(0x0)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    /// Construct new DriverDoorStatus from values
-    pub fn new(driver_door_opened: bool) -> Result<Self, CanError> {
+    /// Construct new 'DriverDoorStatus' from values
+    pub fn new(
+        driver_door_opened: DriverDoorStatusDriverDoorOpened,
+    ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_driver_door_opened(driver_door_opened)?;
         Ok(res)
@@ -128,7 +130,7 @@ impl DriverDoorStatus {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// DriverDoorOpened
+    /// Get value of 'DriverDoorOpened'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -143,7 +145,7 @@ impl DriverDoorStatus {
             _ => DriverDoorStatusDriverDoorOpened::_Other(self.driver_door_opened_raw()),
         }
     }
-    /// Get raw value of DriverDoorOpened
+    /// Get raw value of 'DriverDoorOpened'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -156,9 +158,17 @@ impl DriverDoorStatus {
         let signal = self.raw.view_bits::<Msb0>()[7..8].load_be::<u8>();
         signal == 1
     }
-    /// Set value of DriverDoorOpened
+    /// Set value of 'DriverDoorOpened'
     #[inline(always)]
-    pub fn set_driver_door_opened(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_driver_door_opened(
+        &mut self,
+        value: DriverDoorStatusDriverDoorOpened,
+    ) -> Result<(), CanError> {
+        self.set_driver_door_opened_raw(bool::from(value))
+    }
+    /// Set raw value of 'DriverDoorOpened'
+    #[inline(always)]
+    pub fn set_driver_door_opened_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[7..8].store_be(value);
         Ok(())
@@ -260,7 +270,7 @@ impl Chime {
     pub const CHIME_BYTE5_MAX: u8 = 0_u8;
     pub const CHIME_BYTE4_MIN: u8 = 0_u8;
     pub const CHIME_BYTE4_MAX: u8 = 0_u8;
-    /// Construct new Chime from values
+    /// Construct new 'Chime' from values
     pub fn new(
         chime_type: u8,
         chime_repeat: u8,
@@ -280,7 +290,7 @@ impl Chime {
     pub fn raw(&self) -> &[u8; 5] {
         &self.raw
     }
-    /// ChimeType
+    /// Get value of 'ChimeType'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -290,7 +300,7 @@ impl Chime {
     pub fn chime_type(&self) -> u8 {
         self.chime_type_raw()
     }
-    /// Get raw value of ChimeType
+    /// Get raw value of 'ChimeType'
     ///
     /// - Start bit: 7
     /// - Signal size: 8 bits
@@ -304,7 +314,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeType
+    /// Set value of 'ChimeType'
     #[inline(always)]
     pub fn set_chime_type(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -322,7 +332,7 @@ impl Chime {
         self.raw.view_bits_mut::<Msb0>()[0..8].store_be(value);
         Ok(())
     }
-    /// ChimeRepeat
+    /// Get value of 'ChimeRepeat'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -332,7 +342,7 @@ impl Chime {
     pub fn chime_repeat(&self) -> u8 {
         self.chime_repeat_raw()
     }
-    /// Get raw value of ChimeRepeat
+    /// Get raw value of 'ChimeRepeat'
     ///
     /// - Start bit: 23
     /// - Signal size: 8 bits
@@ -346,7 +356,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeRepeat
+    /// Set value of 'ChimeRepeat'
     #[inline(always)]
     pub fn set_chime_repeat(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -364,7 +374,7 @@ impl Chime {
         self.raw.view_bits_mut::<Msb0>()[16..24].store_be(value);
         Ok(())
     }
-    /// ChimeDuration
+    /// Get value of 'ChimeDuration'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -374,7 +384,7 @@ impl Chime {
     pub fn chime_duration(&self) -> u8 {
         self.chime_duration_raw()
     }
-    /// Get raw value of ChimeDuration
+    /// Get raw value of 'ChimeDuration'
     ///
     /// - Start bit: 15
     /// - Signal size: 8 bits
@@ -388,7 +398,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeDuration
+    /// Set value of 'ChimeDuration'
     #[inline(always)]
     pub fn set_chime_duration(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -406,7 +416,7 @@ impl Chime {
         self.raw.view_bits_mut::<Msb0>()[8..16].store_be(value);
         Ok(())
     }
-    /// ChimeByte5
+    /// Get value of 'ChimeByte5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -416,7 +426,7 @@ impl Chime {
     pub fn chime_byte5(&self) -> u8 {
         self.chime_byte5_raw()
     }
-    /// Get raw value of ChimeByte5
+    /// Get raw value of 'ChimeByte5'
     ///
     /// - Start bit: 39
     /// - Signal size: 8 bits
@@ -430,7 +440,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeByte5
+    /// Set value of 'ChimeByte5'
     #[inline(always)]
     pub fn set_chime_byte5(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -448,7 +458,7 @@ impl Chime {
         self.raw.view_bits_mut::<Msb0>()[32..40].store_be(value);
         Ok(())
     }
-    /// ChimeByte4
+    /// Get value of 'ChimeByte4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -458,7 +468,7 @@ impl Chime {
     pub fn chime_byte4(&self) -> u8 {
         self.chime_byte4_raw()
     }
-    /// Get raw value of ChimeByte4
+    /// Get raw value of 'ChimeByte4'
     ///
     /// - Start bit: 31
     /// - Signal size: 8 bits
@@ -472,7 +482,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeByte4
+    /// Set value of 'ChimeByte4'
     #[inline(always)]
     pub fn set_chime_byte4(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -577,11 +587,11 @@ impl BlinkerStatus {
         StandardId::new_unchecked(0xc000)
     });
     pub const MESSAGE_SIZE: usize = 5;
-    /// Construct new BlinkerStatus from values
+    /// Construct new 'BlinkerStatus' from values
     pub fn new(
-        right_blinker: bool,
-        left_blinker: bool,
-        blinker_light: bool,
+        right_blinker: BlinkerStatusRightBlinker,
+        left_blinker: BlinkerStatusLeftBlinker,
+        blinker_light: BlinkerStatusBlinkerLight,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 5] };
         res.set_right_blinker(right_blinker)?;
@@ -593,7 +603,7 @@ impl BlinkerStatus {
     pub fn raw(&self) -> &[u8; 5] {
         &self.raw
     }
-    /// RightBlinker
+    /// Get value of 'RightBlinker'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -608,7 +618,7 @@ impl BlinkerStatus {
             _ => BlinkerStatusRightBlinker::_Other(self.right_blinker_raw()),
         }
     }
-    /// Get raw value of RightBlinker
+    /// Get raw value of 'RightBlinker'
     ///
     /// - Start bit: 6
     /// - Signal size: 1 bits
@@ -621,14 +631,22 @@ impl BlinkerStatus {
         let signal = self.raw.view_bits::<Msb0>()[1..2].load_be::<u8>();
         signal == 1
     }
-    /// Set value of RightBlinker
+    /// Set value of 'RightBlinker'
     #[inline(always)]
-    pub fn set_right_blinker(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_right_blinker(
+        &mut self,
+        value: BlinkerStatusRightBlinker,
+    ) -> Result<(), CanError> {
+        self.set_right_blinker_raw(bool::from(value))
+    }
+    /// Set raw value of 'RightBlinker'
+    #[inline(always)]
+    pub fn set_right_blinker_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[1..2].store_be(value);
         Ok(())
     }
-    /// LeftBlinker
+    /// Get value of 'LeftBlinker'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -643,7 +661,7 @@ impl BlinkerStatus {
             _ => BlinkerStatusLeftBlinker::_Other(self.left_blinker_raw()),
         }
     }
-    /// Get raw value of LeftBlinker
+    /// Get raw value of 'LeftBlinker'
     ///
     /// - Start bit: 7
     /// - Signal size: 1 bits
@@ -656,14 +674,22 @@ impl BlinkerStatus {
         let signal = self.raw.view_bits::<Msb0>()[0..1].load_be::<u8>();
         signal == 1
     }
-    /// Set value of LeftBlinker
+    /// Set value of 'LeftBlinker'
     #[inline(always)]
-    pub fn set_left_blinker(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_left_blinker(
+        &mut self,
+        value: BlinkerStatusLeftBlinker,
+    ) -> Result<(), CanError> {
+        self.set_left_blinker_raw(bool::from(value))
+    }
+    /// Set raw value of 'LeftBlinker'
+    #[inline(always)]
+    pub fn set_left_blinker_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())
     }
-    /// BlinkerLight
+    /// Get value of 'BlinkerLight'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -678,7 +704,7 @@ impl BlinkerStatus {
             _ => BlinkerStatusBlinkerLight::_Other(self.blinker_light_raw()),
         }
     }
-    /// Get raw value of BlinkerLight
+    /// Get raw value of 'BlinkerLight'
     ///
     /// - Start bit: 25
     /// - Signal size: 1 bits
@@ -691,9 +717,17 @@ impl BlinkerStatus {
         let signal = self.raw.view_bits::<Msb0>()[30..31].load_be::<u8>();
         signal == 1
     }
-    /// Set value of BlinkerLight
+    /// Set value of 'BlinkerLight'
     #[inline(always)]
-    pub fn set_blinker_light(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_blinker_light(
+        &mut self,
+        value: BlinkerStatusBlinkerLight,
+    ) -> Result<(), CanError> {
+        self.set_blinker_light_raw(bool::from(value))
+    }
+    /// Set raw value of 'BlinkerLight'
+    #[inline(always)]
+    pub fn set_blinker_light_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[30..31].store_be(value);
         Ok(())
@@ -837,7 +871,7 @@ impl SteeringWheelAngle {
     pub const MESSAGE_SIZE: usize = 8;
     pub const STEERING_WHEEL_ANGLE_MIN: f32 = -540_f32;
     pub const STEERING_WHEEL_ANGLE_MAX: f32 = 540_f32;
-    /// Construct new SteeringWheelAngle from values
+    /// Construct new 'SteeringWheelAngle' from values
     pub fn new(steering_wheel_angle: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_steering_wheel_angle(steering_wheel_angle)?;
@@ -847,7 +881,7 @@ impl SteeringWheelAngle {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SteeringWheelAngle
+    /// Get value of 'SteeringWheelAngle'
     ///
     /// - Min: -540
     /// - Max: 540
@@ -857,7 +891,7 @@ impl SteeringWheelAngle {
     pub fn steering_wheel_angle(&self) -> f32 {
         self.steering_wheel_angle_raw()
     }
-    /// Get raw value of SteeringWheelAngle
+    /// Get raw value of 'SteeringWheelAngle'
     ///
     /// - Start bit: 39
     /// - Signal size: 16 bits
@@ -872,7 +906,7 @@ impl SteeringWheelAngle {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SteeringWheelAngle
+    /// Set value of 'SteeringWheelAngle'
     #[inline(always)]
     pub fn set_steering_wheel_angle(&mut self, value: f32) -> Result<(), CanError> {
         if value < -540_f32 || 540_f32 < value {
@@ -976,8 +1010,8 @@ impl GearShifter {
     pub const MESSAGE_SIZE: usize = 8;
     pub const GEAR_SHIFTER_MIN: u8 = 0_u8;
     pub const GEAR_SHIFTER_MAX: u8 = 3_u8;
-    /// Construct new GearShifter from values
-    pub fn new(gear_shifter: u8) -> Result<Self, CanError> {
+    /// Construct new 'GearShifter' from values
+    pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_gear_shifter(gear_shifter)?;
         Ok(res)
@@ -986,7 +1020,7 @@ impl GearShifter {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GearShifter
+    /// Get value of 'GearShifter'
     ///
     /// - Min: 0
     /// - Max: 3
@@ -1001,7 +1035,7 @@ impl GearShifter {
             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
         }
     }
-    /// Get raw value of GearShifter
+    /// Get raw value of 'GearShifter'
     ///
     /// - Start bit: 17
     /// - Signal size: 2 bits
@@ -1015,9 +1049,17 @@ impl GearShifter {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GearShifter
+    /// Set value of 'GearShifter'
     #[inline(always)]
-    pub fn set_gear_shifter(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_gear_shifter(
+        &mut self,
+        value: GearShifterGearShifter,
+    ) -> Result<(), CanError> {
+        self.set_gear_shifter_raw(u8::from(value))
+    }
+    /// Set raw value of 'GearShifter'
+    #[inline(always)]
+    pub fn set_gear_shifter_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: GearShifter::MESSAGE_ID,
@@ -1174,9 +1216,9 @@ impl GasPedalRegenCruise {
     pub const GAS_PEDAL_MAX: u8 = 254_u8;
     pub const GEAR_SHIFTER2_NOT_USED_MIN: u8 = 0_u8;
     pub const GEAR_SHIFTER2_NOT_USED_MAX: u8 = 255_u8;
-    /// Construct new GasPedalRegenCruise from values
+    /// Construct new 'GasPedalRegenCruise' from values
     pub fn new(
-        cruise_control_active: bool,
+        cruise_control_active: GasPedalRegenCruiseCruiseControlActive,
         max_regen: bool,
         gas_pedal: u8,
         gear_shifter2_not_used: u8,
@@ -1192,7 +1234,7 @@ impl GasPedalRegenCruise {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// CruiseControlActive
+    /// Get value of 'CruiseControlActive'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1211,7 +1253,7 @@ impl GasPedalRegenCruise {
             }
         }
     }
-    /// Get raw value of CruiseControlActive
+    /// Get raw value of 'CruiseControlActive'
     ///
     /// - Start bit: 56
     /// - Signal size: 1 bits
@@ -1224,14 +1266,25 @@ impl GasPedalRegenCruise {
         let signal = self.raw.view_bits::<Msb0>()[63..64].load_be::<u8>();
         signal == 1
     }
-    /// Set value of CruiseControlActive
+    /// Set value of 'CruiseControlActive'
     #[inline(always)]
-    pub fn set_cruise_control_active(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_cruise_control_active(
+        &mut self,
+        value: GasPedalRegenCruiseCruiseControlActive,
+    ) -> Result<(), CanError> {
+        self.set_cruise_control_active_raw(bool::from(value))
+    }
+    /// Set raw value of 'CruiseControlActive'
+    #[inline(always)]
+    pub fn set_cruise_control_active_raw(
+        &mut self,
+        value: bool,
+    ) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[63..64].store_be(value);
         Ok(())
     }
-    /// MaxRegen
+    /// Get value of 'MaxRegen'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -1241,7 +1294,7 @@ impl GasPedalRegenCruise {
     pub fn max_regen(&self) -> bool {
         self.max_regen_raw()
     }
-    /// Get raw value of MaxRegen
+    /// Get raw value of 'MaxRegen'
     ///
     /// - Start bit: 12
     /// - Signal size: 1 bits
@@ -1254,14 +1307,14 @@ impl GasPedalRegenCruise {
         let signal = self.raw.view_bits::<Msb0>()[11..12].load_be::<u8>();
         signal == 1
     }
-    /// Set value of MaxRegen
+    /// Set value of 'MaxRegen'
     #[inline(always)]
     pub fn set_max_regen(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[11..12].store_be(value);
         Ok(())
     }
-    /// GasPedal
+    /// Get value of 'GasPedal'
     ///
     /// - Min: 0
     /// - Max: 254
@@ -1271,7 +1324,7 @@ impl GasPedalRegenCruise {
     pub fn gas_pedal(&self) -> u8 {
         self.gas_pedal_raw()
     }
-    /// Get raw value of GasPedal
+    /// Get raw value of 'GasPedal'
     ///
     /// - Start bit: 47
     /// - Signal size: 8 bits
@@ -1285,7 +1338,7 @@ impl GasPedalRegenCruise {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GasPedal
+    /// Set value of 'GasPedal'
     #[inline(always)]
     pub fn set_gas_pedal(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 254_u8 < value {
@@ -1303,7 +1356,7 @@ impl GasPedalRegenCruise {
         self.raw.view_bits_mut::<Msb0>()[40..48].store_be(value);
         Ok(())
     }
-    /// GearShifter2NotUsed
+    /// Get value of 'GearShifter2NotUsed'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -1313,7 +1366,7 @@ impl GasPedalRegenCruise {
     pub fn gear_shifter2_not_used(&self) -> u8 {
         self.gear_shifter2_not_used_raw()
     }
-    /// Get raw value of GearShifter2NotUsed
+    /// Get raw value of 'GearShifter2NotUsed'
     ///
     /// - Start bit: 55
     /// - Signal size: 8 bits
@@ -1327,7 +1380,7 @@ impl GasPedalRegenCruise {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GearShifter2NotUsed
+    /// Set value of 'GearShifter2NotUsed'
     #[inline(always)]
     pub fn set_gear_shifter2_not_used(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -1436,7 +1489,7 @@ impl BrakePedal {
     pub const BRAKE_LEVEL_MAX: u8 = 3_u8;
     pub const BRAKE_SENSOR_MIN: u8 = 0_u8;
     pub const BRAKE_SENSOR_MAX: u8 = 255_u8;
-    /// Construct new BrakePedal from values
+    /// Construct new 'BrakePedal' from values
     pub fn new(brake_level: u8, brake_sensor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_brake_level(brake_level)?;
@@ -1447,7 +1500,7 @@ impl BrakePedal {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// BrakeLevel
+    /// Get value of 'BrakeLevel'
     ///
     /// - Min: 0
     /// - Max: 3
@@ -1457,7 +1510,7 @@ impl BrakePedal {
     pub fn brake_level(&self) -> u8 {
         self.brake_level_raw()
     }
-    /// Get raw value of BrakeLevel
+    /// Get raw value of 'BrakeLevel'
     ///
     /// - Start bit: 2
     /// - Signal size: 2 bits
@@ -1471,7 +1524,7 @@ impl BrakePedal {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BrakeLevel
+    /// Set value of 'BrakeLevel'
     #[inline(always)]
     pub fn set_brake_level(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
@@ -1489,7 +1542,7 @@ impl BrakePedal {
         self.raw.view_bits_mut::<Msb0>()[5..7].store_be(value);
         Ok(())
     }
-    /// BrakeSensor
+    /// Get value of 'BrakeSensor'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -1499,7 +1552,7 @@ impl BrakePedal {
     pub fn brake_sensor(&self) -> u8 {
         self.brake_sensor_raw()
     }
-    /// Get raw value of BrakeSensor
+    /// Get raw value of 'BrakeSensor'
     ///
     /// - Start bit: 15
     /// - Signal size: 8 bits
@@ -1513,7 +1566,7 @@ impl BrakePedal {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BrakeSensor
+    /// Set value of 'BrakeSensor'
     #[inline(always)]
     pub fn set_brake_sensor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -1626,7 +1679,7 @@ impl WheelSpeed {
     pub const WHEEL_SPEED_RL_MAX: f32 = 70_f32;
     pub const WHEEL_SPEED_RR_MIN: f32 = 0_f32;
     pub const WHEEL_SPEED_RR_MAX: f32 = 70_f32;
-    /// Construct new WheelSpeed from values
+    /// Construct new 'WheelSpeed' from values
     pub fn new(
         wheel_speed_fl: f32,
         wheel_speed_fr: f32,
@@ -1644,7 +1697,7 @@ impl WheelSpeed {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// WheelSpeedFL
+    /// Get value of 'WheelSpeedFL'
     ///
     /// - Min: 0
     /// - Max: 70
@@ -1654,7 +1707,7 @@ impl WheelSpeed {
     pub fn wheel_speed_fl(&self) -> f32 {
         self.wheel_speed_fl_raw()
     }
-    /// Get raw value of WheelSpeedFL
+    /// Get raw value of 'WheelSpeedFL'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -1669,7 +1722,7 @@ impl WheelSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of WheelSpeedFL
+    /// Set value of 'WheelSpeedFL'
     #[inline(always)]
     pub fn set_wheel_speed_fl(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 70_f32 < value {
@@ -1683,7 +1736,7 @@ impl WheelSpeed {
         self.raw.view_bits_mut::<Msb0>()[0..16].store_be(value);
         Ok(())
     }
-    /// WheelSpeedFR
+    /// Get value of 'WheelSpeedFR'
     ///
     /// - Min: 0
     /// - Max: 70
@@ -1693,7 +1746,7 @@ impl WheelSpeed {
     pub fn wheel_speed_fr(&self) -> f32 {
         self.wheel_speed_fr_raw()
     }
-    /// Get raw value of WheelSpeedFR
+    /// Get raw value of 'WheelSpeedFR'
     ///
     /// - Start bit: 39
     /// - Signal size: 16 bits
@@ -1708,7 +1761,7 @@ impl WheelSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of WheelSpeedFR
+    /// Set value of 'WheelSpeedFR'
     #[inline(always)]
     pub fn set_wheel_speed_fr(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 70_f32 < value {
@@ -1722,7 +1775,7 @@ impl WheelSpeed {
         self.raw.view_bits_mut::<Msb0>()[32..48].store_be(value);
         Ok(())
     }
-    /// WheelSpeedRL
+    /// Get value of 'WheelSpeedRL'
     ///
     /// - Min: 0
     /// - Max: 70
@@ -1732,7 +1785,7 @@ impl WheelSpeed {
     pub fn wheel_speed_rl(&self) -> f32 {
         self.wheel_speed_rl_raw()
     }
-    /// Get raw value of WheelSpeedRL
+    /// Get raw value of 'WheelSpeedRL'
     ///
     /// - Start bit: 23
     /// - Signal size: 16 bits
@@ -1747,7 +1800,7 @@ impl WheelSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of WheelSpeedRL
+    /// Set value of 'WheelSpeedRL'
     #[inline(always)]
     pub fn set_wheel_speed_rl(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 70_f32 < value {
@@ -1761,7 +1814,7 @@ impl WheelSpeed {
         self.raw.view_bits_mut::<Msb0>()[16..32].store_be(value);
         Ok(())
     }
-    /// WheelSpeedRR
+    /// Get value of 'WheelSpeedRR'
     ///
     /// - Min: 0
     /// - Max: 70
@@ -1771,7 +1824,7 @@ impl WheelSpeed {
     pub fn wheel_speed_rr(&self) -> f32 {
         self.wheel_speed_rr_raw()
     }
-    /// Get raw value of WheelSpeedRR
+    /// Get raw value of 'WheelSpeedRR'
     ///
     /// - Start bit: 55
     /// - Signal size: 16 bits
@@ -1786,7 +1839,7 @@ impl WheelSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of WheelSpeedRR
+    /// Set value of 'WheelSpeedRR'
     #[inline(always)]
     pub fn set_wheel_speed_rr(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 70_f32 < value {
@@ -1866,7 +1919,7 @@ impl VehicleSpeed {
     pub const VEHICLE_SPEED1_MAX: f32 = 100_f32;
     pub const VEHICLE_SPEED2_MIN: f32 = 0_f32;
     pub const VEHICLE_SPEED2_MAX: f32 = 100_f32;
-    /// Construct new VehicleSpeed from values
+    /// Construct new 'VehicleSpeed' from values
     pub fn new(vehicle_speed1: f32, vehicle_speed2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_vehicle_speed1(vehicle_speed1)?;
@@ -1877,7 +1930,7 @@ impl VehicleSpeed {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// VehicleSpeed1
+    /// Get value of 'VehicleSpeed1'
     ///
     /// - Min: 0
     /// - Max: 100
@@ -1887,7 +1940,7 @@ impl VehicleSpeed {
     pub fn vehicle_speed1(&self) -> f32 {
         self.vehicle_speed1_raw()
     }
-    /// Get raw value of VehicleSpeed1
+    /// Get raw value of 'VehicleSpeed1'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -1902,7 +1955,7 @@ impl VehicleSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of VehicleSpeed1
+    /// Set value of 'VehicleSpeed1'
     #[inline(always)]
     pub fn set_vehicle_speed1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -1916,7 +1969,7 @@ impl VehicleSpeed {
         self.raw.view_bits_mut::<Msb0>()[0..16].store_be(value);
         Ok(())
     }
-    /// VehicleSpeed2
+    /// Get value of 'VehicleSpeed2'
     ///
     /// - Min: 0
     /// - Max: 100
@@ -1926,7 +1979,7 @@ impl VehicleSpeed {
     pub fn vehicle_speed2(&self) -> f32 {
         self.vehicle_speed2_raw()
     }
-    /// Get raw value of VehicleSpeed2
+    /// Get raw value of 'VehicleSpeed2'
     ///
     /// - Start bit: 39
     /// - Signal size: 16 bits
@@ -1941,7 +1994,7 @@ impl VehicleSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of VehicleSpeed2
+    /// Set value of 'VehicleSpeed2'
     #[inline(always)]
     pub fn set_vehicle_speed2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -2044,8 +2097,8 @@ impl CruiseButtons {
     pub const MESSAGE_SIZE: usize = 3;
     pub const CRUISE_BUTTONS_MIN: u8 = 0_u8;
     pub const CRUISE_BUTTONS_MAX: u8 = 12_u8;
-    /// Construct new CruiseButtons from values
-    pub fn new(cruise_buttons: u8) -> Result<Self, CanError> {
+    /// Construct new 'CruiseButtons' from values
+    pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_cruise_buttons(cruise_buttons)?;
         Ok(res)
@@ -2054,7 +2107,7 @@ impl CruiseButtons {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// CruiseButtons
+    /// Get value of 'CruiseButtons'
     ///
     /// - Min: 0
     /// - Max: 12
@@ -2072,7 +2125,7 @@ impl CruiseButtons {
             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
         }
     }
-    /// Get raw value of CruiseButtons
+    /// Get raw value of 'CruiseButtons'
     ///
     /// - Start bit: 3
     /// - Signal size: 3 bits
@@ -2086,9 +2139,17 @@ impl CruiseButtons {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of CruiseButtons
+    /// Set value of 'CruiseButtons'
     #[inline(always)]
-    pub fn set_cruise_buttons(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_cruise_buttons(
+        &mut self,
+        value: CruiseButtonsCruiseButtons,
+    ) -> Result<(), CanError> {
+        self.set_cruise_buttons_raw(u8::from(value))
+    }
+    /// Set raw value of 'CruiseButtons'
+    #[inline(always)]
+    pub fn set_cruise_buttons_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 12_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CruiseButtons::MESSAGE_ID,
@@ -2168,8 +2229,8 @@ impl CruiseButtons2 {
     pub const MESSAGE_SIZE: usize = 1;
     pub const LKA_GAP_BUTTON_MIN: u8 = 0_u8;
     pub const LKA_GAP_BUTTON_MAX: u8 = 2_u8;
-    /// Construct new CruiseButtons2 from values
-    pub fn new(lka_gap_button: u8) -> Result<Self, CanError> {
+    /// Construct new 'CruiseButtons2' from values
+    pub fn new(lka_gap_button: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_lka_gap_button(lka_gap_button)?;
         Ok(res)
@@ -2178,7 +2239,7 @@ impl CruiseButtons2 {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// LKAGapButton
+    /// Get value of 'LKAGapButton'
     ///
     /// - Min: 0
     /// - Max: 2
@@ -2194,7 +2255,7 @@ impl CruiseButtons2 {
             _ => CruiseButtons2LkaGapButton::_Other(self.lka_gap_button_raw()),
         }
     }
-    /// Get raw value of LKAGapButton
+    /// Get raw value of 'LKAGapButton'
     ///
     /// - Start bit: 1
     /// - Signal size: 2 bits
@@ -2208,9 +2269,17 @@ impl CruiseButtons2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of LKAGapButton
+    /// Set value of 'LKAGapButton'
     #[inline(always)]
-    pub fn set_lka_gap_button(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_lka_gap_button(
+        &mut self,
+        value: CruiseButtons2LkaGapButton,
+    ) -> Result<(), CanError> {
+        self.set_lka_gap_button_raw(u8::from(value))
+    }
+    /// Set raw value of 'LKAGapButton'
+    #[inline(always)]
+    pub fn set_lka_gap_button_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 2_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CruiseButtons2::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/issue_199.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.stderr
@@ -1,200 +1,137 @@
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1014:30
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:998:30
      |
-1014 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
-     |                              ^^^^^^^^^^^^^^^^^^^^^^
+ 998 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+     |                              ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
 ...
-1153 | pub enum GearShifterLeftBlinker {
+1133 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
-     |
-help: an enum with a similar name exists
-     |
-1014 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
-1014 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
-     |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1030:35
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1014:35
      |
-1030 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
-     |                                   ^^^^^^^^^^^^^^^^^^^^^^
+1014 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+     |                                   ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
 ...
-1153 | pub enum GearShifterLeftBlinker {
+1133 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
-     |
-help: an enum with a similar name exists
-     |
-1030 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
-1030 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
-     |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1056:16
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1040:16
      |
-1056 |         value: GearShifterGearShifter,
-     |                ^^^^^^^^^^^^^^^^^^^^^^
+1040 |         value: GearShifterGearShifter,
+     |                ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
 ...
-1153 | pub enum GearShifterLeftBlinker {
+1133 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
-     |
-help: an enum with a similar name exists
-     |
-1056 -         value: GearShifterGearShifter,
-1056 +         value: GearShifterLeftBlinker,
-     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2101:32
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2074:32
      |
-2101 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
-     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+2074 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 ...
-2348 | pub enum CruiseButtons2LkaGapButton {
+2313 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
-     |
-help: an enum with a similar name exists
-     |
-2101 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
-2101 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
-     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2117:37
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2090:37
      |
-2117 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+2090 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 ...
-2348 | pub enum CruiseButtons2LkaGapButton {
+2313 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
-     |
-help: an enum with a similar name exists
-     |
-2117 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-2117 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
-     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2146:16
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2119:16
      |
-2146 |         value: CruiseButtonsCruiseButtons,
-     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+2119 |         value: CruiseButtonsCruiseButtons,
+     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 ...
-2348 | pub enum CruiseButtons2LkaGapButton {
+2313 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
-     |
-help: an enum with a similar name exists
-     |
-2146 -         value: CruiseButtonsCruiseButtons,
-2146 +         value: CruiseButtons2LkaGapButton,
-     |
 
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1033:18
+error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1017:18
      |
-1033 |             3 => GearShifterGearShifter::Park,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-     |
-help: an enum with a similar name exists
-     |
-1033 -             3 => GearShifterGearShifter::Park,
-1033 +             3 => GearShifterLeftBlinker::Park,
-     |
+1017 |             3 => GearShifterGearShifter::Park,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `GearShifterGearShifter`
+     |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
 
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1034:18
+error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1018:18
      |
-1034 |             0 => GearShifterGearShifter::DriveLow,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-     |
-help: an enum with a similar name exists
-     |
-1034 -             0 => GearShifterGearShifter::DriveLow,
-1034 +             0 => GearShifterLeftBlinker::DriveLow,
-     |
+1018 |             0 => GearShifterGearShifter::DriveLow,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `GearShifterGearShifter`
+     |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
 
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1035:18
+error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1019:18
      |
-1035 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-     |
-help: an enum with a similar name exists
-     |
-1035 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-1035 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
-     |
+1019 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+     |                  ^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `GearShifterGearShifter`
+     |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2120:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2093:18
      |
-2120 |             6 => CruiseButtonsCruiseButtons::Cancel,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2120 -             6 => CruiseButtonsCruiseButtons::Cancel,
-2120 +             6 => CruiseButtons2LkaGapButton::Cancel,
-     |
+2093 |             6 => CruiseButtonsCruiseButtons::Cancel,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2121:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2094:18
      |
-2121 |             5 => CruiseButtonsCruiseButtons::Main,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2121 -             5 => CruiseButtonsCruiseButtons::Main,
-2121 +             5 => CruiseButtons2LkaGapButton::Main,
-     |
+2094 |             5 => CruiseButtonsCruiseButtons::Main,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2122:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2095:18
      |
-2122 |             3 => CruiseButtonsCruiseButtons::Set,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2122 -             3 => CruiseButtonsCruiseButtons::Set,
-2122 +             3 => CruiseButtons2LkaGapButton::Set,
-     |
+2095 |             3 => CruiseButtonsCruiseButtons::Set,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2123:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2096:18
      |
-2123 |             2 => CruiseButtonsCruiseButtons::Resume,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2123 -             2 => CruiseButtonsCruiseButtons::Resume,
-2123 +             2 => CruiseButtons2LkaGapButton::Resume,
-     |
+2096 |             2 => CruiseButtonsCruiseButtons::Resume,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2124:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2097:18
      |
-2124 |             1 => CruiseButtonsCruiseButtons::None,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2124 -             1 => CruiseButtonsCruiseButtons::None,
-2124 +             1 => CruiseButtons2LkaGapButton::None,
-     |
+2097 |             1 => CruiseButtonsCruiseButtons::None,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2125:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2098:18
      |
-2125 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2125 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-2125 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
-     |
+2098 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
 error: unreachable pattern
   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:65:13

--- a/tests-snapshots/dbc-cantools/issue_199.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.stderr
@@ -1,139 +1,199 @@
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:996:35
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1014:30
      |
- 996 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
-     |                                   ^^^^^^^^^^^^^^^^^^^^^^
+1014 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+     |                              ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1111 | pub enum GearShifterLeftBlinker {
+1153 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
- 996 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
- 996 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+1014 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+1014 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
+     |
+
+error[E0425]: cannot find type `GearShifterGearShifter` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1030:35
+     |
+1030 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+     |                                   ^^^^^^^^^^^^^^^^^^^^^^
+...
+1153 | pub enum GearShifterLeftBlinker {
+     | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+1030 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+1030 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+     |
+
+error[E0425]: cannot find type `GearShifterGearShifter` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1056:16
+     |
+1056 |         value: GearShifterGearShifter,
+     |                ^^^^^^^^^^^^^^^^^^^^^^
+...
+1153 | pub enum GearShifterLeftBlinker {
+     | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+1056 -         value: GearShifterGearShifter,
+1056 +         value: GearShifterLeftBlinker,
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2064:37
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2101:32
      |
-2064 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+2101 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2279 | pub enum CruiseButtons2LkaGapButton {
+2348 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-2064 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-2064 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+2101 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+2101 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
      |
 
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:999:18
-    |
-999 |             3 => GearShifterGearShifter::Park,
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
+error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2117:37
+     |
+2117 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+2348 | pub enum CruiseButtons2LkaGapButton {
+     | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
 help: an enum with a similar name exists
-    |
-999 -             3 => GearShifterGearShifter::Park,
-999 +             3 => GearShifterLeftBlinker::Park,
-    |
+     |
+2117 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2117 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+     |
+
+error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2146:16
+     |
+2146 |         value: CruiseButtonsCruiseButtons,
+     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+2348 | pub enum CruiseButtons2LkaGapButton {
+     | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
+help: an enum with a similar name exists
+     |
+2146 -         value: CruiseButtonsCruiseButtons,
+2146 +         value: CruiseButtons2LkaGapButton,
+     |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1000:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1033:18
      |
-1000 |             0 => GearShifterGearShifter::DriveLow,
+1033 |             3 => GearShifterGearShifter::Park,
      |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
      |
 help: an enum with a similar name exists
      |
-1000 -             0 => GearShifterGearShifter::DriveLow,
-1000 +             0 => GearShifterLeftBlinker::DriveLow,
+1033 -             3 => GearShifterGearShifter::Park,
+1033 +             3 => GearShifterLeftBlinker::Park,
      |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1001:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1034:18
      |
-1001 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+1034 |             0 => GearShifterGearShifter::DriveLow,
      |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
      |
 help: an enum with a similar name exists
      |
-1001 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-1001 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
+1034 -             0 => GearShifterGearShifter::DriveLow,
+1034 +             0 => GearShifterLeftBlinker::DriveLow,
+     |
+
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1035:18
+     |
+1035 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+     |
+help: an enum with a similar name exists
+     |
+1035 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+1035 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2067:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2120:18
      |
-2067 |             6 => CruiseButtonsCruiseButtons::Cancel,
+2120 |             6 => CruiseButtonsCruiseButtons::Cancel,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2067 -             6 => CruiseButtonsCruiseButtons::Cancel,
-2067 +             6 => CruiseButtons2LkaGapButton::Cancel,
+2120 -             6 => CruiseButtonsCruiseButtons::Cancel,
+2120 +             6 => CruiseButtons2LkaGapButton::Cancel,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2068:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2121:18
      |
-2068 |             5 => CruiseButtonsCruiseButtons::Main,
+2121 |             5 => CruiseButtonsCruiseButtons::Main,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2068 -             5 => CruiseButtonsCruiseButtons::Main,
-2068 +             5 => CruiseButtons2LkaGapButton::Main,
+2121 -             5 => CruiseButtonsCruiseButtons::Main,
+2121 +             5 => CruiseButtons2LkaGapButton::Main,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2069:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2122:18
      |
-2069 |             3 => CruiseButtonsCruiseButtons::Set,
+2122 |             3 => CruiseButtonsCruiseButtons::Set,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2069 -             3 => CruiseButtonsCruiseButtons::Set,
-2069 +             3 => CruiseButtons2LkaGapButton::Set,
+2122 -             3 => CruiseButtonsCruiseButtons::Set,
+2122 +             3 => CruiseButtons2LkaGapButton::Set,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2070:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2123:18
      |
-2070 |             2 => CruiseButtonsCruiseButtons::Resume,
+2123 |             2 => CruiseButtonsCruiseButtons::Resume,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2070 -             2 => CruiseButtonsCruiseButtons::Resume,
-2070 +             2 => CruiseButtons2LkaGapButton::Resume,
+2123 -             2 => CruiseButtonsCruiseButtons::Resume,
+2123 +             2 => CruiseButtons2LkaGapButton::Resume,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2071:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2124:18
      |
-2071 |             1 => CruiseButtonsCruiseButtons::None,
+2124 |             1 => CruiseButtonsCruiseButtons::None,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2071 -             1 => CruiseButtonsCruiseButtons::None,
-2071 +             1 => CruiseButtons2LkaGapButton::None,
+2124 -             1 => CruiseButtonsCruiseButtons::None,
+2124 +             1 => CruiseButtons2LkaGapButton::None,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2072:18
+    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2125:18
      |
-2072 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+2125 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-2072 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-2072 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
+2125 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+2125 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
      |
 
 error: unreachable pattern

--- a/tests-snapshots/dbc-cantools/issue_199.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.stderr
@@ -2,136 +2,199 @@ error[E0425]: cannot find type `GearShifterGearShifter` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:998:30
      |
  998 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
-     |                              ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
+     |                              ^^^^^^^^^^^^^^^^^^^^^^
 ...
 1133 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+ 998 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+ 998 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
+     |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1014:35
      |
 1014 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
-     |                                   ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
+     |                                   ^^^^^^^^^^^^^^^^^^^^^^
 ...
 1133 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+1014 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+1014 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+     |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1040:16
      |
 1040 |         value: GearShifterGearShifter,
-     |                ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
+     |                ^^^^^^^^^^^^^^^^^^^^^^
 ...
 1133 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+1040 -         value: GearShifterGearShifter,
+1040 +         value: GearShifterLeftBlinker,
+     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2074:32
      |
 2074 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
-     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 2313 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
+help: an enum with a similar name exists
+     |
+2074 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+2074 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
+     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2090:37
      |
 2090 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 2313 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
+help: an enum with a similar name exists
+     |
+2090 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2090 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2119:16
      |
 2119 |         value: CruiseButtonsCruiseButtons,
-     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 2313 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
+help: an enum with a similar name exists
+     |
+2119 -         value: CruiseButtonsCruiseButtons,
+2119 +         value: CruiseButtons2LkaGapButton,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1017:18
      |
 1017 |             3 => GearShifterGearShifter::Park,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `GearShifterGearShifter`
-     |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+     |
+help: an enum with a similar name exists
+     |
+1017 -             3 => GearShifterGearShifter::Park,
+1017 +             3 => GearShifterLeftBlinker::Park,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1018:18
      |
 1018 |             0 => GearShifterGearShifter::DriveLow,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `GearShifterGearShifter`
-     |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+     |
+help: an enum with a similar name exists
+     |
+1018 -             0 => GearShifterGearShifter::DriveLow,
+1018 +             0 => GearShifterLeftBlinker::DriveLow,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:1019:18
      |
 1019 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-     |                  ^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `GearShifterGearShifter`
-     |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+     |
+help: an enum with a similar name exists
+     |
+1019 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+1019 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2093:18
      |
 2093 |             6 => CruiseButtonsCruiseButtons::Cancel,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2093 -             6 => CruiseButtonsCruiseButtons::Cancel,
+2093 +             6 => CruiseButtons2LkaGapButton::Cancel,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2094:18
      |
 2094 |             5 => CruiseButtonsCruiseButtons::Main,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2094 -             5 => CruiseButtonsCruiseButtons::Main,
+2094 +             5 => CruiseButtons2LkaGapButton::Main,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2095:18
      |
 2095 |             3 => CruiseButtonsCruiseButtons::Set,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2095 -             3 => CruiseButtonsCruiseButtons::Set,
+2095 +             3 => CruiseButtons2LkaGapButton::Set,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2096:18
      |
 2096 |             2 => CruiseButtonsCruiseButtons::Resume,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2096 -             2 => CruiseButtonsCruiseButtons::Resume,
+2096 +             2 => CruiseButtons2LkaGapButton::Resume,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2097:18
      |
 2097 |             1 => CruiseButtonsCruiseButtons::None,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2097 -             1 => CruiseButtonsCruiseButtons::None,
+2097 +             1 => CruiseButtons2LkaGapButton::None,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2098:18
      |
 2098 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+2098 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+2098 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
+     |
 
 error: unreachable pattern
   --> tests-snapshots/dbc-cantools/issue_199.snap.rs:65:13

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
@@ -164,11 +164,7 @@ impl DriverDoorStatus {
         &mut self,
         value: DriverDoorStatusDriverDoorOpened,
     ) -> Result<(), CanError> {
-        self.set_driver_door_opened_raw(bool::from(value))
-    }
-    /// Set raw value of 'DriverDoorOpened'
-    #[inline(always)]
-    pub fn set_driver_door_opened_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[7..8].store_be(value);
         Ok(())
@@ -612,11 +608,7 @@ impl BlinkerStatus {
         &mut self,
         value: BlinkerStatusRightBlinker,
     ) -> Result<(), CanError> {
-        self.set_right_blinker_raw(bool::from(value))
-    }
-    /// Set raw value of 'RightBlinker'
-    #[inline(always)]
-    pub fn set_right_blinker_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[1..2].store_be(value);
         Ok(())
@@ -655,11 +647,7 @@ impl BlinkerStatus {
         &mut self,
         value: BlinkerStatusLeftBlinker,
     ) -> Result<(), CanError> {
-        self.set_left_blinker_raw(bool::from(value))
-    }
-    /// Set raw value of 'LeftBlinker'
-    #[inline(always)]
-    pub fn set_left_blinker_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())
@@ -698,11 +686,7 @@ impl BlinkerStatus {
         &mut self,
         value: BlinkerStatusBlinkerLight,
     ) -> Result<(), CanError> {
-        self.set_blinker_light_raw(bool::from(value))
-    }
-    /// Set raw value of 'BlinkerLight'
-    #[inline(always)]
-    pub fn set_blinker_light_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[30..31].store_be(value);
         Ok(())
@@ -1005,11 +989,7 @@ impl GearShifter {
         &mut self,
         value: GearShifterGearShifter,
     ) -> Result<(), CanError> {
-        self.set_gear_shifter_raw(u8::from(value))
-    }
-    /// Set raw value of 'GearShifter'
-    #[inline(always)]
-    pub fn set_gear_shifter_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: GearShifter::MESSAGE_ID,
@@ -1222,14 +1202,7 @@ impl GasPedalRegenCruise {
         &mut self,
         value: GasPedalRegenCruiseCruiseControlActive,
     ) -> Result<(), CanError> {
-        self.set_cruise_control_active_raw(bool::from(value))
-    }
-    /// Set raw value of 'CruiseControlActive'
-    #[inline(always)]
-    pub fn set_cruise_control_active_raw(
-        &mut self,
-        value: bool,
-    ) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[63..64].store_be(value);
         Ok(())
@@ -2045,11 +2018,7 @@ impl CruiseButtons {
         &mut self,
         value: CruiseButtonsCruiseButtons,
     ) -> Result<(), CanError> {
-        self.set_cruise_buttons_raw(u8::from(value))
-    }
-    /// Set raw value of 'CruiseButtons'
-    #[inline(always)]
-    pub fn set_cruise_buttons_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 12_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CruiseButtons::MESSAGE_ID,
@@ -2175,11 +2144,7 @@ impl CruiseButtons2 {
         &mut self,
         value: CruiseButtons2LkaGapButton,
     ) -> Result<(), CanError> {
-        self.set_lka_gap_button_raw(u8::from(value))
-    }
-    /// Set raw value of 'LKAGapButton'
-    #[inline(always)]
-    pub fn set_lka_gap_button_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 2_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CruiseButtons2::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.rs
@@ -118,8 +118,10 @@ impl DriverDoorStatus {
         ExtendedId::new_unchecked(0x1fffffff)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    /// Construct new DriverDoorStatus from values
-    pub fn new(driver_door_opened: bool) -> Result<Self, CanError> {
+    /// Construct new 'DriverDoorStatus' from values
+    pub fn new(
+        driver_door_opened: DriverDoorStatusDriverDoorOpened,
+    ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_driver_door_opened(driver_door_opened)?;
         Ok(res)
@@ -128,7 +130,7 @@ impl DriverDoorStatus {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// DriverDoorOpened
+    /// Get value of 'DriverDoorOpened'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -143,7 +145,7 @@ impl DriverDoorStatus {
             _ => DriverDoorStatusDriverDoorOpened::_Other(self.driver_door_opened_raw()),
         }
     }
-    /// Get raw value of DriverDoorOpened
+    /// Get raw value of 'DriverDoorOpened'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -156,9 +158,17 @@ impl DriverDoorStatus {
         let signal = self.raw.view_bits::<Msb0>()[7..8].load_be::<u8>();
         signal == 1
     }
-    /// Set value of DriverDoorOpened
+    /// Set value of 'DriverDoorOpened'
     #[inline(always)]
-    pub fn set_driver_door_opened(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_driver_door_opened(
+        &mut self,
+        value: DriverDoorStatusDriverDoorOpened,
+    ) -> Result<(), CanError> {
+        self.set_driver_door_opened_raw(bool::from(value))
+    }
+    /// Set raw value of 'DriverDoorOpened'
+    #[inline(always)]
+    pub fn set_driver_door_opened_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[7..8].store_be(value);
         Ok(())
@@ -260,7 +270,7 @@ impl Chime {
     pub const CHIME_BYTE5_MAX: u8 = 0_u8;
     pub const CHIME_BYTE4_MIN: u8 = 0_u8;
     pub const CHIME_BYTE4_MAX: u8 = 0_u8;
-    /// Construct new Chime from values
+    /// Construct new 'Chime' from values
     pub fn new(
         chime_type: u8,
         chime_repeat: u8,
@@ -280,7 +290,7 @@ impl Chime {
     pub fn raw(&self) -> &[u8; 5] {
         &self.raw
     }
-    /// ChimeType
+    /// Get value of 'ChimeType'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -290,7 +300,7 @@ impl Chime {
     pub fn chime_type(&self) -> u8 {
         self.chime_type_raw()
     }
-    /// Get raw value of ChimeType
+    /// Get raw value of 'ChimeType'
     ///
     /// - Start bit: 7
     /// - Signal size: 8 bits
@@ -304,7 +314,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeType
+    /// Set value of 'ChimeType'
     #[inline(always)]
     pub fn set_chime_type(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -322,7 +332,7 @@ impl Chime {
         self.raw.view_bits_mut::<Msb0>()[0..8].store_be(value);
         Ok(())
     }
-    /// ChimeRepeat
+    /// Get value of 'ChimeRepeat'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -332,7 +342,7 @@ impl Chime {
     pub fn chime_repeat(&self) -> u8 {
         self.chime_repeat_raw()
     }
-    /// Get raw value of ChimeRepeat
+    /// Get raw value of 'ChimeRepeat'
     ///
     /// - Start bit: 23
     /// - Signal size: 8 bits
@@ -346,7 +356,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeRepeat
+    /// Set value of 'ChimeRepeat'
     #[inline(always)]
     pub fn set_chime_repeat(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -364,7 +374,7 @@ impl Chime {
         self.raw.view_bits_mut::<Msb0>()[16..24].store_be(value);
         Ok(())
     }
-    /// ChimeDuration
+    /// Get value of 'ChimeDuration'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -374,7 +384,7 @@ impl Chime {
     pub fn chime_duration(&self) -> u8 {
         self.chime_duration_raw()
     }
-    /// Get raw value of ChimeDuration
+    /// Get raw value of 'ChimeDuration'
     ///
     /// - Start bit: 15
     /// - Signal size: 8 bits
@@ -388,7 +398,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeDuration
+    /// Set value of 'ChimeDuration'
     #[inline(always)]
     pub fn set_chime_duration(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -406,7 +416,7 @@ impl Chime {
         self.raw.view_bits_mut::<Msb0>()[8..16].store_be(value);
         Ok(())
     }
-    /// ChimeByte5
+    /// Get value of 'ChimeByte5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -416,7 +426,7 @@ impl Chime {
     pub fn chime_byte5(&self) -> u8 {
         self.chime_byte5_raw()
     }
-    /// Get raw value of ChimeByte5
+    /// Get raw value of 'ChimeByte5'
     ///
     /// - Start bit: 39
     /// - Signal size: 8 bits
@@ -430,7 +440,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeByte5
+    /// Set value of 'ChimeByte5'
     #[inline(always)]
     pub fn set_chime_byte5(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -448,7 +458,7 @@ impl Chime {
         self.raw.view_bits_mut::<Msb0>()[32..40].store_be(value);
         Ok(())
     }
-    /// ChimeByte4
+    /// Get value of 'ChimeByte4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -458,7 +468,7 @@ impl Chime {
     pub fn chime_byte4(&self) -> u8 {
         self.chime_byte4_raw()
     }
-    /// Get raw value of ChimeByte4
+    /// Get raw value of 'ChimeByte4'
     ///
     /// - Start bit: 31
     /// - Signal size: 8 bits
@@ -472,7 +482,7 @@ impl Chime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of ChimeByte4
+    /// Set value of 'ChimeByte4'
     #[inline(always)]
     pub fn set_chime_byte4(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -552,11 +562,11 @@ impl BlinkerStatus {
         StandardId::new_unchecked(0xc000)
     });
     pub const MESSAGE_SIZE: usize = 5;
-    /// Construct new BlinkerStatus from values
+    /// Construct new 'BlinkerStatus' from values
     pub fn new(
-        right_blinker: bool,
-        left_blinker: bool,
-        blinker_light: bool,
+        right_blinker: BlinkerStatusRightBlinker,
+        left_blinker: BlinkerStatusLeftBlinker,
+        blinker_light: BlinkerStatusBlinkerLight,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 5] };
         res.set_right_blinker(right_blinker)?;
@@ -568,7 +578,7 @@ impl BlinkerStatus {
     pub fn raw(&self) -> &[u8; 5] {
         &self.raw
     }
-    /// RightBlinker
+    /// Get value of 'RightBlinker'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -583,7 +593,7 @@ impl BlinkerStatus {
             _ => BlinkerStatusRightBlinker::_Other(self.right_blinker_raw()),
         }
     }
-    /// Get raw value of RightBlinker
+    /// Get raw value of 'RightBlinker'
     ///
     /// - Start bit: 6
     /// - Signal size: 1 bits
@@ -596,14 +606,22 @@ impl BlinkerStatus {
         let signal = self.raw.view_bits::<Msb0>()[1..2].load_be::<u8>();
         signal == 1
     }
-    /// Set value of RightBlinker
+    /// Set value of 'RightBlinker'
     #[inline(always)]
-    pub fn set_right_blinker(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_right_blinker(
+        &mut self,
+        value: BlinkerStatusRightBlinker,
+    ) -> Result<(), CanError> {
+        self.set_right_blinker_raw(bool::from(value))
+    }
+    /// Set raw value of 'RightBlinker'
+    #[inline(always)]
+    pub fn set_right_blinker_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[1..2].store_be(value);
         Ok(())
     }
-    /// LeftBlinker
+    /// Get value of 'LeftBlinker'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -618,7 +636,7 @@ impl BlinkerStatus {
             _ => BlinkerStatusLeftBlinker::_Other(self.left_blinker_raw()),
         }
     }
-    /// Get raw value of LeftBlinker
+    /// Get raw value of 'LeftBlinker'
     ///
     /// - Start bit: 7
     /// - Signal size: 1 bits
@@ -631,14 +649,22 @@ impl BlinkerStatus {
         let signal = self.raw.view_bits::<Msb0>()[0..1].load_be::<u8>();
         signal == 1
     }
-    /// Set value of LeftBlinker
+    /// Set value of 'LeftBlinker'
     #[inline(always)]
-    pub fn set_left_blinker(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_left_blinker(
+        &mut self,
+        value: BlinkerStatusLeftBlinker,
+    ) -> Result<(), CanError> {
+        self.set_left_blinker_raw(bool::from(value))
+    }
+    /// Set raw value of 'LeftBlinker'
+    #[inline(always)]
+    pub fn set_left_blinker_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())
     }
-    /// BlinkerLight
+    /// Get value of 'BlinkerLight'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -653,7 +679,7 @@ impl BlinkerStatus {
             _ => BlinkerStatusBlinkerLight::_Other(self.blinker_light_raw()),
         }
     }
-    /// Get raw value of BlinkerLight
+    /// Get raw value of 'BlinkerLight'
     ///
     /// - Start bit: 25
     /// - Signal size: 1 bits
@@ -666,9 +692,17 @@ impl BlinkerStatus {
         let signal = self.raw.view_bits::<Msb0>()[30..31].load_be::<u8>();
         signal == 1
     }
-    /// Set value of BlinkerLight
+    /// Set value of 'BlinkerLight'
     #[inline(always)]
-    pub fn set_blinker_light(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_blinker_light(
+        &mut self,
+        value: BlinkerStatusBlinkerLight,
+    ) -> Result<(), CanError> {
+        self.set_blinker_light_raw(bool::from(value))
+    }
+    /// Set raw value of 'BlinkerLight'
+    #[inline(always)]
+    pub fn set_blinker_light_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[30..31].store_be(value);
         Ok(())
@@ -812,7 +846,7 @@ impl SteeringWheelAngle {
     pub const MESSAGE_SIZE: usize = 8;
     pub const STEERING_WHEEL_ANGLE_MIN: f32 = -540_f32;
     pub const STEERING_WHEEL_ANGLE_MAX: f32 = 540_f32;
-    /// Construct new SteeringWheelAngle from values
+    /// Construct new 'SteeringWheelAngle' from values
     pub fn new(steering_wheel_angle: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_steering_wheel_angle(steering_wheel_angle)?;
@@ -822,7 +856,7 @@ impl SteeringWheelAngle {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SteeringWheelAngle
+    /// Get value of 'SteeringWheelAngle'
     ///
     /// - Min: -540
     /// - Max: 540
@@ -832,7 +866,7 @@ impl SteeringWheelAngle {
     pub fn steering_wheel_angle(&self) -> f32 {
         self.steering_wheel_angle_raw()
     }
-    /// Get raw value of SteeringWheelAngle
+    /// Get raw value of 'SteeringWheelAngle'
     ///
     /// - Start bit: 39
     /// - Signal size: 16 bits
@@ -847,7 +881,7 @@ impl SteeringWheelAngle {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SteeringWheelAngle
+    /// Set value of 'SteeringWheelAngle'
     #[inline(always)]
     pub fn set_steering_wheel_angle(&mut self, value: f32) -> Result<(), CanError> {
         if value < -540_f32 || 540_f32 < value {
@@ -926,8 +960,8 @@ impl GearShifter {
     pub const MESSAGE_SIZE: usize = 8;
     pub const GEAR_SHIFTER_MIN: u8 = 0_u8;
     pub const GEAR_SHIFTER_MAX: u8 = 3_u8;
-    /// Construct new GearShifter from values
-    pub fn new(gear_shifter: u8) -> Result<Self, CanError> {
+    /// Construct new 'GearShifter' from values
+    pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_gear_shifter(gear_shifter)?;
         Ok(res)
@@ -936,7 +970,7 @@ impl GearShifter {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GearShifter
+    /// Get value of 'GearShifter'
     ///
     /// - Min: 0
     /// - Max: 3
@@ -951,7 +985,7 @@ impl GearShifter {
             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
         }
     }
-    /// Get raw value of GearShifter
+    /// Get raw value of 'GearShifter'
     ///
     /// - Start bit: 17
     /// - Signal size: 2 bits
@@ -965,9 +999,17 @@ impl GearShifter {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GearShifter
+    /// Set value of 'GearShifter'
     #[inline(always)]
-    pub fn set_gear_shifter(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_gear_shifter(
+        &mut self,
+        value: GearShifterGearShifter,
+    ) -> Result<(), CanError> {
+        self.set_gear_shifter_raw(u8::from(value))
+    }
+    /// Set raw value of 'GearShifter'
+    #[inline(always)]
+    pub fn set_gear_shifter_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: GearShifter::MESSAGE_ID,
@@ -1124,9 +1166,9 @@ impl GasPedalRegenCruise {
     pub const GAS_PEDAL_MAX: u8 = 254_u8;
     pub const GEAR_SHIFTER2_NOT_USED_MIN: u8 = 0_u8;
     pub const GEAR_SHIFTER2_NOT_USED_MAX: u8 = 255_u8;
-    /// Construct new GasPedalRegenCruise from values
+    /// Construct new 'GasPedalRegenCruise' from values
     pub fn new(
-        cruise_control_active: bool,
+        cruise_control_active: GasPedalRegenCruiseCruiseControlActive,
         max_regen: bool,
         gas_pedal: u8,
         gear_shifter2_not_used: u8,
@@ -1142,7 +1184,7 @@ impl GasPedalRegenCruise {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// CruiseControlActive
+    /// Get value of 'CruiseControlActive'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1161,7 +1203,7 @@ impl GasPedalRegenCruise {
             }
         }
     }
-    /// Get raw value of CruiseControlActive
+    /// Get raw value of 'CruiseControlActive'
     ///
     /// - Start bit: 56
     /// - Signal size: 1 bits
@@ -1174,14 +1216,25 @@ impl GasPedalRegenCruise {
         let signal = self.raw.view_bits::<Msb0>()[63..64].load_be::<u8>();
         signal == 1
     }
-    /// Set value of CruiseControlActive
+    /// Set value of 'CruiseControlActive'
     #[inline(always)]
-    pub fn set_cruise_control_active(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_cruise_control_active(
+        &mut self,
+        value: GasPedalRegenCruiseCruiseControlActive,
+    ) -> Result<(), CanError> {
+        self.set_cruise_control_active_raw(bool::from(value))
+    }
+    /// Set raw value of 'CruiseControlActive'
+    #[inline(always)]
+    pub fn set_cruise_control_active_raw(
+        &mut self,
+        value: bool,
+    ) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[63..64].store_be(value);
         Ok(())
     }
-    /// MaxRegen
+    /// Get value of 'MaxRegen'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -1191,7 +1244,7 @@ impl GasPedalRegenCruise {
     pub fn max_regen(&self) -> bool {
         self.max_regen_raw()
     }
-    /// Get raw value of MaxRegen
+    /// Get raw value of 'MaxRegen'
     ///
     /// - Start bit: 12
     /// - Signal size: 1 bits
@@ -1204,14 +1257,14 @@ impl GasPedalRegenCruise {
         let signal = self.raw.view_bits::<Msb0>()[11..12].load_be::<u8>();
         signal == 1
     }
-    /// Set value of MaxRegen
+    /// Set value of 'MaxRegen'
     #[inline(always)]
     pub fn set_max_regen(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[11..12].store_be(value);
         Ok(())
     }
-    /// GasPedal
+    /// Get value of 'GasPedal'
     ///
     /// - Min: 0
     /// - Max: 254
@@ -1221,7 +1274,7 @@ impl GasPedalRegenCruise {
     pub fn gas_pedal(&self) -> u8 {
         self.gas_pedal_raw()
     }
-    /// Get raw value of GasPedal
+    /// Get raw value of 'GasPedal'
     ///
     /// - Start bit: 47
     /// - Signal size: 8 bits
@@ -1235,7 +1288,7 @@ impl GasPedalRegenCruise {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GasPedal
+    /// Set value of 'GasPedal'
     #[inline(always)]
     pub fn set_gas_pedal(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 254_u8 < value {
@@ -1253,7 +1306,7 @@ impl GasPedalRegenCruise {
         self.raw.view_bits_mut::<Msb0>()[40..48].store_be(value);
         Ok(())
     }
-    /// GearShifter2NotUsed
+    /// Get value of 'GearShifter2NotUsed'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -1263,7 +1316,7 @@ impl GasPedalRegenCruise {
     pub fn gear_shifter2_not_used(&self) -> u8 {
         self.gear_shifter2_not_used_raw()
     }
-    /// Get raw value of GearShifter2NotUsed
+    /// Get raw value of 'GearShifter2NotUsed'
     ///
     /// - Start bit: 55
     /// - Signal size: 8 bits
@@ -1277,7 +1330,7 @@ impl GasPedalRegenCruise {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GearShifter2NotUsed
+    /// Set value of 'GearShifter2NotUsed'
     #[inline(always)]
     pub fn set_gear_shifter2_not_used(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -1386,7 +1439,7 @@ impl BrakePedal {
     pub const BRAKE_LEVEL_MAX: u8 = 3_u8;
     pub const BRAKE_SENSOR_MIN: u8 = 0_u8;
     pub const BRAKE_SENSOR_MAX: u8 = 255_u8;
-    /// Construct new BrakePedal from values
+    /// Construct new 'BrakePedal' from values
     pub fn new(brake_level: u8, brake_sensor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_brake_level(brake_level)?;
@@ -1397,7 +1450,7 @@ impl BrakePedal {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// BrakeLevel
+    /// Get value of 'BrakeLevel'
     ///
     /// - Min: 0
     /// - Max: 3
@@ -1407,7 +1460,7 @@ impl BrakePedal {
     pub fn brake_level(&self) -> u8 {
         self.brake_level_raw()
     }
-    /// Get raw value of BrakeLevel
+    /// Get raw value of 'BrakeLevel'
     ///
     /// - Start bit: 2
     /// - Signal size: 2 bits
@@ -1421,7 +1474,7 @@ impl BrakePedal {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BrakeLevel
+    /// Set value of 'BrakeLevel'
     #[inline(always)]
     pub fn set_brake_level(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
@@ -1439,7 +1492,7 @@ impl BrakePedal {
         self.raw.view_bits_mut::<Msb0>()[5..7].store_be(value);
         Ok(())
     }
-    /// BrakeSensor
+    /// Get value of 'BrakeSensor'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -1449,7 +1502,7 @@ impl BrakePedal {
     pub fn brake_sensor(&self) -> u8 {
         self.brake_sensor_raw()
     }
-    /// Get raw value of BrakeSensor
+    /// Get raw value of 'BrakeSensor'
     ///
     /// - Start bit: 15
     /// - Signal size: 8 bits
@@ -1463,7 +1516,7 @@ impl BrakePedal {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of BrakeSensor
+    /// Set value of 'BrakeSensor'
     #[inline(always)]
     pub fn set_brake_sensor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -1551,7 +1604,7 @@ impl WheelSpeed {
     pub const WHEEL_SPEED_RL_MAX: f32 = 70_f32;
     pub const WHEEL_SPEED_RR_MIN: f32 = 0_f32;
     pub const WHEEL_SPEED_RR_MAX: f32 = 70_f32;
-    /// Construct new WheelSpeed from values
+    /// Construct new 'WheelSpeed' from values
     pub fn new(
         wheel_speed_fl: f32,
         wheel_speed_fr: f32,
@@ -1569,7 +1622,7 @@ impl WheelSpeed {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// WheelSpeedFL
+    /// Get value of 'WheelSpeedFL'
     ///
     /// - Min: 0
     /// - Max: 70
@@ -1579,7 +1632,7 @@ impl WheelSpeed {
     pub fn wheel_speed_fl(&self) -> f32 {
         self.wheel_speed_fl_raw()
     }
-    /// Get raw value of WheelSpeedFL
+    /// Get raw value of 'WheelSpeedFL'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -1594,7 +1647,7 @@ impl WheelSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of WheelSpeedFL
+    /// Set value of 'WheelSpeedFL'
     #[inline(always)]
     pub fn set_wheel_speed_fl(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 70_f32 < value {
@@ -1608,7 +1661,7 @@ impl WheelSpeed {
         self.raw.view_bits_mut::<Msb0>()[0..16].store_be(value);
         Ok(())
     }
-    /// WheelSpeedFR
+    /// Get value of 'WheelSpeedFR'
     ///
     /// - Min: 0
     /// - Max: 70
@@ -1618,7 +1671,7 @@ impl WheelSpeed {
     pub fn wheel_speed_fr(&self) -> f32 {
         self.wheel_speed_fr_raw()
     }
-    /// Get raw value of WheelSpeedFR
+    /// Get raw value of 'WheelSpeedFR'
     ///
     /// - Start bit: 39
     /// - Signal size: 16 bits
@@ -1633,7 +1686,7 @@ impl WheelSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of WheelSpeedFR
+    /// Set value of 'WheelSpeedFR'
     #[inline(always)]
     pub fn set_wheel_speed_fr(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 70_f32 < value {
@@ -1647,7 +1700,7 @@ impl WheelSpeed {
         self.raw.view_bits_mut::<Msb0>()[32..48].store_be(value);
         Ok(())
     }
-    /// WheelSpeedRL
+    /// Get value of 'WheelSpeedRL'
     ///
     /// - Min: 0
     /// - Max: 70
@@ -1657,7 +1710,7 @@ impl WheelSpeed {
     pub fn wheel_speed_rl(&self) -> f32 {
         self.wheel_speed_rl_raw()
     }
-    /// Get raw value of WheelSpeedRL
+    /// Get raw value of 'WheelSpeedRL'
     ///
     /// - Start bit: 23
     /// - Signal size: 16 bits
@@ -1672,7 +1725,7 @@ impl WheelSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of WheelSpeedRL
+    /// Set value of 'WheelSpeedRL'
     #[inline(always)]
     pub fn set_wheel_speed_rl(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 70_f32 < value {
@@ -1686,7 +1739,7 @@ impl WheelSpeed {
         self.raw.view_bits_mut::<Msb0>()[16..32].store_be(value);
         Ok(())
     }
-    /// WheelSpeedRR
+    /// Get value of 'WheelSpeedRR'
     ///
     /// - Min: 0
     /// - Max: 70
@@ -1696,7 +1749,7 @@ impl WheelSpeed {
     pub fn wheel_speed_rr(&self) -> f32 {
         self.wheel_speed_rr_raw()
     }
-    /// Get raw value of WheelSpeedRR
+    /// Get raw value of 'WheelSpeedRR'
     ///
     /// - Start bit: 55
     /// - Signal size: 16 bits
@@ -1711,7 +1764,7 @@ impl WheelSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of WheelSpeedRR
+    /// Set value of 'WheelSpeedRR'
     #[inline(always)]
     pub fn set_wheel_speed_rr(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 70_f32 < value {
@@ -1791,7 +1844,7 @@ impl VehicleSpeed {
     pub const VEHICLE_SPEED1_MAX: f32 = 100_f32;
     pub const VEHICLE_SPEED2_MIN: f32 = 0_f32;
     pub const VEHICLE_SPEED2_MAX: f32 = 100_f32;
-    /// Construct new VehicleSpeed from values
+    /// Construct new 'VehicleSpeed' from values
     pub fn new(vehicle_speed1: f32, vehicle_speed2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_vehicle_speed1(vehicle_speed1)?;
@@ -1802,7 +1855,7 @@ impl VehicleSpeed {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// VehicleSpeed1
+    /// Get value of 'VehicleSpeed1'
     ///
     /// - Min: 0
     /// - Max: 100
@@ -1812,7 +1865,7 @@ impl VehicleSpeed {
     pub fn vehicle_speed1(&self) -> f32 {
         self.vehicle_speed1_raw()
     }
-    /// Get raw value of VehicleSpeed1
+    /// Get raw value of 'VehicleSpeed1'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -1827,7 +1880,7 @@ impl VehicleSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of VehicleSpeed1
+    /// Set value of 'VehicleSpeed1'
     #[inline(always)]
     pub fn set_vehicle_speed1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -1841,7 +1894,7 @@ impl VehicleSpeed {
         self.raw.view_bits_mut::<Msb0>()[0..16].store_be(value);
         Ok(())
     }
-    /// VehicleSpeed2
+    /// Get value of 'VehicleSpeed2'
     ///
     /// - Min: 0
     /// - Max: 100
@@ -1851,7 +1904,7 @@ impl VehicleSpeed {
     pub fn vehicle_speed2(&self) -> f32 {
         self.vehicle_speed2_raw()
     }
-    /// Get raw value of VehicleSpeed2
+    /// Get raw value of 'VehicleSpeed2'
     ///
     /// - Start bit: 39
     /// - Signal size: 16 bits
@@ -1866,7 +1919,7 @@ impl VehicleSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of VehicleSpeed2
+    /// Set value of 'VehicleSpeed2'
     #[inline(always)]
     pub fn set_vehicle_speed2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 100_f32 < value {
@@ -1944,8 +1997,8 @@ impl CruiseButtons {
     pub const MESSAGE_SIZE: usize = 3;
     pub const CRUISE_BUTTONS_MIN: u8 = 0_u8;
     pub const CRUISE_BUTTONS_MAX: u8 = 12_u8;
-    /// Construct new CruiseButtons from values
-    pub fn new(cruise_buttons: u8) -> Result<Self, CanError> {
+    /// Construct new 'CruiseButtons' from values
+    pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_cruise_buttons(cruise_buttons)?;
         Ok(res)
@@ -1954,7 +2007,7 @@ impl CruiseButtons {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// CruiseButtons
+    /// Get value of 'CruiseButtons'
     ///
     /// - Min: 0
     /// - Max: 12
@@ -1972,7 +2025,7 @@ impl CruiseButtons {
             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
         }
     }
-    /// Get raw value of CruiseButtons
+    /// Get raw value of 'CruiseButtons'
     ///
     /// - Start bit: 3
     /// - Signal size: 3 bits
@@ -1986,9 +2039,17 @@ impl CruiseButtons {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of CruiseButtons
+    /// Set value of 'CruiseButtons'
     #[inline(always)]
-    pub fn set_cruise_buttons(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_cruise_buttons(
+        &mut self,
+        value: CruiseButtonsCruiseButtons,
+    ) -> Result<(), CanError> {
+        self.set_cruise_buttons_raw(u8::from(value))
+    }
+    /// Set raw value of 'CruiseButtons'
+    #[inline(always)]
+    pub fn set_cruise_buttons_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 12_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CruiseButtons::MESSAGE_ID,
@@ -2068,8 +2129,8 @@ impl CruiseButtons2 {
     pub const MESSAGE_SIZE: usize = 1;
     pub const LKA_GAP_BUTTON_MIN: u8 = 0_u8;
     pub const LKA_GAP_BUTTON_MAX: u8 = 2_u8;
-    /// Construct new CruiseButtons2 from values
-    pub fn new(lka_gap_button: u8) -> Result<Self, CanError> {
+    /// Construct new 'CruiseButtons2' from values
+    pub fn new(lka_gap_button: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_lka_gap_button(lka_gap_button)?;
         Ok(res)
@@ -2078,7 +2139,7 @@ impl CruiseButtons2 {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// LKAGapButton
+    /// Get value of 'LKAGapButton'
     ///
     /// - Min: 0
     /// - Max: 2
@@ -2094,7 +2155,7 @@ impl CruiseButtons2 {
             _ => CruiseButtons2LkaGapButton::_Other(self.lka_gap_button_raw()),
         }
     }
-    /// Get raw value of LKAGapButton
+    /// Get raw value of 'LKAGapButton'
     ///
     /// - Start bit: 1
     /// - Signal size: 2 bits
@@ -2108,9 +2169,17 @@ impl CruiseButtons2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of LKAGapButton
+    /// Set value of 'LKAGapButton'
     #[inline(always)]
-    pub fn set_lka_gap_button(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_lka_gap_button(
+        &mut self,
+        value: CruiseButtons2LkaGapButton,
+    ) -> Result<(), CanError> {
+        self.set_lka_gap_button_raw(u8::from(value))
+    }
+    /// Set raw value of 'LKAGapButton'
+    #[inline(always)]
+    pub fn set_lka_gap_button_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 2_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: CruiseButtons2::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
@@ -1,200 +1,137 @@
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:964:30
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:948:30
      |
- 964 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
-     |                              ^^^^^^^^^^^^^^^^^^^^^^
+ 948 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+     |                              ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
 ...
-1103 | pub enum GearShifterLeftBlinker {
+1083 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
-     |
-help: an enum with a similar name exists
-     |
- 964 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
- 964 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
-     |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:980:35
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:964:35
      |
- 980 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
-     |                                   ^^^^^^^^^^^^^^^^^^^^^^
+ 964 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+     |                                   ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
 ...
-1103 | pub enum GearShifterLeftBlinker {
+1083 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
-     |
-help: an enum with a similar name exists
-     |
- 980 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
- 980 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
-     |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1006:16
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:990:16
      |
-1006 |         value: GearShifterGearShifter,
-     |                ^^^^^^^^^^^^^^^^^^^^^^
+ 990 |         value: GearShifterGearShifter,
+     |                ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
 ...
-1103 | pub enum GearShifterLeftBlinker {
+1083 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
-     |
-help: an enum with a similar name exists
-     |
-1006 -         value: GearShifterGearShifter,
-1006 +         value: GearShifterLeftBlinker,
-     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2001:32
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1974:32
      |
-2001 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
-     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+1974 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 ...
-2248 | pub enum CruiseButtons2LkaGapButton {
+2213 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
-     |
-help: an enum with a similar name exists
-     |
-2001 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
-2001 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
-     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2017:37
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1990:37
      |
-2017 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+1990 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 ...
-2248 | pub enum CruiseButtons2LkaGapButton {
+2213 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
-     |
-help: an enum with a similar name exists
-     |
-2017 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-2017 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
-     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2046:16
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2019:16
      |
-2046 |         value: CruiseButtonsCruiseButtons,
-     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+2019 |         value: CruiseButtonsCruiseButtons,
+     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 ...
-2248 | pub enum CruiseButtons2LkaGapButton {
+2213 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
-     |
-help: an enum with a similar name exists
-     |
-2046 -         value: CruiseButtonsCruiseButtons,
-2046 +         value: CruiseButtons2LkaGapButton,
-     |
 
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:983:18
+error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:967:18
     |
-983 |             3 => GearShifterGearShifter::Park,
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
-help: an enum with a similar name exists
-    |
-983 -             3 => GearShifterGearShifter::Park,
-983 +             3 => GearShifterLeftBlinker::Park,
-    |
+967 |             3 => GearShifterGearShifter::Park,
+    |                  ^^^^^^^^^^^^^^^^^^^^^^
+    |                  |
+    |                  use of undeclared type `GearShifterGearShifter`
+    |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
 
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:984:18
+error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:968:18
     |
-984 |             0 => GearShifterGearShifter::DriveLow,
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
-help: an enum with a similar name exists
-    |
-984 -             0 => GearShifterGearShifter::DriveLow,
-984 +             0 => GearShifterLeftBlinker::DriveLow,
-    |
+968 |             0 => GearShifterGearShifter::DriveLow,
+    |                  ^^^^^^^^^^^^^^^^^^^^^^
+    |                  |
+    |                  use of undeclared type `GearShifterGearShifter`
+    |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
 
-error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:985:18
+error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:969:18
     |
-985 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
-    |
-help: an enum with a similar name exists
-    |
-985 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-985 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
-    |
+969 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+    |                  ^^^^^^^^^^^^^^^^^^^^^^
+    |                  |
+    |                  use of undeclared type `GearShifterGearShifter`
+    |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2020:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1993:18
      |
-2020 |             6 => CruiseButtonsCruiseButtons::Cancel,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2020 -             6 => CruiseButtonsCruiseButtons::Cancel,
-2020 +             6 => CruiseButtons2LkaGapButton::Cancel,
-     |
+1993 |             6 => CruiseButtonsCruiseButtons::Cancel,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2021:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1994:18
      |
-2021 |             5 => CruiseButtonsCruiseButtons::Main,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2021 -             5 => CruiseButtonsCruiseButtons::Main,
-2021 +             5 => CruiseButtons2LkaGapButton::Main,
-     |
+1994 |             5 => CruiseButtonsCruiseButtons::Main,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2022:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1995:18
      |
-2022 |             3 => CruiseButtonsCruiseButtons::Set,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2022 -             3 => CruiseButtonsCruiseButtons::Set,
-2022 +             3 => CruiseButtons2LkaGapButton::Set,
-     |
+1995 |             3 => CruiseButtonsCruiseButtons::Set,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2023:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1996:18
      |
-2023 |             2 => CruiseButtonsCruiseButtons::Resume,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2023 -             2 => CruiseButtonsCruiseButtons::Resume,
-2023 +             2 => CruiseButtons2LkaGapButton::Resume,
-     |
+1996 |             2 => CruiseButtonsCruiseButtons::Resume,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2024:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1997:18
      |
-2024 |             1 => CruiseButtonsCruiseButtons::None,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2024 -             1 => CruiseButtonsCruiseButtons::None,
-2024 +             1 => CruiseButtons2LkaGapButton::None,
-     |
+1997 |             1 => CruiseButtonsCruiseButtons::None,
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
-error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2025:18
+error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1998:18
      |
-2025 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
-     |
-help: an enum with a similar name exists
-     |
-2025 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-2025 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
-     |
+1998 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |                  |
+     |                  use of undeclared type `CruiseButtonsCruiseButtons`
+     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
 
 error: unreachable pattern
   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:69:13

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
@@ -1,139 +1,199 @@
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:946:35
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:964:30
      |
- 946 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
-     |                                   ^^^^^^^^^^^^^^^^^^^^^^
+ 964 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+     |                              ^^^^^^^^^^^^^^^^^^^^^^
 ...
-1061 | pub enum GearShifterLeftBlinker {
+1103 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
      |
 help: an enum with a similar name exists
      |
- 946 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
- 946 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+ 964 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+ 964 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
+     |
+
+error[E0425]: cannot find type `GearShifterGearShifter` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:980:35
+     |
+ 980 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+     |                                   ^^^^^^^^^^^^^^^^^^^^^^
+...
+1103 | pub enum GearShifterLeftBlinker {
+     | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+ 980 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+ 980 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+     |
+
+error[E0425]: cannot find type `GearShifterGearShifter` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1006:16
+     |
+1006 |         value: GearShifterGearShifter,
+     |                ^^^^^^^^^^^^^^^^^^^^^^
+...
+1103 | pub enum GearShifterLeftBlinker {
+     | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+1006 -         value: GearShifterGearShifter,
+1006 +         value: GearShifterLeftBlinker,
      |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1964:37
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2001:32
      |
-1964 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+2001 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-2179 | pub enum CruiseButtons2LkaGapButton {
+2248 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
      |
 help: an enum with a similar name exists
      |
-1964 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-1964 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+2001 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+2001 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
+     |
+
+error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2017:37
+     |
+2017 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+2248 | pub enum CruiseButtons2LkaGapButton {
+     | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
+help: an enum with a similar name exists
+     |
+2017 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+2017 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+     |
+
+error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2046:16
+     |
+2046 |         value: CruiseButtonsCruiseButtons,
+     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+2248 | pub enum CruiseButtons2LkaGapButton {
+     | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
+help: an enum with a similar name exists
+     |
+2046 -         value: CruiseButtonsCruiseButtons,
+2046 +         value: CruiseButtons2LkaGapButton,
      |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:949:18
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:983:18
     |
-949 |             3 => GearShifterGearShifter::Park,
+983 |             3 => GearShifterGearShifter::Park,
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-949 -             3 => GearShifterGearShifter::Park,
-949 +             3 => GearShifterLeftBlinker::Park,
+983 -             3 => GearShifterGearShifter::Park,
+983 +             3 => GearShifterLeftBlinker::Park,
     |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:950:18
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:984:18
     |
-950 |             0 => GearShifterGearShifter::DriveLow,
+984 |             0 => GearShifterGearShifter::DriveLow,
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-950 -             0 => GearShifterGearShifter::DriveLow,
-950 +             0 => GearShifterLeftBlinker::DriveLow,
+984 -             0 => GearShifterGearShifter::DriveLow,
+984 +             0 => GearShifterLeftBlinker::DriveLow,
     |
 
 error[E0433]: cannot find type `GearShifterGearShifter` in this scope
-   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:951:18
+   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:985:18
     |
-951 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+985 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
     |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
     |
 help: an enum with a similar name exists
     |
-951 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-951 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
+985 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+985 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
     |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1967:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2020:18
      |
-1967 |             6 => CruiseButtonsCruiseButtons::Cancel,
+2020 |             6 => CruiseButtonsCruiseButtons::Cancel,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1967 -             6 => CruiseButtonsCruiseButtons::Cancel,
-1967 +             6 => CruiseButtons2LkaGapButton::Cancel,
+2020 -             6 => CruiseButtonsCruiseButtons::Cancel,
+2020 +             6 => CruiseButtons2LkaGapButton::Cancel,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1968:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2021:18
      |
-1968 |             5 => CruiseButtonsCruiseButtons::Main,
+2021 |             5 => CruiseButtonsCruiseButtons::Main,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1968 -             5 => CruiseButtonsCruiseButtons::Main,
-1968 +             5 => CruiseButtons2LkaGapButton::Main,
+2021 -             5 => CruiseButtonsCruiseButtons::Main,
+2021 +             5 => CruiseButtons2LkaGapButton::Main,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1969:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2022:18
      |
-1969 |             3 => CruiseButtonsCruiseButtons::Set,
+2022 |             3 => CruiseButtonsCruiseButtons::Set,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1969 -             3 => CruiseButtonsCruiseButtons::Set,
-1969 +             3 => CruiseButtons2LkaGapButton::Set,
+2022 -             3 => CruiseButtonsCruiseButtons::Set,
+2022 +             3 => CruiseButtons2LkaGapButton::Set,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1970:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2023:18
      |
-1970 |             2 => CruiseButtonsCruiseButtons::Resume,
+2023 |             2 => CruiseButtonsCruiseButtons::Resume,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1970 -             2 => CruiseButtonsCruiseButtons::Resume,
-1970 +             2 => CruiseButtons2LkaGapButton::Resume,
+2023 -             2 => CruiseButtonsCruiseButtons::Resume,
+2023 +             2 => CruiseButtons2LkaGapButton::Resume,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1971:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2024:18
      |
-1971 |             1 => CruiseButtonsCruiseButtons::None,
+2024 |             1 => CruiseButtonsCruiseButtons::None,
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1971 -             1 => CruiseButtonsCruiseButtons::None,
-1971 +             1 => CruiseButtons2LkaGapButton::None,
+2024 -             1 => CruiseButtonsCruiseButtons::None,
+2024 +             1 => CruiseButtons2LkaGapButton::None,
      |
 
 error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
-    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1972:18
+    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2025:18
      |
-1972 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+2025 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
      |
 help: an enum with a similar name exists
      |
-1972 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-1972 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
+2025 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+2025 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
      |
 
 error: unreachable pattern

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
@@ -2,136 +2,199 @@ error[E0425]: cannot find type `GearShifterGearShifter` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:948:30
      |
  948 |     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
-     |                              ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
+     |                              ^^^^^^^^^^^^^^^^^^^^^^
 ...
 1083 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+ 948 -     pub fn new(gear_shifter: GearShifterGearShifter) -> Result<Self, CanError> {
+ 948 +     pub fn new(gear_shifter: GearShifterLeftBlinker) -> Result<Self, CanError> {
+     |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:964:35
      |
  964 |     pub fn gear_shifter(&self) -> GearShifterGearShifter {
-     |                                   ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
+     |                                   ^^^^^^^^^^^^^^^^^^^^^^
 ...
 1083 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+ 964 -     pub fn gear_shifter(&self) -> GearShifterGearShifter {
+ 964 +     pub fn gear_shifter(&self) -> GearShifterLeftBlinker {
+     |
 
 error[E0425]: cannot find type `GearShifterGearShifter` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:990:16
      |
  990 |         value: GearShifterGearShifter,
-     |                ^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `GearShifterLeftBlinker`
+     |                ^^^^^^^^^^^^^^^^^^^^^^
 ...
 1083 | pub enum GearShifterLeftBlinker {
      | ------------------------------- similarly named enum `GearShifterLeftBlinker` defined here
+     |
+help: an enum with a similar name exists
+     |
+ 990 -         value: GearShifterGearShifter,
+ 990 +         value: GearShifterLeftBlinker,
+     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1974:32
      |
 1974 |     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
-     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 2213 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
+help: an enum with a similar name exists
+     |
+1974 -     pub fn new(cruise_buttons: CruiseButtonsCruiseButtons) -> Result<Self, CanError> {
+1974 +     pub fn new(cruise_buttons: CruiseButtons2LkaGapButton) -> Result<Self, CanError> {
+     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1990:37
      |
 1990 |     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
-     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 2213 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
+help: an enum with a similar name exists
+     |
+1990 -     pub fn cruise_buttons(&self) -> CruiseButtonsCruiseButtons {
+1990 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
+     |
 
 error[E0425]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:2019:16
      |
 2019 |         value: CruiseButtonsCruiseButtons,
-     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 2213 | pub enum CruiseButtons2LkaGapButton {
      | ----------------------------------- similarly named enum `CruiseButtons2LkaGapButton` defined here
+     |
+help: an enum with a similar name exists
+     |
+2019 -         value: CruiseButtonsCruiseButtons,
+2019 +         value: CruiseButtons2LkaGapButton,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:967:18
     |
 967 |             3 => GearShifterGearShifter::Park,
-    |                  ^^^^^^^^^^^^^^^^^^^^^^
-    |                  |
-    |                  use of undeclared type `GearShifterGearShifter`
-    |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
+    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+    |
+help: an enum with a similar name exists
+    |
+967 -             3 => GearShifterGearShifter::Park,
+967 +             3 => GearShifterLeftBlinker::Park,
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:968:18
     |
 968 |             0 => GearShifterGearShifter::DriveLow,
-    |                  ^^^^^^^^^^^^^^^^^^^^^^
-    |                  |
-    |                  use of undeclared type `GearShifterGearShifter`
-    |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
+    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+    |
+help: an enum with a similar name exists
+    |
+968 -             0 => GearShifterGearShifter::DriveLow,
+968 +             0 => GearShifterLeftBlinker::DriveLow,
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:969:18
     |
 969 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
-    |                  ^^^^^^^^^^^^^^^^^^^^^^
-    |                  |
-    |                  use of undeclared type `GearShifterGearShifter`
-    |                  help: an enum with a similar name exists: `GearShifterLeftBlinker`
+    |                  ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `GearShifterGearShifter`
+    |
+help: an enum with a similar name exists
+    |
+969 -             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
+969 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1993:18
      |
 1993 |             6 => CruiseButtonsCruiseButtons::Cancel,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1993 -             6 => CruiseButtonsCruiseButtons::Cancel,
+1993 +             6 => CruiseButtons2LkaGapButton::Cancel,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1994:18
      |
 1994 |             5 => CruiseButtonsCruiseButtons::Main,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1994 -             5 => CruiseButtonsCruiseButtons::Main,
+1994 +             5 => CruiseButtons2LkaGapButton::Main,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1995:18
      |
 1995 |             3 => CruiseButtonsCruiseButtons::Set,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1995 -             3 => CruiseButtonsCruiseButtons::Set,
+1995 +             3 => CruiseButtons2LkaGapButton::Set,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1996:18
      |
 1996 |             2 => CruiseButtonsCruiseButtons::Resume,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1996 -             2 => CruiseButtonsCruiseButtons::Resume,
+1996 +             2 => CruiseButtons2LkaGapButton::Resume,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1997:18
      |
 1997 |             1 => CruiseButtonsCruiseButtons::None,
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1997 -             1 => CruiseButtonsCruiseButtons::None,
+1997 +             1 => CruiseButtons2LkaGapButton::None,
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1998:18
      |
 1998 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-     |                  |
-     |                  use of undeclared type `CruiseButtonsCruiseButtons`
-     |                  help: an enum with a similar name exists: `CruiseButtons2LkaGapButton`
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `CruiseButtonsCruiseButtons`
+     |
+help: an enum with a similar name exists
+     |
+1998 -             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),
+1998 +             _ => CruiseButtons2LkaGapButton::_Other(self.cruise_buttons_raw()),
+     |
 
 error: unreachable pattern
   --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:69:13

--- a/tests-snapshots/dbc-cantools/issue_207_sig_plus.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_207_sig_plus.snap.rs
@@ -71,7 +71,7 @@ impl MyMsg {
     pub const MY_EXTRA_SIG_WITH_PLUS_MAX: i16 = 127_i16;
     pub const MY_NORMAL_SIG_MIN: i16 = -128_i16;
     pub const MY_NORMAL_SIG_MAX: i16 = 127_i16;
-    /// Construct new myMsg from values
+    /// Construct new 'myMsg' from values
     pub fn new(
         my_extra_sig_with_plus: i16,
         my_normal_sig: i16,
@@ -85,7 +85,7 @@ impl MyMsg {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// myExtraSigWithPlus
+    /// Get value of 'myExtraSigWithPlus'
     ///
     /// - Min: -128
     /// - Max: 127
@@ -95,7 +95,7 @@ impl MyMsg {
     pub fn my_extra_sig_with_plus(&self) -> i16 {
         self.my_extra_sig_with_plus_raw()
     }
-    /// Get raw value of myExtraSigWithPlus
+    /// Get raw value of 'myExtraSigWithPlus'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -109,7 +109,7 @@ impl MyMsg {
         let factor = 1;
         i16::from(signal).saturating_mul(factor).saturating_sub(128)
     }
-    /// Set value of myExtraSigWithPlus
+    /// Set value of 'myExtraSigWithPlus'
     #[inline(always)]
     pub fn set_my_extra_sig_with_plus(&mut self, value: i16) -> Result<(), CanError> {
         if value < -128_i16 || 127_i16 < value {
@@ -128,7 +128,7 @@ impl MyMsg {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// myNormalSig
+    /// Get value of 'myNormalSig'
     ///
     /// - Min: -128
     /// - Max: 127
@@ -138,7 +138,7 @@ impl MyMsg {
     pub fn my_normal_sig(&self) -> i16 {
         self.my_normal_sig_raw()
     }
-    /// Get raw value of myNormalSig
+    /// Get raw value of 'myNormalSig'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -152,7 +152,7 @@ impl MyMsg {
         let factor = 1;
         i16::from(signal).saturating_mul(factor).saturating_sub(128)
     }
-    /// Set value of myNormalSig
+    /// Set value of 'myNormalSig'
     #[inline(always)]
     pub fn set_my_normal_sig(&mut self, value: i16) -> Result<(), CanError> {
         if value < -128_i16 || 127_i16 < value {

--- a/tests-snapshots/dbc-cantools/issue_228.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_228.snap.rs
@@ -76,7 +76,7 @@ impl SgMsg {
     pub const SG2_MAX: i8 = 0_i8;
     pub const SG1_MIN: i8 = 0_i8;
     pub const SG1_MAX: i8 = 0_i8;
-    /// Construct new SGMsg from values
+    /// Construct new 'SGMsg' from values
     pub fn new(dupsig: i8, sg2: i8, sg1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_dupsig(dupsig)?;
@@ -88,7 +88,7 @@ impl SgMsg {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// dupsig
+    /// Get value of 'dupsig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -98,7 +98,7 @@ impl SgMsg {
     pub fn dupsig(&self) -> i8 {
         self.dupsig_raw()
     }
-    /// Get raw value of dupsig
+    /// Get raw value of 'dupsig'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -113,7 +113,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of dupsig
+    /// Set value of 'dupsig'
     #[inline(always)]
     pub fn set_dupsig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -132,7 +132,7 @@ impl SgMsg {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// SG2
+    /// Get value of 'SG2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -142,7 +142,7 @@ impl SgMsg {
     pub fn sg2(&self) -> i8 {
         self.sg2_raw()
     }
-    /// Get raw value of SG2
+    /// Get raw value of 'SG2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -157,7 +157,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SG2
+    /// Set value of 'SG2'
     #[inline(always)]
     pub fn set_sg2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -176,7 +176,7 @@ impl SgMsg {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// SG1
+    /// Get value of 'SG1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -186,7 +186,7 @@ impl SgMsg {
     pub fn sg1(&self) -> i8 {
         self.sg1_raw()
     }
-    /// Get raw value of SG1
+    /// Get raw value of 'SG1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -201,7 +201,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SG1
+    /// Set value of 'SG1'
     #[inline(always)]
     pub fn set_sg1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -285,7 +285,7 @@ impl NormalMsg {
     pub const SIG_2_MAX: i8 = 0_i8;
     pub const SIG_1_MIN: i8 = 0_i8;
     pub const SIG_1_MAX: i8 = 0_i8;
-    /// Construct new NormalMsg from values
+    /// Construct new 'NormalMsg' from values
     pub fn new(sig_2: i8, sig_1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_sig_2(sig_2)?;
@@ -296,7 +296,7 @@ impl NormalMsg {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Sig_2
+    /// Get value of 'Sig_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -306,7 +306,7 @@ impl NormalMsg {
     pub fn sig_2(&self) -> i8 {
         self.sig_2_raw()
     }
-    /// Get raw value of Sig_2
+    /// Get raw value of 'Sig_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -321,7 +321,7 @@ impl NormalMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_2
+    /// Set value of 'Sig_2'
     #[inline(always)]
     pub fn set_sig_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -340,7 +340,7 @@ impl NormalMsg {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Sig_1
+    /// Get value of 'Sig_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -350,7 +350,7 @@ impl NormalMsg {
     pub fn sig_1(&self) -> i8 {
         self.sig_1_raw()
     }
-    /// Get raw value of Sig_1
+    /// Get raw value of 'Sig_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -365,7 +365,7 @@ impl NormalMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_1
+    /// Set value of 'Sig_1'
     #[inline(always)]
     pub fn set_sig_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/issue_63.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_63.snap.rs
@@ -79,7 +79,7 @@ impl Aft1psi2 {
     pub const PWR_SUPPLY_MAX: u8 = 3_u8;
     pub const DETECTION_STATUS_MIN: u8 = 0_u8;
     pub const DETECTION_STATUS_MAX: u8 = 15_u8;
-    /// Construct new AFT1PSI2 from values
+    /// Construct new 'AFT1PSI2' from values
     pub fn new(
         htr_res: f32,
         max_res: u32,
@@ -101,7 +101,7 @@ impl Aft1psi2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// HtrRes
+    /// Get value of 'HtrRes'
     ///
     /// - Min: 0
     /// - Max: 6425.5
@@ -111,7 +111,7 @@ impl Aft1psi2 {
     pub fn htr_res(&self) -> f32 {
         self.htr_res_raw()
     }
-    /// Get raw value of HtrRes
+    /// Get raw value of 'HtrRes'
     ///
     /// - Start bit: 40
     /// - Signal size: 16 bits
@@ -126,7 +126,7 @@ impl Aft1psi2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of HtrRes
+    /// Set value of 'HtrRes'
     #[inline(always)]
     pub fn set_htr_res(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 6425.5_f32 < value {
@@ -140,7 +140,7 @@ impl Aft1psi2 {
         self.raw.view_bits_mut::<Lsb0>()[40..56].store_le(value);
         Ok(())
     }
-    /// MaxRes
+    /// Get value of 'MaxRes'
     ///
     /// - Min: 0
     /// - Max: 62500
@@ -150,7 +150,7 @@ impl Aft1psi2 {
     pub fn max_res(&self) -> u32 {
         self.max_res_raw()
     }
-    /// Get raw value of MaxRes
+    /// Get raw value of 'MaxRes'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -164,7 +164,7 @@ impl Aft1psi2 {
         let factor = 250;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MaxRes
+    /// Set value of 'MaxRes'
     #[inline(always)]
     pub fn set_max_res(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 62500_u32 < value {
@@ -182,7 +182,7 @@ impl Aft1psi2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Temp
+    /// Get value of 'Temp'
     ///
     /// - Min: -273
     /// - Max: 1734.96875
@@ -192,7 +192,7 @@ impl Aft1psi2 {
     pub fn temp(&self) -> f32 {
         self.temp_raw()
     }
-    /// Get raw value of Temp
+    /// Get raw value of 'Temp'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -207,7 +207,7 @@ impl Aft1psi2 {
         let offset = -273_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temp
+    /// Set value of 'Temp'
     #[inline(always)]
     pub fn set_temp(&mut self, value: f32) -> Result<(), CanError> {
         if value < -273_f32 || 1734.96875_f32 < value {
@@ -221,7 +221,7 @@ impl Aft1psi2 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// RegenFailedCount
+    /// Get value of 'RegenFailedCount'
     ///
     /// - Min: 0
     /// - Max: 250
@@ -231,7 +231,7 @@ impl Aft1psi2 {
     pub fn regen_failed_count(&self) -> u8 {
         self.regen_failed_count_raw()
     }
-    /// Get raw value of RegenFailedCount
+    /// Get raw value of 'RegenFailedCount'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -245,7 +245,7 @@ impl Aft1psi2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of RegenFailedCount
+    /// Set value of 'RegenFailedCount'
     #[inline(always)]
     pub fn set_regen_failed_count(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 250_u8 < value {
@@ -263,7 +263,7 @@ impl Aft1psi2 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// PwrSupply
+    /// Get value of 'PwrSupply'
     ///
     /// - Min: 0
     /// - Max: 3
@@ -273,7 +273,7 @@ impl Aft1psi2 {
     pub fn pwr_supply(&self) -> u8 {
         self.pwr_supply_raw()
     }
-    /// Get raw value of PwrSupply
+    /// Get raw value of 'PwrSupply'
     ///
     /// - Start bit: 4
     /// - Signal size: 2 bits
@@ -287,7 +287,7 @@ impl Aft1psi2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of PwrSupply
+    /// Set value of 'PwrSupply'
     #[inline(always)]
     pub fn set_pwr_supply(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
@@ -305,7 +305,7 @@ impl Aft1psi2 {
         self.raw.view_bits_mut::<Lsb0>()[4..6].store_le(value);
         Ok(())
     }
-    /// DetectionStatus
+    /// Get value of 'DetectionStatus'
     ///
     /// - Min: 0
     /// - Max: 15
@@ -315,7 +315,7 @@ impl Aft1psi2 {
     pub fn detection_status(&self) -> u8 {
         self.detection_status_raw()
     }
-    /// Get raw value of DetectionStatus
+    /// Get raw value of 'DetectionStatus'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -329,7 +329,7 @@ impl Aft1psi2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of DetectionStatus
+    /// Set value of 'DetectionStatus'
     #[inline(always)]
     pub fn set_detection_status(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {

--- a/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
@@ -120,11 +120,7 @@ impl ExampleMessage {
         &mut self,
         value: ExampleMessageTemperature,
     ) -> Result<(), CanError> {
-        self.set_temperature_raw(f32::from(value))
-    }
-    /// Set raw value of 'Temperature'
-    #[inline(always)]
-    pub fn set_temperature_raw(&mut self, value: f32) -> Result<(), CanError> {
+        let value = f32::from(value);
         if value < 4070_f32 || 4100_f32 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: ExampleMessage::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_636_negative_scaling.snap.rs
@@ -74,8 +74,8 @@ impl ExampleMessage {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_MIN: f32 = 4070_f32;
     pub const TEMPERATURE_MAX: f32 = 4100_f32;
-    /// Construct new ExampleMessage from values
-    pub fn new(temperature: f32) -> Result<Self, CanError> {
+    /// Construct new 'ExampleMessage' from values
+    pub fn new(temperature: ExampleMessageTemperature) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature(temperature)?;
         Ok(res)
@@ -84,7 +84,7 @@ impl ExampleMessage {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature
+    /// Get value of 'Temperature'
     ///
     /// - Min: 4070
     /// - Max: 4100
@@ -99,7 +99,7 @@ impl ExampleMessage {
             _ => ExampleMessageTemperature::_Other(self.temperature_raw()),
         }
     }
-    /// Get raw value of Temperature
+    /// Get raw value of 'Temperature'
     ///
     /// - Start bit: 3
     /// - Signal size: 12 bits
@@ -114,9 +114,17 @@ impl ExampleMessage {
         let offset = 4100_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature
+    /// Set value of 'Temperature'
     #[inline(always)]
-    pub fn set_temperature(&mut self, value: f32) -> Result<(), CanError> {
+    pub fn set_temperature(
+        &mut self,
+        value: ExampleMessageTemperature,
+    ) -> Result<(), CanError> {
+        self.set_temperature_raw(f32::from(value))
+    }
+    /// Set raw value of 'Temperature'
+    #[inline(always)]
+    pub fn set_temperature_raw(&mut self, value: f32) -> Result<(), CanError> {
         if value < 4070_f32 || 4100_f32 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: ExampleMessage::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/issue_725.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_725.snap.rs
@@ -72,7 +72,7 @@ impl TestMessage {
     pub const MESSAGE_SIZE: usize = 1;
     pub const SIGNAL1_MIN: u8 = 0_u8;
     pub const SIGNAL1_MAX: u8 = 250_u8;
-    /// Construct new TestMessage from values
+    /// Construct new 'TestMessage' from values
     pub fn new(signal1: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_signal1(signal1)?;
@@ -82,7 +82,7 @@ impl TestMessage {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// Signal1
+    /// Get value of 'Signal1'
     ///
     /// - Min: 0
     /// - Max: 250
@@ -92,7 +92,7 @@ impl TestMessage {
     pub fn signal1(&self) -> u8 {
         self.signal1_raw()
     }
-    /// Get raw value of Signal1
+    /// Get raw value of 'Signal1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -106,7 +106,7 @@ impl TestMessage {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal1
+    /// Set value of 'Signal1'
     #[inline(always)]
     pub fn set_signal1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 250_u8 < value {

--- a/tests-snapshots/dbc-cantools/j1939.snap.rs
+++ b/tests-snapshots/dbc-cantools/j1939.snap.rs
@@ -73,7 +73,7 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i8 = 0_i8;
     pub const SIGNAL1_MAX: i8 = 0_i8;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new(signal1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal1(signal1)?;
@@ -83,7 +83,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Signal1
+    /// Get value of 'Signal1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -93,7 +93,7 @@ impl Message1 {
     pub fn signal1(&self) -> i8 {
         self.signal1_raw()
     }
-    /// Get raw value of Signal1
+    /// Get raw value of 'Signal1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -108,7 +108,7 @@ impl Message1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal1
+    /// Set value of 'Signal1'
     #[inline(always)]
     pub fn set_signal1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -191,7 +191,7 @@ impl Message2 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL2_MIN: i8 = 0_i8;
     pub const SIGNAL2_MAX: i8 = 0_i8;
-    /// Construct new Message2 from values
+    /// Construct new 'Message2' from values
     pub fn new(signal2: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal2(signal2)?;
@@ -201,7 +201,7 @@ impl Message2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Signal2
+    /// Get value of 'Signal2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -211,7 +211,7 @@ impl Message2 {
     pub fn signal2(&self) -> i8 {
         self.signal2_raw()
     }
-    /// Get raw value of Signal2
+    /// Get raw value of 'Signal2'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -226,7 +226,7 @@ impl Message2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal2
+    /// Set value of 'Signal2'
     #[inline(always)]
     pub fn set_signal2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/long_names.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names.snap.rs
@@ -134,7 +134,7 @@ impl Ss123456789012345678901234587890 {
         StandardId::new_unchecked(0x9)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new SS123456789012345678901234587890 from values
+    /// Construct new 'SS123456789012345678901234587890' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -204,7 +204,7 @@ impl Ss12345678901234567890123450000 {
         StandardId::new_unchecked(0x8)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new SS1234567890123456789012345_0000 from values
+    /// Construct new 'SS1234567890123456789012345_0000' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -274,7 +274,7 @@ impl Ss12345678901234567890123450001 {
         StandardId::new_unchecked(0x7)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new SS1234567890123456789012345_0001 from values
+    /// Construct new 'SS1234567890123456789012345_0001' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -344,7 +344,7 @@ impl Ss123456789012345678901234577890 {
         StandardId::new_unchecked(0x6)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new SS123456789012345678901234577890 from values
+    /// Construct new 'SS123456789012345678901234577890' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -414,7 +414,7 @@ impl Ss123456789012345678901234567890 {
         StandardId::new_unchecked(0x5)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new SS123456789012345678901234567890 from values
+    /// Construct new 'SS123456789012345678901234567890' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -486,7 +486,7 @@ impl S1234567890123456789012345678901 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SS123456789012345678901234567890_MIN: i8 = 0_i8;
     pub const SS123456789012345678901234567890_MAX: i8 = 0_i8;
-    /// Construct new S1234567890123456789012345678901 from values
+    /// Construct new 'S1234567890123456789012345678901' from values
     pub fn new(ss123456789012345678901234567890: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_ss123456789012345678901234567890(ss123456789012345678901234567890)?;
@@ -496,7 +496,7 @@ impl S1234567890123456789012345678901 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SS123456789012345678901234567890
+    /// Get value of 'SS123456789012345678901234567890'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -506,7 +506,7 @@ impl S1234567890123456789012345678901 {
     pub fn ss123456789012345678901234567890(&self) -> i8 {
         self.ss123456789012345678901234567890_raw()
     }
-    /// Get raw value of SS123456789012345678901234567890
+    /// Get raw value of 'SS123456789012345678901234567890'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -521,7 +521,7 @@ impl S1234567890123456789012345678901 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SS123456789012345678901234567890
+    /// Set value of 'SS123456789012345678901234567890'
     #[inline(always)]
     pub fn set_ss123456789012345678901234567890(
         &mut self,
@@ -606,7 +606,7 @@ impl M123456789012345678901234560000 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SSS12345678901234567890123456789_MIN: i8 = 0_i8;
     pub const SSS12345678901234567890123456789_MAX: i8 = 0_i8;
-    /// Construct new M12345678901234567890123456_0000 from values
+    /// Construct new 'M12345678901234567890123456_0000' from values
     pub fn new(sss12345678901234567890123456789: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_sss12345678901234567890123456789(sss12345678901234567890123456789)?;
@@ -616,7 +616,7 @@ impl M123456789012345678901234560000 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SSS12345678901234567890123456789
+    /// Get value of 'SSS12345678901234567890123456789'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -626,7 +626,7 @@ impl M123456789012345678901234560000 {
     pub fn sss12345678901234567890123456789(&self) -> i8 {
         self.sss12345678901234567890123456789_raw()
     }
-    /// Get raw value of SSS12345678901234567890123456789
+    /// Get raw value of 'SSS12345678901234567890123456789'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -641,7 +641,7 @@ impl M123456789012345678901234560000 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SSS12345678901234567890123456789
+    /// Set value of 'SSS12345678901234567890123456789'
     #[inline(always)]
     pub fn set_sss12345678901234567890123456789(
         &mut self,
@@ -735,7 +735,7 @@ impl M1234567890123456789012345678901 {
     pub const S12345678901234567890123456_0000_MAX: i8 = 0_i8;
     pub const S1234567890123456789012345678901_MIN: i8 = 0_i8;
     pub const S1234567890123456789012345678901_MAX: i8 = 0_i8;
-    /// Construct new M1234567890123456789012345678901 from values
+    /// Construct new 'M1234567890123456789012345678901' from values
     pub fn new(
         ss1234567890123456789012345_0000: i8,
         ss1234567890123456789012345_0001: i8,
@@ -755,7 +755,7 @@ impl M1234567890123456789012345678901 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SS1234567890123456789012345_0000
+    /// Get value of 'SS1234567890123456789012345_0000'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -765,7 +765,7 @@ impl M1234567890123456789012345678901 {
     pub fn ss1234567890123456789012345_0000(&self) -> i8 {
         self.ss1234567890123456789012345_0000_raw()
     }
-    /// Get raw value of SS1234567890123456789012345_0000
+    /// Get raw value of 'SS1234567890123456789012345_0000'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -780,7 +780,7 @@ impl M1234567890123456789012345678901 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SS1234567890123456789012345_0000
+    /// Set value of 'SS1234567890123456789012345_0000'
     #[inline(always)]
     pub fn set_ss1234567890123456789012345_0000(
         &mut self,
@@ -802,7 +802,7 @@ impl M1234567890123456789012345678901 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// SS1234567890123456789012345_0001
+    /// Get value of 'SS1234567890123456789012345_0001'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -812,7 +812,7 @@ impl M1234567890123456789012345678901 {
     pub fn ss1234567890123456789012345_0001(&self) -> i8 {
         self.ss1234567890123456789012345_0001_raw()
     }
-    /// Get raw value of SS1234567890123456789012345_0001
+    /// Get raw value of 'SS1234567890123456789012345_0001'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -827,7 +827,7 @@ impl M1234567890123456789012345678901 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SS1234567890123456789012345_0001
+    /// Set value of 'SS1234567890123456789012345_0001'
     #[inline(always)]
     pub fn set_ss1234567890123456789012345_0001(
         &mut self,
@@ -849,7 +849,7 @@ impl M1234567890123456789012345678901 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// SS1234567890123456789012345_0002
+    /// Get value of 'SS1234567890123456789012345_0002'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -859,7 +859,7 @@ impl M1234567890123456789012345678901 {
     pub fn ss1234567890123456789012345_0002(&self) -> i8 {
         self.ss1234567890123456789012345_0002_raw()
     }
-    /// Get raw value of SS1234567890123456789012345_0002
+    /// Get raw value of 'SS1234567890123456789012345_0002'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -874,7 +874,7 @@ impl M1234567890123456789012345678901 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SS1234567890123456789012345_0002
+    /// Set value of 'SS1234567890123456789012345_0002'
     #[inline(always)]
     pub fn set_ss1234567890123456789012345_0002(
         &mut self,
@@ -896,7 +896,7 @@ impl M1234567890123456789012345678901 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// S12345678901234567890123456_0000
+    /// Get value of 'S12345678901234567890123456_0000'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -906,7 +906,7 @@ impl M1234567890123456789012345678901 {
     pub fn s12345678901234567890123456_0000(&self) -> i8 {
         self.s12345678901234567890123456_0000_raw()
     }
-    /// Get raw value of S12345678901234567890123456_0000
+    /// Get raw value of 'S12345678901234567890123456_0000'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -921,7 +921,7 @@ impl M1234567890123456789012345678901 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S12345678901234567890123456_0000
+    /// Set value of 'S12345678901234567890123456_0000'
     #[inline(always)]
     pub fn set_s12345678901234567890123456_0000(
         &mut self,
@@ -943,7 +943,7 @@ impl M1234567890123456789012345678901 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// S1234567890123456789012345678901
+    /// Get value of 'S1234567890123456789012345678901'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -953,7 +953,7 @@ impl M1234567890123456789012345678901 {
     pub fn s1234567890123456789012345678901(&self) -> i8 {
         self.s1234567890123456789012345678901_raw()
     }
-    /// Get raw value of S1234567890123456789012345678901
+    /// Get raw value of 'S1234567890123456789012345678901'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -968,7 +968,7 @@ impl M1234567890123456789012345678901 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S1234567890123456789012345678901
+    /// Set value of 'S1234567890123456789012345678901'
     #[inline(always)]
     pub fn set_s1234567890123456789012345678901(
         &mut self,
@@ -1060,7 +1060,7 @@ impl M123456789012345678901234560001 {
     pub const S12345678901234567890123456_0001_MAX: i8 = 0_i8;
     pub const S12345678901234567890123456_0002_MIN: i8 = 0_i8;
     pub const S12345678901234567890123456_0002_MAX: i8 = 0_i8;
-    /// Construct new M12345678901234567890123456_0001 from values
+    /// Construct new 'M12345678901234567890123456_0001' from values
     pub fn new(
         ss1234567890123456789012345_0003: i8,
         ss1234567890123456789012345_0004: i8,
@@ -1078,7 +1078,7 @@ impl M123456789012345678901234560001 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SS1234567890123456789012345_0003
+    /// Get value of 'SS1234567890123456789012345_0003'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1088,7 +1088,7 @@ impl M123456789012345678901234560001 {
     pub fn ss1234567890123456789012345_0003(&self) -> i8 {
         self.ss1234567890123456789012345_0003_raw()
     }
-    /// Get raw value of SS1234567890123456789012345_0003
+    /// Get raw value of 'SS1234567890123456789012345_0003'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -1103,7 +1103,7 @@ impl M123456789012345678901234560001 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SS1234567890123456789012345_0003
+    /// Set value of 'SS1234567890123456789012345_0003'
     #[inline(always)]
     pub fn set_ss1234567890123456789012345_0003(
         &mut self,
@@ -1125,7 +1125,7 @@ impl M123456789012345678901234560001 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// SS1234567890123456789012345_0004
+    /// Get value of 'SS1234567890123456789012345_0004'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1135,7 +1135,7 @@ impl M123456789012345678901234560001 {
     pub fn ss1234567890123456789012345_0004(&self) -> i8 {
         self.ss1234567890123456789012345_0004_raw()
     }
-    /// Get raw value of SS1234567890123456789012345_0004
+    /// Get raw value of 'SS1234567890123456789012345_0004'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -1150,7 +1150,7 @@ impl M123456789012345678901234560001 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SS1234567890123456789012345_0004
+    /// Set value of 'SS1234567890123456789012345_0004'
     #[inline(always)]
     pub fn set_ss1234567890123456789012345_0004(
         &mut self,
@@ -1172,7 +1172,7 @@ impl M123456789012345678901234560001 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// S12345678901234567890123456_0001
+    /// Get value of 'S12345678901234567890123456_0001'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1182,7 +1182,7 @@ impl M123456789012345678901234560001 {
     pub fn s12345678901234567890123456_0001(&self) -> i8 {
         self.s12345678901234567890123456_0001_raw()
     }
-    /// Get raw value of S12345678901234567890123456_0001
+    /// Get raw value of 'S12345678901234567890123456_0001'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -1197,7 +1197,7 @@ impl M123456789012345678901234560001 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S12345678901234567890123456_0001
+    /// Set value of 'S12345678901234567890123456_0001'
     #[inline(always)]
     pub fn set_s12345678901234567890123456_0001(
         &mut self,
@@ -1219,7 +1219,7 @@ impl M123456789012345678901234560001 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// S12345678901234567890123456_0002
+    /// Get value of 'S12345678901234567890123456_0002'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1229,7 +1229,7 @@ impl M123456789012345678901234560001 {
     pub fn s12345678901234567890123456_0002(&self) -> i8 {
         self.s12345678901234567890123456_0002_raw()
     }
-    /// Get raw value of S12345678901234567890123456_0002
+    /// Get raw value of 'S12345678901234567890123456_0002'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -1244,7 +1244,7 @@ impl M123456789012345678901234560001 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S12345678901234567890123456_0002
+    /// Set value of 'S12345678901234567890123456_0002'
     #[inline(always)]
     pub fn set_s12345678901234567890123456_0002(
         &mut self,
@@ -1331,7 +1331,7 @@ impl Mm123456789012345678901234567890 {
     pub const SSS123456789012345678901234_0000_MAX: i8 = 0_i8;
     pub const SS1234567890123456789012345_0005_MIN: i8 = 0_i8;
     pub const SS1234567890123456789012345_0005_MAX: i8 = 0_i8;
-    /// Construct new MM123456789012345678901234567890 from values
+    /// Construct new 'MM123456789012345678901234567890' from values
     pub fn new(
         sss123456789012345678901234_0000: i8,
         ss1234567890123456789012345_0005: i8,
@@ -1345,7 +1345,7 @@ impl Mm123456789012345678901234567890 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SSS123456789012345678901234_0000
+    /// Get value of 'SSS123456789012345678901234_0000'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1355,7 +1355,7 @@ impl Mm123456789012345678901234567890 {
     pub fn sss123456789012345678901234_0000(&self) -> i8 {
         self.sss123456789012345678901234_0000_raw()
     }
-    /// Get raw value of SSS123456789012345678901234_0000
+    /// Get raw value of 'SSS123456789012345678901234_0000'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -1370,7 +1370,7 @@ impl Mm123456789012345678901234567890 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SSS123456789012345678901234_0000
+    /// Set value of 'SSS123456789012345678901234_0000'
     #[inline(always)]
     pub fn set_sss123456789012345678901234_0000(
         &mut self,
@@ -1392,7 +1392,7 @@ impl Mm123456789012345678901234567890 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// SS1234567890123456789012345_0005
+    /// Get value of 'SS1234567890123456789012345_0005'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1402,7 +1402,7 @@ impl Mm123456789012345678901234567890 {
     pub fn ss1234567890123456789012345_0005(&self) -> i8 {
         self.ss1234567890123456789012345_0005_raw()
     }
-    /// Get raw value of SS1234567890123456789012345_0005
+    /// Get raw value of 'SS1234567890123456789012345_0005'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -1417,7 +1417,7 @@ impl Mm123456789012345678901234567890 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SS1234567890123456789012345_0005
+    /// Set value of 'SS1234567890123456789012345_0005'
     #[inline(always)]
     pub fn set_ss1234567890123456789012345_0005(
         &mut self,

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
@@ -827,14 +827,7 @@ impl MsgWithValueTableSigs {
         &mut self,
         value: MsgWithValueTableSigsSigWithShortValTable,
     ) -> Result<(), CanError> {
-        self.set_sig_with_short_val_table_raw(i8::from(value))
-    }
-    /// Set raw value of 'Sig_with_short_val_table'
-    #[inline(always)]
-    pub fn set_sig_with_short_val_table_raw(
-        &mut self,
-        value: i8,
-    ) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -905,14 +898,7 @@ impl MsgWithValueTableSigs {
         &mut self,
         value: MsgWithValueTableSigsSigWithLongValTable2,
     ) -> Result<(), CanError> {
-        self.set_sig_with_long_val_table_2_raw(i8::from(value))
-    }
-    /// Set raw value of 'Sig_with_long_val_table_2'
-    #[inline(always)]
-    pub fn set_sig_with_long_val_table_2_raw(
-        &mut self,
-        value: i8,
-    ) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -973,14 +959,7 @@ impl MsgWithValueTableSigs {
         &mut self,
         value: MsgWithValueTableSigsSigWithLongValTable1,
     ) -> Result<(), CanError> {
-        self.set_sig_with_long_val_table_1_raw(i8::from(value))
-    }
-    /// Set raw value of 'Sig_with_long_val_table_1'
-    #[inline(always)]
-    pub fn set_sig_with_long_val_table_1_raw(
-        &mut self,
-        value: i8,
-    ) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs
@@ -114,7 +114,7 @@ impl MsgLongName5678912345678912 {
     pub const RX_TWICE_SHORT_MAX: i32 = 0_i32;
     pub const SIG_USED_TWICE_EFGH_ABCDEFGHI_AB_MIN: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFGHI_AB_MAX: i8 = 0_i8;
-    /// Construct new Msg_Long_Name_56789_123456789_12 from values
+    /// Construct new 'Msg_Long_Name_56789_123456789_12' from values
     pub fn new(
         rx_twice_11111111111111111111111: i8,
         rx_twice_short: i32,
@@ -130,7 +130,7 @@ impl MsgLongName5678912345678912 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// rx_twice_11111111111111111111111
+    /// Get value of 'rx_twice_11111111111111111111111'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -140,7 +140,7 @@ impl MsgLongName5678912345678912 {
     pub fn rx_twice_11111111111111111111111(&self) -> i8 {
         self.rx_twice_11111111111111111111111_raw()
     }
-    /// Get raw value of rx_twice_11111111111111111111111
+    /// Get raw value of 'rx_twice_11111111111111111111111'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -155,7 +155,7 @@ impl MsgLongName5678912345678912 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_11111111111111111111111
+    /// Set value of 'rx_twice_11111111111111111111111'
     #[inline(always)]
     pub fn set_rx_twice_11111111111111111111111(
         &mut self,
@@ -177,7 +177,7 @@ impl MsgLongName5678912345678912 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// rx_twice_short
+    /// Get value of 'rx_twice_short'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -187,7 +187,7 @@ impl MsgLongName5678912345678912 {
     pub fn rx_twice_short(&self) -> i32 {
         self.rx_twice_short_raw()
     }
-    /// Get raw value of rx_twice_short
+    /// Get raw value of 'rx_twice_short'
     ///
     /// - Start bit: 16
     /// - Signal size: 18 bits
@@ -202,7 +202,7 @@ impl MsgLongName5678912345678912 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_short
+    /// Set value of 'rx_twice_short'
     #[inline(always)]
     pub fn set_rx_twice_short(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -221,7 +221,7 @@ impl MsgLongName5678912345678912 {
         self.raw.view_bits_mut::<Lsb0>()[16..34].store_le(value);
         Ok(())
     }
-    /// Sig_used_twice_efgh_abcdefghi_ab
+    /// Get value of 'Sig_used_twice_efgh_abcdefghi_ab'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -231,7 +231,7 @@ impl MsgLongName5678912345678912 {
     pub fn sig_used_twice_efgh_abcdefghi_ab(&self) -> i8 {
         self.sig_used_twice_efgh_abcdefghi_ab_raw()
     }
-    /// Get raw value of Sig_used_twice_efgh_abcdefghi_ab
+    /// Get raw value of 'Sig_used_twice_efgh_abcdefghi_ab'
     ///
     /// - Start bit: 0
     /// - Signal size: 6 bits
@@ -246,7 +246,7 @@ impl MsgLongName5678912345678912 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_used_twice_efgh_abcdefghi_ab
+    /// Set value of 'Sig_used_twice_efgh_abcdefghi_ab'
     #[inline(always)]
     pub fn set_sig_used_twice_efgh_abcdefghi_ab(
         &mut self,
@@ -334,7 +334,7 @@ impl TxTwice {
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MAX: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MIN: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MAX: i8 = 0_i8;
-    /// Construct new TX_twice from values
+    /// Construct new 'TX_twice' from values
     pub fn new(
         rx_twice_long_yyyyyyyyyyyyyyyyyy: i8,
         rx_twice_short: i8,
@@ -348,7 +348,7 @@ impl TxTwice {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// rx_twice_long_yyyyyyyyyyyyyyyyyy
+    /// Get value of 'rx_twice_long_yyyyyyyyyyyyyyyyyy'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -358,7 +358,7 @@ impl TxTwice {
     pub fn rx_twice_long_yyyyyyyyyyyyyyyyyy(&self) -> i8 {
         self.rx_twice_long_yyyyyyyyyyyyyyyyyy_raw()
     }
-    /// Get raw value of rx_twice_long_yyyyyyyyyyyyyyyyyy
+    /// Get raw value of 'rx_twice_long_yyyyyyyyyyyyyyyyyy'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -373,7 +373,7 @@ impl TxTwice {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_long_yyyyyyyyyyyyyyyyyy
+    /// Set value of 'rx_twice_long_yyyyyyyyyyyyyyyyyy'
     #[inline(always)]
     pub fn set_rx_twice_long_yyyyyyyyyyyyyyyyyy(
         &mut self,
@@ -395,7 +395,7 @@ impl TxTwice {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// rx_twice_short
+    /// Get value of 'rx_twice_short'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -405,7 +405,7 @@ impl TxTwice {
     pub fn rx_twice_short(&self) -> i8 {
         self.rx_twice_short_raw()
     }
-    /// Get raw value of rx_twice_short
+    /// Get raw value of 'rx_twice_short'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -420,7 +420,7 @@ impl TxTwice {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_short
+    /// Set value of 'rx_twice_short'
     #[inline(always)]
     pub fn set_rx_twice_short(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -503,7 +503,7 @@ impl RxTx1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MIN: i16 = 0_i16;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MAX: i16 = 0_i16;
-    /// Construct new RX_TX_1 from values
+    /// Construct new 'RX_TX_1' from values
     pub fn new(sig_used_twice_efgh_abcdefg_0000: i16) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_sig_used_twice_efgh_abcdefg_0000(sig_used_twice_efgh_abcdefg_0000)?;
@@ -513,7 +513,7 @@ impl RxTx1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Sig_used_twice_efgh_abcdefg_0000
+    /// Get value of 'Sig_used_twice_efgh_abcdefg_0000'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -523,7 +523,7 @@ impl RxTx1 {
     pub fn sig_used_twice_efgh_abcdefg_0000(&self) -> i16 {
         self.sig_used_twice_efgh_abcdefg_0000_raw()
     }
-    /// Get raw value of Sig_used_twice_efgh_abcdefg_0000
+    /// Get raw value of 'Sig_used_twice_efgh_abcdefg_0000'
     ///
     /// - Start bit: 0
     /// - Signal size: 9 bits
@@ -538,7 +538,7 @@ impl RxTx1 {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_used_twice_efgh_abcdefg_0000
+    /// Set value of 'Sig_used_twice_efgh_abcdefg_0000'
     #[inline(always)]
     pub fn set_sig_used_twice_efgh_abcdefg_0000(
         &mut self,
@@ -621,7 +621,7 @@ impl MsgCaseTest {
         StandardId::new_unchecked(0x4)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new MSG_CASE_TEST from values
+    /// Construct new 'MSG_CASE_TEST' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -691,7 +691,7 @@ impl MsgCaseTest {
         StandardId::new_unchecked(0x3)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new msg_case_test from values
+    /// Construct new 'msg_case_test' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -767,11 +767,11 @@ impl MsgWithValueTableSigs {
     pub const SIG_WITH_LONG_VAL_TABLE_2_MAX: i8 = 0_i8;
     pub const SIG_WITH_LONG_VAL_TABLE_1_MIN: i8 = 0_i8;
     pub const SIG_WITH_LONG_VAL_TABLE_1_MAX: i8 = 0_i8;
-    /// Construct new Msg_with_value_table_sigs from values
+    /// Construct new 'Msg_with_value_table_sigs' from values
     pub fn new(
-        sig_with_short_val_table: i8,
-        sig_with_long_val_table_2: i8,
-        sig_with_long_val_table_1: i8,
+        sig_with_short_val_table: MsgWithValueTableSigsSigWithShortValTable,
+        sig_with_long_val_table_2: MsgWithValueTableSigsSigWithLongValTable2,
+        sig_with_long_val_table_1: MsgWithValueTableSigsSigWithLongValTable1,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_sig_with_short_val_table(sig_with_short_val_table)?;
@@ -783,7 +783,7 @@ impl MsgWithValueTableSigs {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Sig_with_short_val_table
+    /// Get value of 'Sig_with_short_val_table'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -806,7 +806,7 @@ impl MsgWithValueTableSigs {
             }
         }
     }
-    /// Get raw value of Sig_with_short_val_table
+    /// Get raw value of 'Sig_with_short_val_table'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -821,9 +821,20 @@ impl MsgWithValueTableSigs {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_with_short_val_table
+    /// Set value of 'Sig_with_short_val_table'
     #[inline(always)]
-    pub fn set_sig_with_short_val_table(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_sig_with_short_val_table(
+        &mut self,
+        value: MsgWithValueTableSigsSigWithShortValTable,
+    ) -> Result<(), CanError> {
+        self.set_sig_with_short_val_table_raw(i8::from(value))
+    }
+    /// Set raw value of 'Sig_with_short_val_table'
+    #[inline(always)]
+    pub fn set_sig_with_short_val_table_raw(
+        &mut self,
+        value: i8,
+    ) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -840,7 +851,7 @@ impl MsgWithValueTableSigs {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Sig_with_long_val_table_2
+    /// Get value of 'Sig_with_long_val_table_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -873,7 +884,7 @@ impl MsgWithValueTableSigs {
             }
         }
     }
-    /// Get raw value of Sig_with_long_val_table_2
+    /// Get raw value of 'Sig_with_long_val_table_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -888,9 +899,20 @@ impl MsgWithValueTableSigs {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_with_long_val_table_2
+    /// Set value of 'Sig_with_long_val_table_2'
     #[inline(always)]
-    pub fn set_sig_with_long_val_table_2(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_sig_with_long_val_table_2(
+        &mut self,
+        value: MsgWithValueTableSigsSigWithLongValTable2,
+    ) -> Result<(), CanError> {
+        self.set_sig_with_long_val_table_2_raw(i8::from(value))
+    }
+    /// Set raw value of 'Sig_with_long_val_table_2'
+    #[inline(always)]
+    pub fn set_sig_with_long_val_table_2_raw(
+        &mut self,
+        value: i8,
+    ) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -907,7 +929,7 @@ impl MsgWithValueTableSigs {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Sig_with_long_val_table_1
+    /// Get value of 'Sig_with_long_val_table_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -930,7 +952,7 @@ impl MsgWithValueTableSigs {
             }
         }
     }
-    /// Get raw value of Sig_with_long_val_table_1
+    /// Get raw value of 'Sig_with_long_val_table_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -945,9 +967,20 @@ impl MsgWithValueTableSigs {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_with_long_val_table_1
+    /// Set value of 'Sig_with_long_val_table_1'
     #[inline(always)]
-    pub fn set_sig_with_long_val_table_1(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_sig_with_long_val_table_1(
+        &mut self,
+        value: MsgWithValueTableSigsSigWithLongValTable1,
+    ) -> Result<(), CanError> {
+        self.set_sig_with_long_val_table_1_raw(i8::from(value))
+    }
+    /// Set raw value of 'Sig_with_long_val_table_1'
+    #[inline(always)]
+    pub fn set_sig_with_long_val_table_1_raw(
+        &mut self,
+        value: i8,
+    ) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -1136,7 +1169,7 @@ impl MsgLongName5678912345670000 {
     pub const RX_TWICE_11111111111111111111111_MAX: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0001_MIN: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0001_MAX: i8 = 0_i8;
-    /// Construct new Msg_Long_Name_56789_1234567_0000 from values
+    /// Construct new 'Msg_Long_Name_56789_1234567_0000' from values
     pub fn new(
         rx_twice_11111111111111111111111: i8,
         sig_used_twice_efgh_abcdefg_0001: i8,
@@ -1150,7 +1183,7 @@ impl MsgLongName5678912345670000 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// rx_twice_11111111111111111111111
+    /// Get value of 'rx_twice_11111111111111111111111'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1160,7 +1193,7 @@ impl MsgLongName5678912345670000 {
     pub fn rx_twice_11111111111111111111111(&self) -> i8 {
         self.rx_twice_11111111111111111111111_raw()
     }
-    /// Get raw value of rx_twice_11111111111111111111111
+    /// Get raw value of 'rx_twice_11111111111111111111111'
     ///
     /// - Start bit: 8
     /// - Signal size: 2 bits
@@ -1175,7 +1208,7 @@ impl MsgLongName5678912345670000 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_11111111111111111111111
+    /// Set value of 'rx_twice_11111111111111111111111'
     #[inline(always)]
     pub fn set_rx_twice_11111111111111111111111(
         &mut self,
@@ -1197,7 +1230,7 @@ impl MsgLongName5678912345670000 {
         self.raw.view_bits_mut::<Lsb0>()[8..10].store_le(value);
         Ok(())
     }
-    /// Sig_used_twice_efgh_abcdefg_0001
+    /// Get value of 'Sig_used_twice_efgh_abcdefg_0001'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1207,7 +1240,7 @@ impl MsgLongName5678912345670000 {
     pub fn sig_used_twice_efgh_abcdefg_0001(&self) -> i8 {
         self.sig_used_twice_efgh_abcdefg_0001_raw()
     }
-    /// Get raw value of Sig_used_twice_efgh_abcdefg_0001
+    /// Get raw value of 'Sig_used_twice_efgh_abcdefg_0001'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -1222,7 +1255,7 @@ impl MsgLongName5678912345670000 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_used_twice_efgh_abcdefg_0001
+    /// Set value of 'Sig_used_twice_efgh_abcdefg_0001'
     #[inline(always)]
     pub fn set_sig_used_twice_efgh_abcdefg_0001(
         &mut self,
@@ -1309,7 +1342,7 @@ impl MsgLongName5678912345670001 {
     pub const RX_TWICE_SHORT_MAX: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0002_MIN: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0002_MAX: i8 = 0_i8;
-    /// Construct new Msg_Long_Name_56789_1234567_0001 from values
+    /// Construct new 'Msg_Long_Name_56789_1234567_0001' from values
     pub fn new(
         rx_twice_short: i8,
         sig_used_twice_efgh_abcdefg_0002: i8,
@@ -1323,7 +1356,7 @@ impl MsgLongName5678912345670001 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// rx_twice_short
+    /// Get value of 'rx_twice_short'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1333,7 +1366,7 @@ impl MsgLongName5678912345670001 {
     pub fn rx_twice_short(&self) -> i8 {
         self.rx_twice_short_raw()
     }
-    /// Get raw value of rx_twice_short
+    /// Get raw value of 'rx_twice_short'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -1348,7 +1381,7 @@ impl MsgLongName5678912345670001 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_short
+    /// Set value of 'rx_twice_short'
     #[inline(always)]
     pub fn set_rx_twice_short(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -1367,7 +1400,7 @@ impl MsgLongName5678912345670001 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Sig_used_twice_efgh_abcdefg_0002
+    /// Get value of 'Sig_used_twice_efgh_abcdefg_0002'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1377,7 +1410,7 @@ impl MsgLongName5678912345670001 {
     pub fn sig_used_twice_efgh_abcdefg_0002(&self) -> i8 {
         self.sig_used_twice_efgh_abcdefg_0002_raw()
     }
-    /// Get raw value of Sig_used_twice_efgh_abcdefg_0002
+    /// Get raw value of 'Sig_used_twice_efgh_abcdefg_0002'
     ///
     /// - Start bit: 0
     /// - Signal size: 6 bits
@@ -1392,7 +1425,7 @@ impl MsgLongName5678912345670001 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_used_twice_efgh_abcdefg_0002
+    /// Set value of 'Sig_used_twice_efgh_abcdefg_0002'
     #[inline(always)]
     pub fn set_sig_used_twice_efgh_abcdefg_0002(
         &mut self,

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
@@ -29,7 +29,7 @@ error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest
 676 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
-error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
+error[E0119]: conflicting implementations of trait `std::marker::Copy` for type `MsgCaseTest`
    --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:676:17
     |
 606 | #[derive(Clone, Copy)]

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
@@ -29,7 +29,7 @@ error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest
 676 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
-error[E0119]: conflicting implementations of trait `std::marker::Copy` for type `MsgCaseTest`
+error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
    --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:676:17
     |
 606 | #[derive(Clone, Copy)]

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
@@ -827,14 +827,7 @@ impl MsgWithValueTableSigs {
         &mut self,
         value: MsgWithValueTableSigsSigWithShortValTable,
     ) -> Result<(), CanError> {
-        self.set_sig_with_short_val_table_raw(i8::from(value))
-    }
-    /// Set raw value of 'Sig_with_short_val_table'
-    #[inline(always)]
-    pub fn set_sig_with_short_val_table_raw(
-        &mut self,
-        value: i8,
-    ) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -905,14 +898,7 @@ impl MsgWithValueTableSigs {
         &mut self,
         value: MsgWithValueTableSigsSigWithLongValTable2,
     ) -> Result<(), CanError> {
-        self.set_sig_with_long_val_table_2_raw(i8::from(value))
-    }
-    /// Set raw value of 'Sig_with_long_val_table_2'
-    #[inline(always)]
-    pub fn set_sig_with_long_val_table_2_raw(
-        &mut self,
-        value: i8,
-    ) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -973,14 +959,7 @@ impl MsgWithValueTableSigs {
         &mut self,
         value: MsgWithValueTableSigsSigWithLongValTable1,
     ) -> Result<(), CanError> {
-        self.set_sig_with_long_val_table_1_raw(i8::from(value))
-    }
-    /// Set raw value of 'Sig_with_long_val_table_1'
-    #[inline(always)]
-    pub fn set_sig_with_long_val_table_1_raw(
-        &mut self,
-        value: i8,
-    ) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs
@@ -114,7 +114,7 @@ impl MsgLongName5678912345678912 {
     pub const RX_TWICE_11111111111111111111111_MAX: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFGHI_AB_MIN: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFGHI_AB_MAX: i8 = 0_i8;
-    /// Construct new Msg_Long_Name_56789_123456789_12 from values
+    /// Construct new 'Msg_Long_Name_56789_123456789_12' from values
     pub fn new(
         rx_twice_short: i32,
         rx_twice_11111111111111111111111: i8,
@@ -130,7 +130,7 @@ impl MsgLongName5678912345678912 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// rx_twice_short
+    /// Get value of 'rx_twice_short'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -140,7 +140,7 @@ impl MsgLongName5678912345678912 {
     pub fn rx_twice_short(&self) -> i32 {
         self.rx_twice_short_raw()
     }
-    /// Get raw value of rx_twice_short
+    /// Get raw value of 'rx_twice_short'
     ///
     /// - Start bit: 16
     /// - Signal size: 18 bits
@@ -155,7 +155,7 @@ impl MsgLongName5678912345678912 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_short
+    /// Set value of 'rx_twice_short'
     #[inline(always)]
     pub fn set_rx_twice_short(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -174,7 +174,7 @@ impl MsgLongName5678912345678912 {
         self.raw.view_bits_mut::<Lsb0>()[16..34].store_le(value);
         Ok(())
     }
-    /// rx_twice_11111111111111111111111
+    /// Get value of 'rx_twice_11111111111111111111111'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -184,7 +184,7 @@ impl MsgLongName5678912345678912 {
     pub fn rx_twice_11111111111111111111111(&self) -> i8 {
         self.rx_twice_11111111111111111111111_raw()
     }
-    /// Get raw value of rx_twice_11111111111111111111111
+    /// Get raw value of 'rx_twice_11111111111111111111111'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -199,7 +199,7 @@ impl MsgLongName5678912345678912 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_11111111111111111111111
+    /// Set value of 'rx_twice_11111111111111111111111'
     #[inline(always)]
     pub fn set_rx_twice_11111111111111111111111(
         &mut self,
@@ -221,7 +221,7 @@ impl MsgLongName5678912345678912 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Sig_used_twice_efgh_abcdefghi_ab
+    /// Get value of 'Sig_used_twice_efgh_abcdefghi_ab'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -231,7 +231,7 @@ impl MsgLongName5678912345678912 {
     pub fn sig_used_twice_efgh_abcdefghi_ab(&self) -> i8 {
         self.sig_used_twice_efgh_abcdefghi_ab_raw()
     }
-    /// Get raw value of Sig_used_twice_efgh_abcdefghi_ab
+    /// Get raw value of 'Sig_used_twice_efgh_abcdefghi_ab'
     ///
     /// - Start bit: 0
     /// - Signal size: 6 bits
@@ -246,7 +246,7 @@ impl MsgLongName5678912345678912 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_used_twice_efgh_abcdefghi_ab
+    /// Set value of 'Sig_used_twice_efgh_abcdefghi_ab'
     #[inline(always)]
     pub fn set_sig_used_twice_efgh_abcdefghi_ab(
         &mut self,
@@ -334,7 +334,7 @@ impl TxTwice {
     pub const RX_TWICE_LONG_YYYYYYYYYYYYYYYYYY_MAX: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MIN: i8 = 0_i8;
     pub const RX_TWICE_SHORT_MAX: i8 = 0_i8;
-    /// Construct new TX_twice from values
+    /// Construct new 'TX_twice' from values
     pub fn new(
         rx_twice_long_yyyyyyyyyyyyyyyyyy: i8,
         rx_twice_short: i8,
@@ -348,7 +348,7 @@ impl TxTwice {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// rx_twice_long_yyyyyyyyyyyyyyyyyy
+    /// Get value of 'rx_twice_long_yyyyyyyyyyyyyyyyyy'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -358,7 +358,7 @@ impl TxTwice {
     pub fn rx_twice_long_yyyyyyyyyyyyyyyyyy(&self) -> i8 {
         self.rx_twice_long_yyyyyyyyyyyyyyyyyy_raw()
     }
-    /// Get raw value of rx_twice_long_yyyyyyyyyyyyyyyyyy
+    /// Get raw value of 'rx_twice_long_yyyyyyyyyyyyyyyyyy'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -373,7 +373,7 @@ impl TxTwice {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_long_yyyyyyyyyyyyyyyyyy
+    /// Set value of 'rx_twice_long_yyyyyyyyyyyyyyyyyy'
     #[inline(always)]
     pub fn set_rx_twice_long_yyyyyyyyyyyyyyyyyy(
         &mut self,
@@ -395,7 +395,7 @@ impl TxTwice {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// rx_twice_short
+    /// Get value of 'rx_twice_short'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -405,7 +405,7 @@ impl TxTwice {
     pub fn rx_twice_short(&self) -> i8 {
         self.rx_twice_short_raw()
     }
-    /// Get raw value of rx_twice_short
+    /// Get raw value of 'rx_twice_short'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -420,7 +420,7 @@ impl TxTwice {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_short
+    /// Set value of 'rx_twice_short'
     #[inline(always)]
     pub fn set_rx_twice_short(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -503,7 +503,7 @@ impl RxTx1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MIN: i16 = 0_i16;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0000_MAX: i16 = 0_i16;
-    /// Construct new RX_TX_1 from values
+    /// Construct new 'RX_TX_1' from values
     pub fn new(sig_used_twice_efgh_abcdefg_0000: i16) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_sig_used_twice_efgh_abcdefg_0000(sig_used_twice_efgh_abcdefg_0000)?;
@@ -513,7 +513,7 @@ impl RxTx1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Sig_used_twice_efgh_abcdefg_0000
+    /// Get value of 'Sig_used_twice_efgh_abcdefg_0000'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -523,7 +523,7 @@ impl RxTx1 {
     pub fn sig_used_twice_efgh_abcdefg_0000(&self) -> i16 {
         self.sig_used_twice_efgh_abcdefg_0000_raw()
     }
-    /// Get raw value of Sig_used_twice_efgh_abcdefg_0000
+    /// Get raw value of 'Sig_used_twice_efgh_abcdefg_0000'
     ///
     /// - Start bit: 0
     /// - Signal size: 9 bits
@@ -538,7 +538,7 @@ impl RxTx1 {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_used_twice_efgh_abcdefg_0000
+    /// Set value of 'Sig_used_twice_efgh_abcdefg_0000'
     #[inline(always)]
     pub fn set_sig_used_twice_efgh_abcdefg_0000(
         &mut self,
@@ -621,7 +621,7 @@ impl MsgCaseTest {
         StandardId::new_unchecked(0x4)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new MSG_CASE_TEST from values
+    /// Construct new 'MSG_CASE_TEST' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -691,7 +691,7 @@ impl MsgCaseTest {
         StandardId::new_unchecked(0x3)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    /// Construct new msg_case_test from values
+    /// Construct new 'msg_case_test' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 8] };
         Ok(res)
@@ -767,11 +767,11 @@ impl MsgWithValueTableSigs {
     pub const SIG_WITH_LONG_VAL_TABLE_2_MAX: i8 = 0_i8;
     pub const SIG_WITH_LONG_VAL_TABLE_1_MIN: i8 = 0_i8;
     pub const SIG_WITH_LONG_VAL_TABLE_1_MAX: i8 = 0_i8;
-    /// Construct new Msg_with_value_table_sigs from values
+    /// Construct new 'Msg_with_value_table_sigs' from values
     pub fn new(
-        sig_with_short_val_table: i8,
-        sig_with_long_val_table_2: i8,
-        sig_with_long_val_table_1: i8,
+        sig_with_short_val_table: MsgWithValueTableSigsSigWithShortValTable,
+        sig_with_long_val_table_2: MsgWithValueTableSigsSigWithLongValTable2,
+        sig_with_long_val_table_1: MsgWithValueTableSigsSigWithLongValTable1,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_sig_with_short_val_table(sig_with_short_val_table)?;
@@ -783,7 +783,7 @@ impl MsgWithValueTableSigs {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Sig_with_short_val_table
+    /// Get value of 'Sig_with_short_val_table'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -806,7 +806,7 @@ impl MsgWithValueTableSigs {
             }
         }
     }
-    /// Get raw value of Sig_with_short_val_table
+    /// Get raw value of 'Sig_with_short_val_table'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -821,9 +821,20 @@ impl MsgWithValueTableSigs {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_with_short_val_table
+    /// Set value of 'Sig_with_short_val_table'
     #[inline(always)]
-    pub fn set_sig_with_short_val_table(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_sig_with_short_val_table(
+        &mut self,
+        value: MsgWithValueTableSigsSigWithShortValTable,
+    ) -> Result<(), CanError> {
+        self.set_sig_with_short_val_table_raw(i8::from(value))
+    }
+    /// Set raw value of 'Sig_with_short_val_table'
+    #[inline(always)]
+    pub fn set_sig_with_short_val_table_raw(
+        &mut self,
+        value: i8,
+    ) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -840,7 +851,7 @@ impl MsgWithValueTableSigs {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Sig_with_long_val_table_2
+    /// Get value of 'Sig_with_long_val_table_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -873,7 +884,7 @@ impl MsgWithValueTableSigs {
             }
         }
     }
-    /// Get raw value of Sig_with_long_val_table_2
+    /// Get raw value of 'Sig_with_long_val_table_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -888,9 +899,20 @@ impl MsgWithValueTableSigs {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_with_long_val_table_2
+    /// Set value of 'Sig_with_long_val_table_2'
     #[inline(always)]
-    pub fn set_sig_with_long_val_table_2(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_sig_with_long_val_table_2(
+        &mut self,
+        value: MsgWithValueTableSigsSigWithLongValTable2,
+    ) -> Result<(), CanError> {
+        self.set_sig_with_long_val_table_2_raw(i8::from(value))
+    }
+    /// Set raw value of 'Sig_with_long_val_table_2'
+    #[inline(always)]
+    pub fn set_sig_with_long_val_table_2_raw(
+        &mut self,
+        value: i8,
+    ) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -907,7 +929,7 @@ impl MsgWithValueTableSigs {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Sig_with_long_val_table_1
+    /// Get value of 'Sig_with_long_val_table_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -930,7 +952,7 @@ impl MsgWithValueTableSigs {
             }
         }
     }
-    /// Get raw value of Sig_with_long_val_table_1
+    /// Get raw value of 'Sig_with_long_val_table_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -945,9 +967,20 @@ impl MsgWithValueTableSigs {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_with_long_val_table_1
+    /// Set value of 'Sig_with_long_val_table_1'
     #[inline(always)]
-    pub fn set_sig_with_long_val_table_1(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_sig_with_long_val_table_1(
+        &mut self,
+        value: MsgWithValueTableSigsSigWithLongValTable1,
+    ) -> Result<(), CanError> {
+        self.set_sig_with_long_val_table_1_raw(i8::from(value))
+    }
+    /// Set raw value of 'Sig_with_long_val_table_1'
+    #[inline(always)]
+    pub fn set_sig_with_long_val_table_1_raw(
+        &mut self,
+        value: i8,
+    ) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: MsgWithValueTableSigs::MESSAGE_ID,
@@ -1136,7 +1169,7 @@ impl MsgLongName5678912345670000 {
     pub const RX_TWICE_11111111111111111111111_MAX: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0001_MIN: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0001_MAX: i8 = 0_i8;
-    /// Construct new Msg_Long_Name_56789_1234567_0000 from values
+    /// Construct new 'Msg_Long_Name_56789_1234567_0000' from values
     pub fn new(
         rx_twice_11111111111111111111111: i8,
         sig_used_twice_efgh_abcdefg_0001: i8,
@@ -1150,7 +1183,7 @@ impl MsgLongName5678912345670000 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// rx_twice_11111111111111111111111
+    /// Get value of 'rx_twice_11111111111111111111111'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1160,7 +1193,7 @@ impl MsgLongName5678912345670000 {
     pub fn rx_twice_11111111111111111111111(&self) -> i8 {
         self.rx_twice_11111111111111111111111_raw()
     }
-    /// Get raw value of rx_twice_11111111111111111111111
+    /// Get raw value of 'rx_twice_11111111111111111111111'
     ///
     /// - Start bit: 8
     /// - Signal size: 2 bits
@@ -1175,7 +1208,7 @@ impl MsgLongName5678912345670000 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_11111111111111111111111
+    /// Set value of 'rx_twice_11111111111111111111111'
     #[inline(always)]
     pub fn set_rx_twice_11111111111111111111111(
         &mut self,
@@ -1197,7 +1230,7 @@ impl MsgLongName5678912345670000 {
         self.raw.view_bits_mut::<Lsb0>()[8..10].store_le(value);
         Ok(())
     }
-    /// Sig_used_twice_efgh_abcdefg_0001
+    /// Get value of 'Sig_used_twice_efgh_abcdefg_0001'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1207,7 +1240,7 @@ impl MsgLongName5678912345670000 {
     pub fn sig_used_twice_efgh_abcdefg_0001(&self) -> i8 {
         self.sig_used_twice_efgh_abcdefg_0001_raw()
     }
-    /// Get raw value of Sig_used_twice_efgh_abcdefg_0001
+    /// Get raw value of 'Sig_used_twice_efgh_abcdefg_0001'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -1222,7 +1255,7 @@ impl MsgLongName5678912345670000 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_used_twice_efgh_abcdefg_0001
+    /// Set value of 'Sig_used_twice_efgh_abcdefg_0001'
     #[inline(always)]
     pub fn set_sig_used_twice_efgh_abcdefg_0001(
         &mut self,
@@ -1309,7 +1342,7 @@ impl MsgLongName5678912345670001 {
     pub const RX_TWICE_SHORT_MAX: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0002_MIN: i8 = 0_i8;
     pub const SIG_USED_TWICE_EFGH_ABCDEFG_0002_MAX: i8 = 0_i8;
-    /// Construct new Msg_Long_Name_56789_1234567_0001 from values
+    /// Construct new 'Msg_Long_Name_56789_1234567_0001' from values
     pub fn new(
         rx_twice_short: i8,
         sig_used_twice_efgh_abcdefg_0002: i8,
@@ -1323,7 +1356,7 @@ impl MsgLongName5678912345670001 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// rx_twice_short
+    /// Get value of 'rx_twice_short'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1333,7 +1366,7 @@ impl MsgLongName5678912345670001 {
     pub fn rx_twice_short(&self) -> i8 {
         self.rx_twice_short_raw()
     }
-    /// Get raw value of rx_twice_short
+    /// Get raw value of 'rx_twice_short'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -1348,7 +1381,7 @@ impl MsgLongName5678912345670001 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of rx_twice_short
+    /// Set value of 'rx_twice_short'
     #[inline(always)]
     pub fn set_rx_twice_short(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -1367,7 +1400,7 @@ impl MsgLongName5678912345670001 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Sig_used_twice_efgh_abcdefg_0002
+    /// Get value of 'Sig_used_twice_efgh_abcdefg_0002'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1377,7 +1410,7 @@ impl MsgLongName5678912345670001 {
     pub fn sig_used_twice_efgh_abcdefg_0002(&self) -> i8 {
         self.sig_used_twice_efgh_abcdefg_0002_raw()
     }
-    /// Get raw value of Sig_used_twice_efgh_abcdefg_0002
+    /// Get raw value of 'Sig_used_twice_efgh_abcdefg_0002'
     ///
     /// - Start bit: 0
     /// - Signal size: 6 bits
@@ -1392,7 +1425,7 @@ impl MsgLongName5678912345670001 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_used_twice_efgh_abcdefg_0002
+    /// Set value of 'Sig_used_twice_efgh_abcdefg_0002'
     #[inline(always)]
     pub fn set_sig_used_twice_efgh_abcdefg_0002(
         &mut self,

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
@@ -29,7 +29,7 @@ error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest
 676 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
-error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
+error[E0119]: conflicting implementations of trait `std::marker::Copy` for type `MsgCaseTest`
    --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:676:17
     |
 606 | #[derive(Clone, Copy)]

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
@@ -29,7 +29,7 @@ error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest
 676 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
-error[E0119]: conflicting implementations of trait `std::marker::Copy` for type `MsgCaseTest`
+error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
    --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:676:17
     |
 606 | #[derive(Clone, Copy)]

--- a/tests-snapshots/dbc-cantools/message-dlc-zero.snap.rs
+++ b/tests-snapshots/dbc-cantools/message-dlc-zero.snap.rs
@@ -68,7 +68,7 @@ impl Message1 {
         StandardId::new_unchecked(0x400)
     });
     pub const MESSAGE_SIZE: usize = 0;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 0] };
         Ok(res)

--- a/tests-snapshots/dbc-cantools/mod_name_len_dest.snap.rs
+++ b/tests-snapshots/dbc-cantools/mod_name_len_dest.snap.rs
@@ -72,7 +72,7 @@ impl MsgNowShort {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_NOW_SHORT_MIN: u8 = 0_u8;
     pub const SIG_NOW_SHORT_MAX: u8 = 0_u8;
-    /// Construct new msg_now_short from values
+    /// Construct new 'msg_now_short' from values
     pub fn new(sig_now_short: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_sig_now_short(sig_now_short)?;
@@ -82,7 +82,7 @@ impl MsgNowShort {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// sig_now_short
+    /// Get value of 'sig_now_short'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -92,7 +92,7 @@ impl MsgNowShort {
     pub fn sig_now_short(&self) -> u8 {
         self.sig_now_short_raw()
     }
-    /// Get raw value of sig_now_short
+    /// Get raw value of 'sig_now_short'
     ///
     /// - Start bit: 1
     /// - Signal size: 8 bits
@@ -106,7 +106,7 @@ impl MsgNowShort {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of sig_now_short
+    /// Set value of 'sig_now_short'
     #[inline(always)]
     pub fn set_sig_now_short(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {

--- a/tests-snapshots/dbc-cantools/mod_name_len_src.snap.rs
+++ b/tests-snapshots/dbc-cantools/mod_name_len_src.snap.rs
@@ -74,7 +74,7 @@ impl MsgWillBeShortened345678912 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIG_WILL_BE_SHORTENED_3456789_12_MIN: u8 = 0_u8;
     pub const SIG_WILL_BE_SHORTENED_3456789_12_MAX: u8 = 0_u8;
-    /// Construct new Msg_will_be_shortened_3456789_12 from values
+    /// Construct new 'Msg_will_be_shortened_3456789_12' from values
     pub fn new(sig_will_be_shortened_3456789_12: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_sig_will_be_shortened_3456789_12(sig_will_be_shortened_3456789_12)?;
@@ -84,7 +84,7 @@ impl MsgWillBeShortened345678912 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Sig_will_be_shortened_3456789_12
+    /// Get value of 'Sig_will_be_shortened_3456789_12'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -94,7 +94,7 @@ impl MsgWillBeShortened345678912 {
     pub fn sig_will_be_shortened_3456789_12(&self) -> u8 {
         self.sig_will_be_shortened_3456789_12_raw()
     }
-    /// Get raw value of Sig_will_be_shortened_3456789_12
+    /// Get raw value of 'Sig_will_be_shortened_3456789_12'
     ///
     /// - Start bit: 1
     /// - Signal size: 8 bits
@@ -108,7 +108,7 @@ impl MsgWillBeShortened345678912 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_will_be_shortened_3456789_12
+    /// Set value of 'Sig_will_be_shortened_3456789_12'
     #[inline(always)]
     pub fn set_sig_will_be_shortened_3456789_12(
         &mut self,

--- a/tests-snapshots/dbc-cantools/motohawk.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk.snap.rs
@@ -202,11 +202,7 @@ impl ExampleMessage {
     /// Set value of 'Enable'
     #[inline(always)]
     pub fn set_enable(&mut self, value: ExampleMessageEnable) -> Result<(), CanError> {
-        self.set_enable_raw(bool::from(value))
-    }
-    /// Set raw value of 'Enable'
-    #[inline(always)]
-    pub fn set_enable_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/motohawk.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk.snap.rs
@@ -76,11 +76,11 @@ impl ExampleMessage {
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;
     pub const AVERAGE_RADIUS_MIN: f32 = 0_f32;
     pub const AVERAGE_RADIUS_MAX: f32 = 5_f32;
-    /// Construct new ExampleMessage from values
+    /// Construct new 'ExampleMessage' from values
     pub fn new(
         temperature: f32,
         average_radius: f32,
-        enable: bool,
+        enable: ExampleMessageEnable,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_temperature(temperature)?;
@@ -92,7 +92,7 @@ impl ExampleMessage {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Temperature
+    /// Get value of 'Temperature'
     ///
     /// - Min: 229.52
     /// - Max: 270.47
@@ -102,7 +102,7 @@ impl ExampleMessage {
     pub fn temperature(&self) -> f32 {
         self.temperature_raw()
     }
-    /// Get raw value of Temperature
+    /// Get raw value of 'Temperature'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -117,7 +117,7 @@ impl ExampleMessage {
         let offset = 250_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature
+    /// Set value of 'Temperature'
     #[inline(always)]
     pub fn set_temperature(&mut self, value: f32) -> Result<(), CanError> {
         if value < 229.52_f32 || 270.47_f32 < value {
@@ -132,7 +132,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Msb0>()[7..19].store_be(value);
         Ok(())
     }
-    /// AverageRadius
+    /// Get value of 'AverageRadius'
     ///
     /// - Min: 0
     /// - Max: 5
@@ -142,7 +142,7 @@ impl ExampleMessage {
     pub fn average_radius(&self) -> f32 {
         self.average_radius_raw()
     }
-    /// Get raw value of AverageRadius
+    /// Get raw value of 'AverageRadius'
     ///
     /// - Start bit: 6
     /// - Signal size: 6 bits
@@ -157,7 +157,7 @@ impl ExampleMessage {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AverageRadius
+    /// Set value of 'AverageRadius'
     #[inline(always)]
     pub fn set_average_radius(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 5_f32 < value {
@@ -171,7 +171,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Msb0>()[1..7].store_be(value);
         Ok(())
     }
-    /// Enable
+    /// Get value of 'Enable'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -186,7 +186,7 @@ impl ExampleMessage {
             _ => ExampleMessageEnable::_Other(self.enable_raw()),
         }
     }
-    /// Get raw value of Enable
+    /// Get raw value of 'Enable'
     ///
     /// - Start bit: 7
     /// - Signal size: 1 bits
@@ -199,9 +199,14 @@ impl ExampleMessage {
         let signal = self.raw.view_bits::<Msb0>()[0..1].load_be::<u8>();
         signal == 1
     }
-    /// Set value of Enable
+    /// Set value of 'Enable'
     #[inline(always)]
-    pub fn set_enable(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_enable(&mut self, value: ExampleMessageEnable) -> Result<(), CanError> {
+        self.set_enable_raw(bool::from(value))
+    }
+    /// Set raw value of 'Enable'
+    #[inline(always)]
+    pub fn set_enable_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
@@ -202,11 +202,7 @@ impl ExampleMessage {
     /// Set value of 'Enable'
     #[inline(always)]
     pub fn set_enable(&mut self, value: ExampleMessageEnable) -> Result<(), CanError> {
-        self.set_enable_raw(bool::from(value))
-    }
-    /// Set raw value of 'Enable'
-    #[inline(always)]
-    pub fn set_enable_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_fd.snap.rs
@@ -76,11 +76,11 @@ impl ExampleMessage {
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;
     pub const AVERAGE_RADIUS_MIN: f32 = 0_f32;
     pub const AVERAGE_RADIUS_MAX: f32 = 5_f32;
-    /// Construct new ExampleMessage from values
+    /// Construct new 'ExampleMessage' from values
     pub fn new(
         temperature: f32,
         average_radius: f32,
-        enable: bool,
+        enable: ExampleMessageEnable,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_temperature(temperature)?;
@@ -92,7 +92,7 @@ impl ExampleMessage {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Temperature
+    /// Get value of 'Temperature'
     ///
     /// - Min: 229.52
     /// - Max: 270.47
@@ -102,7 +102,7 @@ impl ExampleMessage {
     pub fn temperature(&self) -> f32 {
         self.temperature_raw()
     }
-    /// Get raw value of Temperature
+    /// Get raw value of 'Temperature'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -117,7 +117,7 @@ impl ExampleMessage {
         let offset = 250_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature
+    /// Set value of 'Temperature'
     #[inline(always)]
     pub fn set_temperature(&mut self, value: f32) -> Result<(), CanError> {
         if value < 229.52_f32 || 270.47_f32 < value {
@@ -132,7 +132,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Msb0>()[7..19].store_be(value);
         Ok(())
     }
-    /// AverageRadius
+    /// Get value of 'AverageRadius'
     ///
     /// - Min: 0
     /// - Max: 5
@@ -142,7 +142,7 @@ impl ExampleMessage {
     pub fn average_radius(&self) -> f32 {
         self.average_radius_raw()
     }
-    /// Get raw value of AverageRadius
+    /// Get raw value of 'AverageRadius'
     ///
     /// - Start bit: 6
     /// - Signal size: 6 bits
@@ -157,7 +157,7 @@ impl ExampleMessage {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AverageRadius
+    /// Set value of 'AverageRadius'
     #[inline(always)]
     pub fn set_average_radius(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 5_f32 < value {
@@ -171,7 +171,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Msb0>()[1..7].store_be(value);
         Ok(())
     }
-    /// Enable
+    /// Get value of 'Enable'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -186,7 +186,7 @@ impl ExampleMessage {
             _ => ExampleMessageEnable::_Other(self.enable_raw()),
         }
     }
-    /// Get raw value of Enable
+    /// Get raw value of 'Enable'
     ///
     /// - Start bit: 7
     /// - Signal size: 1 bits
@@ -199,9 +199,14 @@ impl ExampleMessage {
         let signal = self.raw.view_bits::<Msb0>()[0..1].load_be::<u8>();
         signal == 1
     }
-    /// Set value of Enable
+    /// Set value of 'Enable'
     #[inline(always)]
-    pub fn set_enable(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_enable(&mut self, value: ExampleMessageEnable) -> Result<(), CanError> {
+        self.set_enable_raw(bool::from(value))
+    }
+    /// Set raw value of 'Enable'
+    #[inline(always)]
+    pub fn set_enable_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
@@ -202,11 +202,7 @@ impl ExampleMessage {
     /// Set value of 'Enable'
     #[inline(always)]
     pub fn set_enable(&mut self, value: ExampleMessageEnable) -> Result<(), CanError> {
-        self.set_enable_raw(bool::from(value))
-    }
-    /// Set raw value of 'Enable'
-    #[inline(always)]
-    pub fn set_enable_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_use_round.snap.rs
@@ -76,11 +76,11 @@ impl ExampleMessage {
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;
     pub const AVERAGE_RADIUS_MIN: f32 = 0_f32;
     pub const AVERAGE_RADIUS_MAX: f32 = 5_f32;
-    /// Construct new ExampleMessage from values
+    /// Construct new 'ExampleMessage' from values
     pub fn new(
         temperature: f32,
         average_radius: f32,
-        enable: bool,
+        enable: ExampleMessageEnable,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_temperature(temperature)?;
@@ -92,7 +92,7 @@ impl ExampleMessage {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Temperature
+    /// Get value of 'Temperature'
     ///
     /// - Min: 229.52
     /// - Max: 270.47
@@ -102,7 +102,7 @@ impl ExampleMessage {
     pub fn temperature(&self) -> f32 {
         self.temperature_raw()
     }
-    /// Get raw value of Temperature
+    /// Get raw value of 'Temperature'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -117,7 +117,7 @@ impl ExampleMessage {
         let offset = 250_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature
+    /// Set value of 'Temperature'
     #[inline(always)]
     pub fn set_temperature(&mut self, value: f32) -> Result<(), CanError> {
         if value < 229.52_f32 || 270.47_f32 < value {
@@ -132,7 +132,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Msb0>()[7..19].store_be(value);
         Ok(())
     }
-    /// AverageRadius
+    /// Get value of 'AverageRadius'
     ///
     /// - Min: 0
     /// - Max: 5
@@ -142,7 +142,7 @@ impl ExampleMessage {
     pub fn average_radius(&self) -> f32 {
         self.average_radius_raw()
     }
-    /// Get raw value of AverageRadius
+    /// Get raw value of 'AverageRadius'
     ///
     /// - Start bit: 6
     /// - Signal size: 6 bits
@@ -157,7 +157,7 @@ impl ExampleMessage {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AverageRadius
+    /// Set value of 'AverageRadius'
     #[inline(always)]
     pub fn set_average_radius(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 5_f32 < value {
@@ -171,7 +171,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Msb0>()[1..7].store_be(value);
         Ok(())
     }
-    /// Enable
+    /// Get value of 'Enable'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -186,7 +186,7 @@ impl ExampleMessage {
             _ => ExampleMessageEnable::_Other(self.enable_raw()),
         }
     }
-    /// Get raw value of Enable
+    /// Get raw value of 'Enable'
     ///
     /// - Start bit: 7
     /// - Signal size: 1 bits
@@ -199,9 +199,14 @@ impl ExampleMessage {
         let signal = self.raw.view_bits::<Msb0>()[0..1].load_be::<u8>();
         signal == 1
     }
-    /// Set value of Enable
+    /// Set value of 'Enable'
     #[inline(always)]
-    pub fn set_enable(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_enable(&mut self, value: ExampleMessageEnable) -> Result<(), CanError> {
+        self.set_enable_raw(bool::from(value))
+    }
+    /// Set raw value of 'Enable'
+    #[inline(always)]
+    pub fn set_enable_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
@@ -208,11 +208,7 @@ impl ExampleMessage {
     /// Set value of 'Enable'
     #[inline(always)]
     pub fn set_enable(&mut self, value: ExampleMessageEnable) -> Result<(), CanError> {
-        self.set_enable_raw(bool::from(value))
-    }
-    /// Set raw value of 'Enable'
-    #[inline(always)]
-    pub fn set_enable_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
+++ b/tests-snapshots/dbc-cantools/motohawk_with_comments.snap.rs
@@ -76,11 +76,11 @@ impl ExampleMessage {
     pub const TEMPERATURE_MAX: f32 = 270.47_f32;
     pub const AVERAGE_RADIUS_MIN: f32 = 0_f32;
     pub const AVERAGE_RADIUS_MAX: f32 = 5_f32;
-    /// Construct new ExampleMessage from values
+    /// Construct new 'ExampleMessage' from values
     pub fn new(
         temperature: f32,
         average_radius: f32,
-        enable: bool,
+        enable: ExampleMessageEnable,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_temperature(temperature)?;
@@ -92,7 +92,7 @@ impl ExampleMessage {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Temperature
+    /// Get value of 'Temperature'
     ///
     /// Temperature with a really long and complicated comment that probably require many many lines in a decently wide terminal
     ///
@@ -104,7 +104,7 @@ impl ExampleMessage {
     pub fn temperature(&self) -> f32 {
         self.temperature_raw()
     }
-    /// Get raw value of Temperature
+    /// Get raw value of 'Temperature'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -119,7 +119,7 @@ impl ExampleMessage {
         let offset = 250_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature
+    /// Set value of 'Temperature'
     #[inline(always)]
     pub fn set_temperature(&mut self, value: f32) -> Result<(), CanError> {
         if value < 229.52_f32 || 270.47_f32 < value {
@@ -134,7 +134,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Msb0>()[7..19].store_be(value);
         Ok(())
     }
-    /// AverageRadius
+    /// Get value of 'AverageRadius'
     ///
     /// AverageRadius signal comment
     ///
@@ -146,7 +146,7 @@ impl ExampleMessage {
     pub fn average_radius(&self) -> f32 {
         self.average_radius_raw()
     }
-    /// Get raw value of AverageRadius
+    /// Get raw value of 'AverageRadius'
     ///
     /// - Start bit: 6
     /// - Signal size: 6 bits
@@ -161,7 +161,7 @@ impl ExampleMessage {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AverageRadius
+    /// Set value of 'AverageRadius'
     #[inline(always)]
     pub fn set_average_radius(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 5_f32 < value {
@@ -175,7 +175,7 @@ impl ExampleMessage {
         self.raw.view_bits_mut::<Msb0>()[1..7].store_be(value);
         Ok(())
     }
-    /// Enable
+    /// Get value of 'Enable'
     ///
     /// Enable signal comment
     ///
@@ -192,7 +192,7 @@ impl ExampleMessage {
             _ => ExampleMessageEnable::_Other(self.enable_raw()),
         }
     }
-    /// Get raw value of Enable
+    /// Get raw value of 'Enable'
     ///
     /// - Start bit: 7
     /// - Signal size: 1 bits
@@ -205,9 +205,14 @@ impl ExampleMessage {
         let signal = self.raw.view_bits::<Msb0>()[0..1].load_be::<u8>();
         signal == 1
     }
-    /// Set value of Enable
+    /// Set value of 'Enable'
     #[inline(always)]
-    pub fn set_enable(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_enable(&mut self, value: ExampleMessageEnable) -> Result<(), CanError> {
+        self.set_enable_raw(bool::from(value))
+    }
+    /// Set raw value of 'Enable'
+    #[inline(always)]
+    pub fn set_enable_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/msxii_system_can.snap.rs
+++ b/tests-snapshots/dbc-cantools/msxii_system_can.snap.rs
@@ -214,7 +214,7 @@ impl BatteryVt {
     pub const MODULE_VOLTAGE_00_MAX: u16 = 0_u16;
     pub const BATTERY_VT_INDEX_MIN: u16 = 0_u16;
     pub const BATTERY_VT_INDEX_MAX: u16 = 0_u16;
-    /// Construct new BATTERY_VT from values
+    /// Construct new 'BATTERY_VT' from values
     pub fn new(battery_vt_index: u16) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 6] };
         res.set_battery_vt_index(battery_vt_index)?;
@@ -224,7 +224,7 @@ impl BatteryVt {
     pub fn raw(&self) -> &[u8; 6] {
         &self.raw
     }
-    /// Get raw value of BATTERY_VT_INDEX
+    /// Get raw value of 'BATTERY_VT_INDEX'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -502,7 +502,7 @@ impl BatteryVt {
             }
         }
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     fn set_battery_vt_index(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -520,7 +520,7 @@ impl BatteryVt {
         self.raw.view_bits_mut::<Lsb0>()[0..16].store_le(value);
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m0(&mut self, value: BatteryVtBatteryVtIndexM0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -529,7 +529,7 @@ impl BatteryVt {
         self.set_battery_vt_index(0)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m1(&mut self, value: BatteryVtBatteryVtIndexM1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -538,7 +538,7 @@ impl BatteryVt {
         self.set_battery_vt_index(1)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m2(&mut self, value: BatteryVtBatteryVtIndexM2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -547,7 +547,7 @@ impl BatteryVt {
         self.set_battery_vt_index(2)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m3(&mut self, value: BatteryVtBatteryVtIndexM3) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -556,7 +556,7 @@ impl BatteryVt {
         self.set_battery_vt_index(3)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m4(&mut self, value: BatteryVtBatteryVtIndexM4) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -565,7 +565,7 @@ impl BatteryVt {
         self.set_battery_vt_index(4)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m5(&mut self, value: BatteryVtBatteryVtIndexM5) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -574,7 +574,7 @@ impl BatteryVt {
         self.set_battery_vt_index(5)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m6(&mut self, value: BatteryVtBatteryVtIndexM6) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -583,7 +583,7 @@ impl BatteryVt {
         self.set_battery_vt_index(6)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m7(&mut self, value: BatteryVtBatteryVtIndexM7) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -592,7 +592,7 @@ impl BatteryVt {
         self.set_battery_vt_index(7)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m8(&mut self, value: BatteryVtBatteryVtIndexM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -601,7 +601,7 @@ impl BatteryVt {
         self.set_battery_vt_index(8)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m9(&mut self, value: BatteryVtBatteryVtIndexM9) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -610,7 +610,7 @@ impl BatteryVt {
         self.set_battery_vt_index(9)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m10(
         &mut self,
@@ -622,7 +622,7 @@ impl BatteryVt {
         self.set_battery_vt_index(10)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m11(
         &mut self,
@@ -634,7 +634,7 @@ impl BatteryVt {
         self.set_battery_vt_index(11)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m12(
         &mut self,
@@ -646,7 +646,7 @@ impl BatteryVt {
         self.set_battery_vt_index(12)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m13(
         &mut self,
@@ -658,7 +658,7 @@ impl BatteryVt {
         self.set_battery_vt_index(13)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m14(
         &mut self,
@@ -670,7 +670,7 @@ impl BatteryVt {
         self.set_battery_vt_index(14)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m15(
         &mut self,
@@ -682,7 +682,7 @@ impl BatteryVt {
         self.set_battery_vt_index(15)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m16(
         &mut self,
@@ -694,7 +694,7 @@ impl BatteryVt {
         self.set_battery_vt_index(16)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m17(
         &mut self,
@@ -706,7 +706,7 @@ impl BatteryVt {
         self.set_battery_vt_index(17)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m18(
         &mut self,
@@ -718,7 +718,7 @@ impl BatteryVt {
         self.set_battery_vt_index(18)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m19(
         &mut self,
@@ -730,7 +730,7 @@ impl BatteryVt {
         self.set_battery_vt_index(19)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m20(
         &mut self,
@@ -742,7 +742,7 @@ impl BatteryVt {
         self.set_battery_vt_index(20)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m21(
         &mut self,
@@ -754,7 +754,7 @@ impl BatteryVt {
         self.set_battery_vt_index(21)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m22(
         &mut self,
@@ -766,7 +766,7 @@ impl BatteryVt {
         self.set_battery_vt_index(22)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m23(
         &mut self,
@@ -778,7 +778,7 @@ impl BatteryVt {
         self.set_battery_vt_index(23)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m24(
         &mut self,
@@ -790,7 +790,7 @@ impl BatteryVt {
         self.set_battery_vt_index(24)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m25(
         &mut self,
@@ -802,7 +802,7 @@ impl BatteryVt {
         self.set_battery_vt_index(25)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m26(
         &mut self,
@@ -814,7 +814,7 @@ impl BatteryVt {
         self.set_battery_vt_index(26)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m27(
         &mut self,
@@ -826,7 +826,7 @@ impl BatteryVt {
         self.set_battery_vt_index(27)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m28(
         &mut self,
@@ -838,7 +838,7 @@ impl BatteryVt {
         self.set_battery_vt_index(28)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m29(
         &mut self,
@@ -850,7 +850,7 @@ impl BatteryVt {
         self.set_battery_vt_index(29)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m30(
         &mut self,
@@ -862,7 +862,7 @@ impl BatteryVt {
         self.set_battery_vt_index(30)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m31(
         &mut self,
@@ -874,7 +874,7 @@ impl BatteryVt {
         self.set_battery_vt_index(31)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m32(
         &mut self,
@@ -886,7 +886,7 @@ impl BatteryVt {
         self.set_battery_vt_index(32)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m33(
         &mut self,
@@ -898,7 +898,7 @@ impl BatteryVt {
         self.set_battery_vt_index(33)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m34(
         &mut self,
@@ -910,7 +910,7 @@ impl BatteryVt {
         self.set_battery_vt_index(34)?;
         Ok(())
     }
-    /// Set value of BATTERY_VT_INDEX
+    /// Set value of 'BATTERY_VT_INDEX'
     #[inline(always)]
     pub fn set_m35(
         &mut self,
@@ -1035,7 +1035,7 @@ impl BatteryVtBatteryVtIndexM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_00
+    /// Get value of 'MODULE_TEMP_00'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1045,7 +1045,7 @@ impl BatteryVtBatteryVtIndexM0 {
     pub fn module_temp_00(&self) -> u16 {
         self.module_temp_00_raw()
     }
-    /// Get raw value of MODULE_TEMP_00
+    /// Get raw value of 'MODULE_TEMP_00'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1059,7 +1059,7 @@ impl BatteryVtBatteryVtIndexM0 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_00
+    /// Set value of 'MODULE_TEMP_00'
     #[inline(always)]
     pub fn set_module_temp_00(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1077,7 +1077,7 @@ impl BatteryVtBatteryVtIndexM0 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_00
+    /// Get value of 'MODULE_VOLTAGE_00'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1087,7 +1087,7 @@ impl BatteryVtBatteryVtIndexM0 {
     pub fn module_voltage_00(&self) -> u16 {
         self.module_voltage_00_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_00
+    /// Get raw value of 'MODULE_VOLTAGE_00'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1101,7 +1101,7 @@ impl BatteryVtBatteryVtIndexM0 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_00
+    /// Set value of 'MODULE_VOLTAGE_00'
     #[inline(always)]
     pub fn set_module_voltage_00(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1146,7 +1146,7 @@ impl BatteryVtBatteryVtIndexM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_01
+    /// Get value of 'MODULE_TEMP_01'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1156,7 +1156,7 @@ impl BatteryVtBatteryVtIndexM1 {
     pub fn module_temp_01(&self) -> u16 {
         self.module_temp_01_raw()
     }
-    /// Get raw value of MODULE_TEMP_01
+    /// Get raw value of 'MODULE_TEMP_01'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1170,7 +1170,7 @@ impl BatteryVtBatteryVtIndexM1 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_01
+    /// Set value of 'MODULE_TEMP_01'
     #[inline(always)]
     pub fn set_module_temp_01(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1188,7 +1188,7 @@ impl BatteryVtBatteryVtIndexM1 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_01
+    /// Get value of 'MODULE_VOLTAGE_01'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1198,7 +1198,7 @@ impl BatteryVtBatteryVtIndexM1 {
     pub fn module_voltage_01(&self) -> u16 {
         self.module_voltage_01_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_01
+    /// Get raw value of 'MODULE_VOLTAGE_01'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1212,7 +1212,7 @@ impl BatteryVtBatteryVtIndexM1 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_01
+    /// Set value of 'MODULE_VOLTAGE_01'
     #[inline(always)]
     pub fn set_module_voltage_01(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1257,7 +1257,7 @@ impl BatteryVtBatteryVtIndexM2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_02
+    /// Get value of 'MODULE_TEMP_02'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1267,7 +1267,7 @@ impl BatteryVtBatteryVtIndexM2 {
     pub fn module_temp_02(&self) -> u16 {
         self.module_temp_02_raw()
     }
-    /// Get raw value of MODULE_TEMP_02
+    /// Get raw value of 'MODULE_TEMP_02'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1281,7 +1281,7 @@ impl BatteryVtBatteryVtIndexM2 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_02
+    /// Set value of 'MODULE_TEMP_02'
     #[inline(always)]
     pub fn set_module_temp_02(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1299,7 +1299,7 @@ impl BatteryVtBatteryVtIndexM2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_02
+    /// Get value of 'MODULE_VOLTAGE_02'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1309,7 +1309,7 @@ impl BatteryVtBatteryVtIndexM2 {
     pub fn module_voltage_02(&self) -> u16 {
         self.module_voltage_02_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_02
+    /// Get raw value of 'MODULE_VOLTAGE_02'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1323,7 +1323,7 @@ impl BatteryVtBatteryVtIndexM2 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_02
+    /// Set value of 'MODULE_VOLTAGE_02'
     #[inline(always)]
     pub fn set_module_voltage_02(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1368,7 +1368,7 @@ impl BatteryVtBatteryVtIndexM3 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_03
+    /// Get value of 'MODULE_TEMP_03'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1378,7 +1378,7 @@ impl BatteryVtBatteryVtIndexM3 {
     pub fn module_temp_03(&self) -> u16 {
         self.module_temp_03_raw()
     }
-    /// Get raw value of MODULE_TEMP_03
+    /// Get raw value of 'MODULE_TEMP_03'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1392,7 +1392,7 @@ impl BatteryVtBatteryVtIndexM3 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_03
+    /// Set value of 'MODULE_TEMP_03'
     #[inline(always)]
     pub fn set_module_temp_03(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1410,7 +1410,7 @@ impl BatteryVtBatteryVtIndexM3 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_03
+    /// Get value of 'MODULE_VOLTAGE_03'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1420,7 +1420,7 @@ impl BatteryVtBatteryVtIndexM3 {
     pub fn module_voltage_03(&self) -> u16 {
         self.module_voltage_03_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_03
+    /// Get raw value of 'MODULE_VOLTAGE_03'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1434,7 +1434,7 @@ impl BatteryVtBatteryVtIndexM3 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_03
+    /// Set value of 'MODULE_VOLTAGE_03'
     #[inline(always)]
     pub fn set_module_voltage_03(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1479,7 +1479,7 @@ impl BatteryVtBatteryVtIndexM4 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_04
+    /// Get value of 'MODULE_TEMP_04'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1489,7 +1489,7 @@ impl BatteryVtBatteryVtIndexM4 {
     pub fn module_temp_04(&self) -> u16 {
         self.module_temp_04_raw()
     }
-    /// Get raw value of MODULE_TEMP_04
+    /// Get raw value of 'MODULE_TEMP_04'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1503,7 +1503,7 @@ impl BatteryVtBatteryVtIndexM4 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_04
+    /// Set value of 'MODULE_TEMP_04'
     #[inline(always)]
     pub fn set_module_temp_04(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1521,7 +1521,7 @@ impl BatteryVtBatteryVtIndexM4 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_04
+    /// Get value of 'MODULE_VOLTAGE_04'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1531,7 +1531,7 @@ impl BatteryVtBatteryVtIndexM4 {
     pub fn module_voltage_04(&self) -> u16 {
         self.module_voltage_04_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_04
+    /// Get raw value of 'MODULE_VOLTAGE_04'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1545,7 +1545,7 @@ impl BatteryVtBatteryVtIndexM4 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_04
+    /// Set value of 'MODULE_VOLTAGE_04'
     #[inline(always)]
     pub fn set_module_voltage_04(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1590,7 +1590,7 @@ impl BatteryVtBatteryVtIndexM5 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_05
+    /// Get value of 'MODULE_TEMP_05'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1600,7 +1600,7 @@ impl BatteryVtBatteryVtIndexM5 {
     pub fn module_temp_05(&self) -> u16 {
         self.module_temp_05_raw()
     }
-    /// Get raw value of MODULE_TEMP_05
+    /// Get raw value of 'MODULE_TEMP_05'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1614,7 +1614,7 @@ impl BatteryVtBatteryVtIndexM5 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_05
+    /// Set value of 'MODULE_TEMP_05'
     #[inline(always)]
     pub fn set_module_temp_05(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1632,7 +1632,7 @@ impl BatteryVtBatteryVtIndexM5 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_05
+    /// Get value of 'MODULE_VOLTAGE_05'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1642,7 +1642,7 @@ impl BatteryVtBatteryVtIndexM5 {
     pub fn module_voltage_05(&self) -> u16 {
         self.module_voltage_05_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_05
+    /// Get raw value of 'MODULE_VOLTAGE_05'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1656,7 +1656,7 @@ impl BatteryVtBatteryVtIndexM5 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_05
+    /// Set value of 'MODULE_VOLTAGE_05'
     #[inline(always)]
     pub fn set_module_voltage_05(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1701,7 +1701,7 @@ impl BatteryVtBatteryVtIndexM6 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_06
+    /// Get value of 'MODULE_TEMP_06'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1711,7 +1711,7 @@ impl BatteryVtBatteryVtIndexM6 {
     pub fn module_temp_06(&self) -> u16 {
         self.module_temp_06_raw()
     }
-    /// Get raw value of MODULE_TEMP_06
+    /// Get raw value of 'MODULE_TEMP_06'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1725,7 +1725,7 @@ impl BatteryVtBatteryVtIndexM6 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_06
+    /// Set value of 'MODULE_TEMP_06'
     #[inline(always)]
     pub fn set_module_temp_06(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1743,7 +1743,7 @@ impl BatteryVtBatteryVtIndexM6 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_06
+    /// Get value of 'MODULE_VOLTAGE_06'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1753,7 +1753,7 @@ impl BatteryVtBatteryVtIndexM6 {
     pub fn module_voltage_06(&self) -> u16 {
         self.module_voltage_06_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_06
+    /// Get raw value of 'MODULE_VOLTAGE_06'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1767,7 +1767,7 @@ impl BatteryVtBatteryVtIndexM6 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_06
+    /// Set value of 'MODULE_VOLTAGE_06'
     #[inline(always)]
     pub fn set_module_voltage_06(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1812,7 +1812,7 @@ impl BatteryVtBatteryVtIndexM7 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_07
+    /// Get value of 'MODULE_TEMP_07'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1822,7 +1822,7 @@ impl BatteryVtBatteryVtIndexM7 {
     pub fn module_temp_07(&self) -> u16 {
         self.module_temp_07_raw()
     }
-    /// Get raw value of MODULE_TEMP_07
+    /// Get raw value of 'MODULE_TEMP_07'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1836,7 +1836,7 @@ impl BatteryVtBatteryVtIndexM7 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_07
+    /// Set value of 'MODULE_TEMP_07'
     #[inline(always)]
     pub fn set_module_temp_07(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1854,7 +1854,7 @@ impl BatteryVtBatteryVtIndexM7 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_07
+    /// Get value of 'MODULE_VOLTAGE_07'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1864,7 +1864,7 @@ impl BatteryVtBatteryVtIndexM7 {
     pub fn module_voltage_07(&self) -> u16 {
         self.module_voltage_07_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_07
+    /// Get raw value of 'MODULE_VOLTAGE_07'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1878,7 +1878,7 @@ impl BatteryVtBatteryVtIndexM7 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_07
+    /// Set value of 'MODULE_VOLTAGE_07'
     #[inline(always)]
     pub fn set_module_voltage_07(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1923,7 +1923,7 @@ impl BatteryVtBatteryVtIndexM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_08
+    /// Get value of 'MODULE_TEMP_08'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1933,7 +1933,7 @@ impl BatteryVtBatteryVtIndexM8 {
     pub fn module_temp_08(&self) -> u16 {
         self.module_temp_08_raw()
     }
-    /// Get raw value of MODULE_TEMP_08
+    /// Get raw value of 'MODULE_TEMP_08'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -1947,7 +1947,7 @@ impl BatteryVtBatteryVtIndexM8 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_08
+    /// Set value of 'MODULE_TEMP_08'
     #[inline(always)]
     pub fn set_module_temp_08(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1965,7 +1965,7 @@ impl BatteryVtBatteryVtIndexM8 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_08
+    /// Get value of 'MODULE_VOLTAGE_08'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1975,7 +1975,7 @@ impl BatteryVtBatteryVtIndexM8 {
     pub fn module_voltage_08(&self) -> u16 {
         self.module_voltage_08_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_08
+    /// Get raw value of 'MODULE_VOLTAGE_08'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1989,7 +1989,7 @@ impl BatteryVtBatteryVtIndexM8 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_08
+    /// Set value of 'MODULE_VOLTAGE_08'
     #[inline(always)]
     pub fn set_module_voltage_08(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2034,7 +2034,7 @@ impl BatteryVtBatteryVtIndexM9 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_09
+    /// Get value of 'MODULE_TEMP_09'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2044,7 +2044,7 @@ impl BatteryVtBatteryVtIndexM9 {
     pub fn module_temp_09(&self) -> u16 {
         self.module_temp_09_raw()
     }
-    /// Get raw value of MODULE_TEMP_09
+    /// Get raw value of 'MODULE_TEMP_09'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2058,7 +2058,7 @@ impl BatteryVtBatteryVtIndexM9 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_09
+    /// Set value of 'MODULE_TEMP_09'
     #[inline(always)]
     pub fn set_module_temp_09(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2076,7 +2076,7 @@ impl BatteryVtBatteryVtIndexM9 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_09
+    /// Get value of 'MODULE_VOLTAGE_09'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2086,7 +2086,7 @@ impl BatteryVtBatteryVtIndexM9 {
     pub fn module_voltage_09(&self) -> u16 {
         self.module_voltage_09_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_09
+    /// Get raw value of 'MODULE_VOLTAGE_09'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2100,7 +2100,7 @@ impl BatteryVtBatteryVtIndexM9 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_09
+    /// Set value of 'MODULE_VOLTAGE_09'
     #[inline(always)]
     pub fn set_module_voltage_09(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2145,7 +2145,7 @@ impl BatteryVtBatteryVtIndexM10 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_10
+    /// Get value of 'MODULE_TEMP_10'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2155,7 +2155,7 @@ impl BatteryVtBatteryVtIndexM10 {
     pub fn module_temp_10(&self) -> u16 {
         self.module_temp_10_raw()
     }
-    /// Get raw value of MODULE_TEMP_10
+    /// Get raw value of 'MODULE_TEMP_10'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2169,7 +2169,7 @@ impl BatteryVtBatteryVtIndexM10 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_10
+    /// Set value of 'MODULE_TEMP_10'
     #[inline(always)]
     pub fn set_module_temp_10(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2187,7 +2187,7 @@ impl BatteryVtBatteryVtIndexM10 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_10
+    /// Get value of 'MODULE_VOLTAGE_10'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2197,7 +2197,7 @@ impl BatteryVtBatteryVtIndexM10 {
     pub fn module_voltage_10(&self) -> u16 {
         self.module_voltage_10_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_10
+    /// Get raw value of 'MODULE_VOLTAGE_10'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2211,7 +2211,7 @@ impl BatteryVtBatteryVtIndexM10 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_10
+    /// Set value of 'MODULE_VOLTAGE_10'
     #[inline(always)]
     pub fn set_module_voltage_10(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2256,7 +2256,7 @@ impl BatteryVtBatteryVtIndexM11 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_11
+    /// Get value of 'MODULE_TEMP_11'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2266,7 +2266,7 @@ impl BatteryVtBatteryVtIndexM11 {
     pub fn module_temp_11(&self) -> u16 {
         self.module_temp_11_raw()
     }
-    /// Get raw value of MODULE_TEMP_11
+    /// Get raw value of 'MODULE_TEMP_11'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2280,7 +2280,7 @@ impl BatteryVtBatteryVtIndexM11 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_11
+    /// Set value of 'MODULE_TEMP_11'
     #[inline(always)]
     pub fn set_module_temp_11(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2298,7 +2298,7 @@ impl BatteryVtBatteryVtIndexM11 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_11
+    /// Get value of 'MODULE_VOLTAGE_11'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2308,7 +2308,7 @@ impl BatteryVtBatteryVtIndexM11 {
     pub fn module_voltage_11(&self) -> u16 {
         self.module_voltage_11_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_11
+    /// Get raw value of 'MODULE_VOLTAGE_11'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2322,7 +2322,7 @@ impl BatteryVtBatteryVtIndexM11 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_11
+    /// Set value of 'MODULE_VOLTAGE_11'
     #[inline(always)]
     pub fn set_module_voltage_11(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2367,7 +2367,7 @@ impl BatteryVtBatteryVtIndexM12 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_12
+    /// Get value of 'MODULE_TEMP_12'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2377,7 +2377,7 @@ impl BatteryVtBatteryVtIndexM12 {
     pub fn module_temp_12(&self) -> u16 {
         self.module_temp_12_raw()
     }
-    /// Get raw value of MODULE_TEMP_12
+    /// Get raw value of 'MODULE_TEMP_12'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2391,7 +2391,7 @@ impl BatteryVtBatteryVtIndexM12 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_12
+    /// Set value of 'MODULE_TEMP_12'
     #[inline(always)]
     pub fn set_module_temp_12(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2409,7 +2409,7 @@ impl BatteryVtBatteryVtIndexM12 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_12
+    /// Get value of 'MODULE_VOLTAGE_12'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2419,7 +2419,7 @@ impl BatteryVtBatteryVtIndexM12 {
     pub fn module_voltage_12(&self) -> u16 {
         self.module_voltage_12_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_12
+    /// Get raw value of 'MODULE_VOLTAGE_12'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2433,7 +2433,7 @@ impl BatteryVtBatteryVtIndexM12 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_12
+    /// Set value of 'MODULE_VOLTAGE_12'
     #[inline(always)]
     pub fn set_module_voltage_12(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2478,7 +2478,7 @@ impl BatteryVtBatteryVtIndexM13 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_13
+    /// Get value of 'MODULE_TEMP_13'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2488,7 +2488,7 @@ impl BatteryVtBatteryVtIndexM13 {
     pub fn module_temp_13(&self) -> u16 {
         self.module_temp_13_raw()
     }
-    /// Get raw value of MODULE_TEMP_13
+    /// Get raw value of 'MODULE_TEMP_13'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2502,7 +2502,7 @@ impl BatteryVtBatteryVtIndexM13 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_13
+    /// Set value of 'MODULE_TEMP_13'
     #[inline(always)]
     pub fn set_module_temp_13(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2520,7 +2520,7 @@ impl BatteryVtBatteryVtIndexM13 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_13
+    /// Get value of 'MODULE_VOLTAGE_13'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2530,7 +2530,7 @@ impl BatteryVtBatteryVtIndexM13 {
     pub fn module_voltage_13(&self) -> u16 {
         self.module_voltage_13_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_13
+    /// Get raw value of 'MODULE_VOLTAGE_13'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2544,7 +2544,7 @@ impl BatteryVtBatteryVtIndexM13 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_13
+    /// Set value of 'MODULE_VOLTAGE_13'
     #[inline(always)]
     pub fn set_module_voltage_13(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2589,7 +2589,7 @@ impl BatteryVtBatteryVtIndexM14 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_14
+    /// Get value of 'MODULE_TEMP_14'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2599,7 +2599,7 @@ impl BatteryVtBatteryVtIndexM14 {
     pub fn module_temp_14(&self) -> u16 {
         self.module_temp_14_raw()
     }
-    /// Get raw value of MODULE_TEMP_14
+    /// Get raw value of 'MODULE_TEMP_14'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2613,7 +2613,7 @@ impl BatteryVtBatteryVtIndexM14 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_14
+    /// Set value of 'MODULE_TEMP_14'
     #[inline(always)]
     pub fn set_module_temp_14(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2631,7 +2631,7 @@ impl BatteryVtBatteryVtIndexM14 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_14
+    /// Get value of 'MODULE_VOLTAGE_14'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2641,7 +2641,7 @@ impl BatteryVtBatteryVtIndexM14 {
     pub fn module_voltage_14(&self) -> u16 {
         self.module_voltage_14_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_14
+    /// Get raw value of 'MODULE_VOLTAGE_14'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2655,7 +2655,7 @@ impl BatteryVtBatteryVtIndexM14 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_14
+    /// Set value of 'MODULE_VOLTAGE_14'
     #[inline(always)]
     pub fn set_module_voltage_14(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2700,7 +2700,7 @@ impl BatteryVtBatteryVtIndexM15 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_15
+    /// Get value of 'MODULE_TEMP_15'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2710,7 +2710,7 @@ impl BatteryVtBatteryVtIndexM15 {
     pub fn module_temp_15(&self) -> u16 {
         self.module_temp_15_raw()
     }
-    /// Get raw value of MODULE_TEMP_15
+    /// Get raw value of 'MODULE_TEMP_15'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2724,7 +2724,7 @@ impl BatteryVtBatteryVtIndexM15 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_15
+    /// Set value of 'MODULE_TEMP_15'
     #[inline(always)]
     pub fn set_module_temp_15(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2742,7 +2742,7 @@ impl BatteryVtBatteryVtIndexM15 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_15
+    /// Get value of 'MODULE_VOLTAGE_15'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2752,7 +2752,7 @@ impl BatteryVtBatteryVtIndexM15 {
     pub fn module_voltage_15(&self) -> u16 {
         self.module_voltage_15_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_15
+    /// Get raw value of 'MODULE_VOLTAGE_15'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2766,7 +2766,7 @@ impl BatteryVtBatteryVtIndexM15 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_15
+    /// Set value of 'MODULE_VOLTAGE_15'
     #[inline(always)]
     pub fn set_module_voltage_15(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2811,7 +2811,7 @@ impl BatteryVtBatteryVtIndexM16 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_16
+    /// Get value of 'MODULE_TEMP_16'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2821,7 +2821,7 @@ impl BatteryVtBatteryVtIndexM16 {
     pub fn module_temp_16(&self) -> u16 {
         self.module_temp_16_raw()
     }
-    /// Get raw value of MODULE_TEMP_16
+    /// Get raw value of 'MODULE_TEMP_16'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2835,7 +2835,7 @@ impl BatteryVtBatteryVtIndexM16 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_16
+    /// Set value of 'MODULE_TEMP_16'
     #[inline(always)]
     pub fn set_module_temp_16(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2853,7 +2853,7 @@ impl BatteryVtBatteryVtIndexM16 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_16
+    /// Get value of 'MODULE_VOLTAGE_16'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2863,7 +2863,7 @@ impl BatteryVtBatteryVtIndexM16 {
     pub fn module_voltage_16(&self) -> u16 {
         self.module_voltage_16_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_16
+    /// Get raw value of 'MODULE_VOLTAGE_16'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2877,7 +2877,7 @@ impl BatteryVtBatteryVtIndexM16 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_16
+    /// Set value of 'MODULE_VOLTAGE_16'
     #[inline(always)]
     pub fn set_module_voltage_16(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2922,7 +2922,7 @@ impl BatteryVtBatteryVtIndexM17 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_17
+    /// Get value of 'MODULE_TEMP_17'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2932,7 +2932,7 @@ impl BatteryVtBatteryVtIndexM17 {
     pub fn module_temp_17(&self) -> u16 {
         self.module_temp_17_raw()
     }
-    /// Get raw value of MODULE_TEMP_17
+    /// Get raw value of 'MODULE_TEMP_17'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2946,7 +2946,7 @@ impl BatteryVtBatteryVtIndexM17 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_17
+    /// Set value of 'MODULE_TEMP_17'
     #[inline(always)]
     pub fn set_module_temp_17(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -2964,7 +2964,7 @@ impl BatteryVtBatteryVtIndexM17 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_17
+    /// Get value of 'MODULE_VOLTAGE_17'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2974,7 +2974,7 @@ impl BatteryVtBatteryVtIndexM17 {
     pub fn module_voltage_17(&self) -> u16 {
         self.module_voltage_17_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_17
+    /// Get raw value of 'MODULE_VOLTAGE_17'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2988,7 +2988,7 @@ impl BatteryVtBatteryVtIndexM17 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_17
+    /// Set value of 'MODULE_VOLTAGE_17'
     #[inline(always)]
     pub fn set_module_voltage_17(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3033,7 +3033,7 @@ impl BatteryVtBatteryVtIndexM18 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_18
+    /// Get value of 'MODULE_TEMP_18'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3043,7 +3043,7 @@ impl BatteryVtBatteryVtIndexM18 {
     pub fn module_temp_18(&self) -> u16 {
         self.module_temp_18_raw()
     }
-    /// Get raw value of MODULE_TEMP_18
+    /// Get raw value of 'MODULE_TEMP_18'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3057,7 +3057,7 @@ impl BatteryVtBatteryVtIndexM18 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_18
+    /// Set value of 'MODULE_TEMP_18'
     #[inline(always)]
     pub fn set_module_temp_18(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3075,7 +3075,7 @@ impl BatteryVtBatteryVtIndexM18 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_18
+    /// Get value of 'MODULE_VOLTAGE_18'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3085,7 +3085,7 @@ impl BatteryVtBatteryVtIndexM18 {
     pub fn module_voltage_18(&self) -> u16 {
         self.module_voltage_18_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_18
+    /// Get raw value of 'MODULE_VOLTAGE_18'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3099,7 +3099,7 @@ impl BatteryVtBatteryVtIndexM18 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_18
+    /// Set value of 'MODULE_VOLTAGE_18'
     #[inline(always)]
     pub fn set_module_voltage_18(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3144,7 +3144,7 @@ impl BatteryVtBatteryVtIndexM19 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_19
+    /// Get value of 'MODULE_TEMP_19'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3154,7 +3154,7 @@ impl BatteryVtBatteryVtIndexM19 {
     pub fn module_temp_19(&self) -> u16 {
         self.module_temp_19_raw()
     }
-    /// Get raw value of MODULE_TEMP_19
+    /// Get raw value of 'MODULE_TEMP_19'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3168,7 +3168,7 @@ impl BatteryVtBatteryVtIndexM19 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_19
+    /// Set value of 'MODULE_TEMP_19'
     #[inline(always)]
     pub fn set_module_temp_19(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3186,7 +3186,7 @@ impl BatteryVtBatteryVtIndexM19 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_19
+    /// Get value of 'MODULE_VOLTAGE_19'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3196,7 +3196,7 @@ impl BatteryVtBatteryVtIndexM19 {
     pub fn module_voltage_19(&self) -> u16 {
         self.module_voltage_19_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_19
+    /// Get raw value of 'MODULE_VOLTAGE_19'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3210,7 +3210,7 @@ impl BatteryVtBatteryVtIndexM19 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_19
+    /// Set value of 'MODULE_VOLTAGE_19'
     #[inline(always)]
     pub fn set_module_voltage_19(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3255,7 +3255,7 @@ impl BatteryVtBatteryVtIndexM20 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_20
+    /// Get value of 'MODULE_TEMP_20'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3265,7 +3265,7 @@ impl BatteryVtBatteryVtIndexM20 {
     pub fn module_temp_20(&self) -> u16 {
         self.module_temp_20_raw()
     }
-    /// Get raw value of MODULE_TEMP_20
+    /// Get raw value of 'MODULE_TEMP_20'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3279,7 +3279,7 @@ impl BatteryVtBatteryVtIndexM20 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_20
+    /// Set value of 'MODULE_TEMP_20'
     #[inline(always)]
     pub fn set_module_temp_20(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3297,7 +3297,7 @@ impl BatteryVtBatteryVtIndexM20 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_20
+    /// Get value of 'MODULE_VOLTAGE_20'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3307,7 +3307,7 @@ impl BatteryVtBatteryVtIndexM20 {
     pub fn module_voltage_20(&self) -> u16 {
         self.module_voltage_20_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_20
+    /// Get raw value of 'MODULE_VOLTAGE_20'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3321,7 +3321,7 @@ impl BatteryVtBatteryVtIndexM20 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_20
+    /// Set value of 'MODULE_VOLTAGE_20'
     #[inline(always)]
     pub fn set_module_voltage_20(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3366,7 +3366,7 @@ impl BatteryVtBatteryVtIndexM21 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_21
+    /// Get value of 'MODULE_TEMP_21'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3376,7 +3376,7 @@ impl BatteryVtBatteryVtIndexM21 {
     pub fn module_temp_21(&self) -> u16 {
         self.module_temp_21_raw()
     }
-    /// Get raw value of MODULE_TEMP_21
+    /// Get raw value of 'MODULE_TEMP_21'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3390,7 +3390,7 @@ impl BatteryVtBatteryVtIndexM21 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_21
+    /// Set value of 'MODULE_TEMP_21'
     #[inline(always)]
     pub fn set_module_temp_21(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3408,7 +3408,7 @@ impl BatteryVtBatteryVtIndexM21 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_21
+    /// Get value of 'MODULE_VOLTAGE_21'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3418,7 +3418,7 @@ impl BatteryVtBatteryVtIndexM21 {
     pub fn module_voltage_21(&self) -> u16 {
         self.module_voltage_21_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_21
+    /// Get raw value of 'MODULE_VOLTAGE_21'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3432,7 +3432,7 @@ impl BatteryVtBatteryVtIndexM21 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_21
+    /// Set value of 'MODULE_VOLTAGE_21'
     #[inline(always)]
     pub fn set_module_voltage_21(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3477,7 +3477,7 @@ impl BatteryVtBatteryVtIndexM22 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_22
+    /// Get value of 'MODULE_TEMP_22'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3487,7 +3487,7 @@ impl BatteryVtBatteryVtIndexM22 {
     pub fn module_temp_22(&self) -> u16 {
         self.module_temp_22_raw()
     }
-    /// Get raw value of MODULE_TEMP_22
+    /// Get raw value of 'MODULE_TEMP_22'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3501,7 +3501,7 @@ impl BatteryVtBatteryVtIndexM22 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_22
+    /// Set value of 'MODULE_TEMP_22'
     #[inline(always)]
     pub fn set_module_temp_22(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3519,7 +3519,7 @@ impl BatteryVtBatteryVtIndexM22 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_22
+    /// Get value of 'MODULE_VOLTAGE_22'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3529,7 +3529,7 @@ impl BatteryVtBatteryVtIndexM22 {
     pub fn module_voltage_22(&self) -> u16 {
         self.module_voltage_22_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_22
+    /// Get raw value of 'MODULE_VOLTAGE_22'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3543,7 +3543,7 @@ impl BatteryVtBatteryVtIndexM22 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_22
+    /// Set value of 'MODULE_VOLTAGE_22'
     #[inline(always)]
     pub fn set_module_voltage_22(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3588,7 +3588,7 @@ impl BatteryVtBatteryVtIndexM23 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_23
+    /// Get value of 'MODULE_TEMP_23'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3598,7 +3598,7 @@ impl BatteryVtBatteryVtIndexM23 {
     pub fn module_temp_23(&self) -> u16 {
         self.module_temp_23_raw()
     }
-    /// Get raw value of MODULE_TEMP_23
+    /// Get raw value of 'MODULE_TEMP_23'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3612,7 +3612,7 @@ impl BatteryVtBatteryVtIndexM23 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_23
+    /// Set value of 'MODULE_TEMP_23'
     #[inline(always)]
     pub fn set_module_temp_23(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3630,7 +3630,7 @@ impl BatteryVtBatteryVtIndexM23 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_23
+    /// Get value of 'MODULE_VOLTAGE_23'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3640,7 +3640,7 @@ impl BatteryVtBatteryVtIndexM23 {
     pub fn module_voltage_23(&self) -> u16 {
         self.module_voltage_23_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_23
+    /// Get raw value of 'MODULE_VOLTAGE_23'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3654,7 +3654,7 @@ impl BatteryVtBatteryVtIndexM23 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_23
+    /// Set value of 'MODULE_VOLTAGE_23'
     #[inline(always)]
     pub fn set_module_voltage_23(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3699,7 +3699,7 @@ impl BatteryVtBatteryVtIndexM24 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_24
+    /// Get value of 'MODULE_TEMP_24'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3709,7 +3709,7 @@ impl BatteryVtBatteryVtIndexM24 {
     pub fn module_temp_24(&self) -> u16 {
         self.module_temp_24_raw()
     }
-    /// Get raw value of MODULE_TEMP_24
+    /// Get raw value of 'MODULE_TEMP_24'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3723,7 +3723,7 @@ impl BatteryVtBatteryVtIndexM24 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_24
+    /// Set value of 'MODULE_TEMP_24'
     #[inline(always)]
     pub fn set_module_temp_24(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3741,7 +3741,7 @@ impl BatteryVtBatteryVtIndexM24 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_24
+    /// Get value of 'MODULE_VOLTAGE_24'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3751,7 +3751,7 @@ impl BatteryVtBatteryVtIndexM24 {
     pub fn module_voltage_24(&self) -> u16 {
         self.module_voltage_24_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_24
+    /// Get raw value of 'MODULE_VOLTAGE_24'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3765,7 +3765,7 @@ impl BatteryVtBatteryVtIndexM24 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_24
+    /// Set value of 'MODULE_VOLTAGE_24'
     #[inline(always)]
     pub fn set_module_voltage_24(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3810,7 +3810,7 @@ impl BatteryVtBatteryVtIndexM25 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_25
+    /// Get value of 'MODULE_TEMP_25'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3820,7 +3820,7 @@ impl BatteryVtBatteryVtIndexM25 {
     pub fn module_temp_25(&self) -> u16 {
         self.module_temp_25_raw()
     }
-    /// Get raw value of MODULE_TEMP_25
+    /// Get raw value of 'MODULE_TEMP_25'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3834,7 +3834,7 @@ impl BatteryVtBatteryVtIndexM25 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_25
+    /// Set value of 'MODULE_TEMP_25'
     #[inline(always)]
     pub fn set_module_temp_25(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3852,7 +3852,7 @@ impl BatteryVtBatteryVtIndexM25 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_25
+    /// Get value of 'MODULE_VOLTAGE_25'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3862,7 +3862,7 @@ impl BatteryVtBatteryVtIndexM25 {
     pub fn module_voltage_25(&self) -> u16 {
         self.module_voltage_25_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_25
+    /// Get raw value of 'MODULE_VOLTAGE_25'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3876,7 +3876,7 @@ impl BatteryVtBatteryVtIndexM25 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_25
+    /// Set value of 'MODULE_VOLTAGE_25'
     #[inline(always)]
     pub fn set_module_voltage_25(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3921,7 +3921,7 @@ impl BatteryVtBatteryVtIndexM26 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_26
+    /// Get value of 'MODULE_TEMP_26'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3931,7 +3931,7 @@ impl BatteryVtBatteryVtIndexM26 {
     pub fn module_temp_26(&self) -> u16 {
         self.module_temp_26_raw()
     }
-    /// Get raw value of MODULE_TEMP_26
+    /// Get raw value of 'MODULE_TEMP_26'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3945,7 +3945,7 @@ impl BatteryVtBatteryVtIndexM26 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_26
+    /// Set value of 'MODULE_TEMP_26'
     #[inline(always)]
     pub fn set_module_temp_26(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -3963,7 +3963,7 @@ impl BatteryVtBatteryVtIndexM26 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_26
+    /// Get value of 'MODULE_VOLTAGE_26'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3973,7 +3973,7 @@ impl BatteryVtBatteryVtIndexM26 {
     pub fn module_voltage_26(&self) -> u16 {
         self.module_voltage_26_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_26
+    /// Get raw value of 'MODULE_VOLTAGE_26'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3987,7 +3987,7 @@ impl BatteryVtBatteryVtIndexM26 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_26
+    /// Set value of 'MODULE_VOLTAGE_26'
     #[inline(always)]
     pub fn set_module_voltage_26(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4032,7 +4032,7 @@ impl BatteryVtBatteryVtIndexM27 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_27
+    /// Get value of 'MODULE_TEMP_27'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4042,7 +4042,7 @@ impl BatteryVtBatteryVtIndexM27 {
     pub fn module_temp_27(&self) -> u16 {
         self.module_temp_27_raw()
     }
-    /// Get raw value of MODULE_TEMP_27
+    /// Get raw value of 'MODULE_TEMP_27'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4056,7 +4056,7 @@ impl BatteryVtBatteryVtIndexM27 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_27
+    /// Set value of 'MODULE_TEMP_27'
     #[inline(always)]
     pub fn set_module_temp_27(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4074,7 +4074,7 @@ impl BatteryVtBatteryVtIndexM27 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_27
+    /// Get value of 'MODULE_VOLTAGE_27'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4084,7 +4084,7 @@ impl BatteryVtBatteryVtIndexM27 {
     pub fn module_voltage_27(&self) -> u16 {
         self.module_voltage_27_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_27
+    /// Get raw value of 'MODULE_VOLTAGE_27'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4098,7 +4098,7 @@ impl BatteryVtBatteryVtIndexM27 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_27
+    /// Set value of 'MODULE_VOLTAGE_27'
     #[inline(always)]
     pub fn set_module_voltage_27(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4143,7 +4143,7 @@ impl BatteryVtBatteryVtIndexM28 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_28
+    /// Get value of 'MODULE_TEMP_28'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4153,7 +4153,7 @@ impl BatteryVtBatteryVtIndexM28 {
     pub fn module_temp_28(&self) -> u16 {
         self.module_temp_28_raw()
     }
-    /// Get raw value of MODULE_TEMP_28
+    /// Get raw value of 'MODULE_TEMP_28'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4167,7 +4167,7 @@ impl BatteryVtBatteryVtIndexM28 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_28
+    /// Set value of 'MODULE_TEMP_28'
     #[inline(always)]
     pub fn set_module_temp_28(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4185,7 +4185,7 @@ impl BatteryVtBatteryVtIndexM28 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_28
+    /// Get value of 'MODULE_VOLTAGE_28'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4195,7 +4195,7 @@ impl BatteryVtBatteryVtIndexM28 {
     pub fn module_voltage_28(&self) -> u16 {
         self.module_voltage_28_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_28
+    /// Get raw value of 'MODULE_VOLTAGE_28'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4209,7 +4209,7 @@ impl BatteryVtBatteryVtIndexM28 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_28
+    /// Set value of 'MODULE_VOLTAGE_28'
     #[inline(always)]
     pub fn set_module_voltage_28(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4254,7 +4254,7 @@ impl BatteryVtBatteryVtIndexM29 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_29
+    /// Get value of 'MODULE_TEMP_29'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4264,7 +4264,7 @@ impl BatteryVtBatteryVtIndexM29 {
     pub fn module_temp_29(&self) -> u16 {
         self.module_temp_29_raw()
     }
-    /// Get raw value of MODULE_TEMP_29
+    /// Get raw value of 'MODULE_TEMP_29'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4278,7 +4278,7 @@ impl BatteryVtBatteryVtIndexM29 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_29
+    /// Set value of 'MODULE_TEMP_29'
     #[inline(always)]
     pub fn set_module_temp_29(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4296,7 +4296,7 @@ impl BatteryVtBatteryVtIndexM29 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_29
+    /// Get value of 'MODULE_VOLTAGE_29'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4306,7 +4306,7 @@ impl BatteryVtBatteryVtIndexM29 {
     pub fn module_voltage_29(&self) -> u16 {
         self.module_voltage_29_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_29
+    /// Get raw value of 'MODULE_VOLTAGE_29'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4320,7 +4320,7 @@ impl BatteryVtBatteryVtIndexM29 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_29
+    /// Set value of 'MODULE_VOLTAGE_29'
     #[inline(always)]
     pub fn set_module_voltage_29(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4365,7 +4365,7 @@ impl BatteryVtBatteryVtIndexM30 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_30
+    /// Get value of 'MODULE_TEMP_30'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4375,7 +4375,7 @@ impl BatteryVtBatteryVtIndexM30 {
     pub fn module_temp_30(&self) -> u16 {
         self.module_temp_30_raw()
     }
-    /// Get raw value of MODULE_TEMP_30
+    /// Get raw value of 'MODULE_TEMP_30'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4389,7 +4389,7 @@ impl BatteryVtBatteryVtIndexM30 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_30
+    /// Set value of 'MODULE_TEMP_30'
     #[inline(always)]
     pub fn set_module_temp_30(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4407,7 +4407,7 @@ impl BatteryVtBatteryVtIndexM30 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_30
+    /// Get value of 'MODULE_VOLTAGE_30'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4417,7 +4417,7 @@ impl BatteryVtBatteryVtIndexM30 {
     pub fn module_voltage_30(&self) -> u16 {
         self.module_voltage_30_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_30
+    /// Get raw value of 'MODULE_VOLTAGE_30'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4431,7 +4431,7 @@ impl BatteryVtBatteryVtIndexM30 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_30
+    /// Set value of 'MODULE_VOLTAGE_30'
     #[inline(always)]
     pub fn set_module_voltage_30(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4476,7 +4476,7 @@ impl BatteryVtBatteryVtIndexM31 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_31
+    /// Get value of 'MODULE_TEMP_31'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4486,7 +4486,7 @@ impl BatteryVtBatteryVtIndexM31 {
     pub fn module_temp_31(&self) -> u16 {
         self.module_temp_31_raw()
     }
-    /// Get raw value of MODULE_TEMP_31
+    /// Get raw value of 'MODULE_TEMP_31'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4500,7 +4500,7 @@ impl BatteryVtBatteryVtIndexM31 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_31
+    /// Set value of 'MODULE_TEMP_31'
     #[inline(always)]
     pub fn set_module_temp_31(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4518,7 +4518,7 @@ impl BatteryVtBatteryVtIndexM31 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_31
+    /// Get value of 'MODULE_VOLTAGE_31'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4528,7 +4528,7 @@ impl BatteryVtBatteryVtIndexM31 {
     pub fn module_voltage_31(&self) -> u16 {
         self.module_voltage_31_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_31
+    /// Get raw value of 'MODULE_VOLTAGE_31'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4542,7 +4542,7 @@ impl BatteryVtBatteryVtIndexM31 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_31
+    /// Set value of 'MODULE_VOLTAGE_31'
     #[inline(always)]
     pub fn set_module_voltage_31(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4587,7 +4587,7 @@ impl BatteryVtBatteryVtIndexM32 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_32
+    /// Get value of 'MODULE_TEMP_32'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4597,7 +4597,7 @@ impl BatteryVtBatteryVtIndexM32 {
     pub fn module_temp_32(&self) -> u16 {
         self.module_temp_32_raw()
     }
-    /// Get raw value of MODULE_TEMP_32
+    /// Get raw value of 'MODULE_TEMP_32'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4611,7 +4611,7 @@ impl BatteryVtBatteryVtIndexM32 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_32
+    /// Set value of 'MODULE_TEMP_32'
     #[inline(always)]
     pub fn set_module_temp_32(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4629,7 +4629,7 @@ impl BatteryVtBatteryVtIndexM32 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_32
+    /// Get value of 'MODULE_VOLTAGE_32'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4639,7 +4639,7 @@ impl BatteryVtBatteryVtIndexM32 {
     pub fn module_voltage_32(&self) -> u16 {
         self.module_voltage_32_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_32
+    /// Get raw value of 'MODULE_VOLTAGE_32'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4653,7 +4653,7 @@ impl BatteryVtBatteryVtIndexM32 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_32
+    /// Set value of 'MODULE_VOLTAGE_32'
     #[inline(always)]
     pub fn set_module_voltage_32(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4698,7 +4698,7 @@ impl BatteryVtBatteryVtIndexM33 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_33
+    /// Get value of 'MODULE_TEMP_33'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4708,7 +4708,7 @@ impl BatteryVtBatteryVtIndexM33 {
     pub fn module_temp_33(&self) -> u16 {
         self.module_temp_33_raw()
     }
-    /// Get raw value of MODULE_TEMP_33
+    /// Get raw value of 'MODULE_TEMP_33'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4722,7 +4722,7 @@ impl BatteryVtBatteryVtIndexM33 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_33
+    /// Set value of 'MODULE_TEMP_33'
     #[inline(always)]
     pub fn set_module_temp_33(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4740,7 +4740,7 @@ impl BatteryVtBatteryVtIndexM33 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_33
+    /// Get value of 'MODULE_VOLTAGE_33'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4750,7 +4750,7 @@ impl BatteryVtBatteryVtIndexM33 {
     pub fn module_voltage_33(&self) -> u16 {
         self.module_voltage_33_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_33
+    /// Get raw value of 'MODULE_VOLTAGE_33'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4764,7 +4764,7 @@ impl BatteryVtBatteryVtIndexM33 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_33
+    /// Set value of 'MODULE_VOLTAGE_33'
     #[inline(always)]
     pub fn set_module_voltage_33(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4809,7 +4809,7 @@ impl BatteryVtBatteryVtIndexM34 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_34
+    /// Get value of 'MODULE_TEMP_34'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4819,7 +4819,7 @@ impl BatteryVtBatteryVtIndexM34 {
     pub fn module_temp_34(&self) -> u16 {
         self.module_temp_34_raw()
     }
-    /// Get raw value of MODULE_TEMP_34
+    /// Get raw value of 'MODULE_TEMP_34'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4833,7 +4833,7 @@ impl BatteryVtBatteryVtIndexM34 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_34
+    /// Set value of 'MODULE_TEMP_34'
     #[inline(always)]
     pub fn set_module_temp_34(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4851,7 +4851,7 @@ impl BatteryVtBatteryVtIndexM34 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_34
+    /// Get value of 'MODULE_VOLTAGE_34'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4861,7 +4861,7 @@ impl BatteryVtBatteryVtIndexM34 {
     pub fn module_voltage_34(&self) -> u16 {
         self.module_voltage_34_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_34
+    /// Get raw value of 'MODULE_VOLTAGE_34'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4875,7 +4875,7 @@ impl BatteryVtBatteryVtIndexM34 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_34
+    /// Set value of 'MODULE_VOLTAGE_34'
     #[inline(always)]
     pub fn set_module_voltage_34(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4920,7 +4920,7 @@ impl BatteryVtBatteryVtIndexM35 {
     pub fn new() -> Self {
         Self { raw: [0u8; 6] }
     }
-    /// MODULE_TEMP_35
+    /// Get value of 'MODULE_TEMP_35'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4930,7 +4930,7 @@ impl BatteryVtBatteryVtIndexM35 {
     pub fn module_temp_35(&self) -> u16 {
         self.module_temp_35_raw()
     }
-    /// Get raw value of MODULE_TEMP_35
+    /// Get raw value of 'MODULE_TEMP_35'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4944,7 +4944,7 @@ impl BatteryVtBatteryVtIndexM35 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_TEMP_35
+    /// Set value of 'MODULE_TEMP_35'
     #[inline(always)]
     pub fn set_module_temp_35(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -4962,7 +4962,7 @@ impl BatteryVtBatteryVtIndexM35 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// MODULE_VOLTAGE_35
+    /// Get value of 'MODULE_VOLTAGE_35'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4972,7 +4972,7 @@ impl BatteryVtBatteryVtIndexM35 {
     pub fn module_voltage_35(&self) -> u16 {
         self.module_voltage_35_raw()
     }
-    /// Get raw value of MODULE_VOLTAGE_35
+    /// Get raw value of 'MODULE_VOLTAGE_35'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4986,7 +4986,7 @@ impl BatteryVtBatteryVtIndexM35 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MODULE_VOLTAGE_35
+    /// Set value of 'MODULE_VOLTAGE_35'
     #[inline(always)]
     pub fn set_module_voltage_35(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {

--- a/tests-snapshots/dbc-cantools/multiple_senders.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiple_senders.snap.rs
@@ -70,7 +70,7 @@ impl Bar {
     pub const MESSAGE_SIZE: usize = 4;
     pub const BINARY32_MIN: i32 = 0_i32;
     pub const BINARY32_MAX: i32 = 0_i32;
-    /// Construct new Bar from values
+    /// Construct new 'Bar' from values
     pub fn new(binary32: i32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 4] };
         res.set_binary32(binary32)?;
@@ -80,7 +80,7 @@ impl Bar {
     pub fn raw(&self) -> &[u8; 4] {
         &self.raw
     }
-    /// Binary32
+    /// Get value of 'Binary32'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -90,7 +90,7 @@ impl Bar {
     pub fn binary32(&self) -> i32 {
         self.binary32_raw()
     }
-    /// Get raw value of Binary32
+    /// Get raw value of 'Binary32'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -105,7 +105,7 @@ impl Bar {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Binary32
+    /// Set value of 'Binary32'
     #[inline(always)]
     pub fn set_binary32(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {

--- a/tests-snapshots/dbc-cantools/multiplex.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex.snap.rs
@@ -69,7 +69,7 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new(multiplexor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_multiplexor(multiplexor)?;
@@ -79,7 +79,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Multiplexor
+    /// Get raw value of 'Multiplexor'
     ///
     /// - Start bit: 2
     /// - Signal size: 6 bits
@@ -117,7 +117,7 @@ impl Message1 {
             }
         }
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     fn set_multiplexor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -135,7 +135,7 @@ impl Message1 {
         self.raw.view_bits_mut::<Lsb0>()[2..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m8(&mut self, value: Message1MultiplexorM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -144,7 +144,7 @@ impl Message1 {
         self.set_multiplexor(8)?;
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m24(&mut self, value: Message1MultiplexorM24) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -232,7 +232,7 @@ impl Message1MultiplexorM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_L
+    /// Get value of 'BIT_L'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -242,7 +242,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_l(&self) -> bool {
         self.bit_l_raw()
     }
-    /// Get raw value of BIT_L
+    /// Get raw value of 'BIT_L'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -255,14 +255,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_L
+    /// Set value of 'BIT_L'
     #[inline(always)]
     pub fn set_bit_l(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// BIT_G
+    /// Get value of 'BIT_G'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -272,7 +272,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_g(&self) -> bool {
         self.bit_g_raw()
     }
-    /// Get raw value of BIT_G
+    /// Get raw value of 'BIT_G'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -285,14 +285,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_G
+    /// Set value of 'BIT_G'
     #[inline(always)]
     pub fn set_bit_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// BIT_C
+    /// Get value of 'BIT_C'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -302,7 +302,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_c(&self) -> bool {
         self.bit_c_raw()
     }
-    /// Get raw value of BIT_C
+    /// Get raw value of 'BIT_C'
     ///
     /// - Start bit: 19
     /// - Signal size: 1 bits
@@ -315,14 +315,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[19..20].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_C
+    /// Set value of 'BIT_C'
     #[inline(always)]
     pub fn set_bit_c(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[19..20].store_le(value);
         Ok(())
     }
-    /// BIT_J
+    /// Get value of 'BIT_J'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -332,7 +332,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_j(&self) -> bool {
         self.bit_j_raw()
     }
-    /// Get raw value of BIT_J
+    /// Get raw value of 'BIT_J'
     ///
     /// - Start bit: 18
     /// - Signal size: 1 bits
@@ -345,7 +345,7 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[18..19].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_J
+    /// Set value of 'BIT_J'
     #[inline(always)]
     pub fn set_bit_j(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -379,7 +379,7 @@ impl Message1MultiplexorM24 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_K
+    /// Get value of 'BIT_K'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -389,7 +389,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_k(&self) -> bool {
         self.bit_k_raw()
     }
-    /// Get raw value of BIT_K
+    /// Get raw value of 'BIT_K'
     ///
     /// - Start bit: 28
     /// - Signal size: 1 bits
@@ -402,14 +402,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[28..29].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_K
+    /// Set value of 'BIT_K'
     #[inline(always)]
     pub fn set_bit_k(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[28..29].store_le(value);
         Ok(())
     }
-    /// BIT_D
+    /// Get value of 'BIT_D'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -419,7 +419,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_d(&self) -> bool {
         self.bit_d_raw()
     }
-    /// Get raw value of BIT_D
+    /// Get raw value of 'BIT_D'
     ///
     /// - Start bit: 32
     /// - Signal size: 1 bits
@@ -432,14 +432,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[32..33].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_D
+    /// Set value of 'BIT_D'
     #[inline(always)]
     pub fn set_bit_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[32..33].store_le(value);
         Ok(())
     }
-    /// BIT_B
+    /// Get value of 'BIT_B'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -449,7 +449,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_b(&self) -> bool {
         self.bit_b_raw()
     }
-    /// Get raw value of BIT_B
+    /// Get raw value of 'BIT_B'
     ///
     /// - Start bit: 33
     /// - Signal size: 1 bits
@@ -462,14 +462,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[33..34].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_B
+    /// Set value of 'BIT_B'
     #[inline(always)]
     pub fn set_bit_b(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[33..34].store_le(value);
         Ok(())
     }
-    /// BIT_F
+    /// Get value of 'BIT_F'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -479,7 +479,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_f(&self) -> bool {
         self.bit_f_raw()
     }
-    /// Get raw value of BIT_F
+    /// Get raw value of 'BIT_F'
     ///
     /// - Start bit: 39
     /// - Signal size: 1 bits
@@ -492,14 +492,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[39..40].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_F
+    /// Set value of 'BIT_F'
     #[inline(always)]
     pub fn set_bit_f(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[39..40].store_le(value);
         Ok(())
     }
-    /// BIT_H
+    /// Get value of 'BIT_H'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -509,7 +509,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_h(&self) -> bool {
         self.bit_h_raw()
     }
-    /// Get raw value of BIT_H
+    /// Get raw value of 'BIT_H'
     ///
     /// - Start bit: 38
     /// - Signal size: 1 bits
@@ -522,14 +522,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[38..39].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_H
+    /// Set value of 'BIT_H'
     #[inline(always)]
     pub fn set_bit_h(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[38..39].store_le(value);
         Ok(())
     }
-    /// BIT_E
+    /// Get value of 'BIT_E'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -539,7 +539,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_e(&self) -> bool {
         self.bit_e_raw()
     }
-    /// Get raw value of BIT_E
+    /// Get raw value of 'BIT_E'
     ///
     /// - Start bit: 29
     /// - Signal size: 1 bits
@@ -552,14 +552,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[29..30].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_E
+    /// Set value of 'BIT_E'
     #[inline(always)]
     pub fn set_bit_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[29..30].store_le(value);
         Ok(())
     }
-    /// BIT_A
+    /// Get value of 'BIT_A'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -569,7 +569,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_a(&self) -> bool {
         self.bit_a_raw()
     }
-    /// Get raw value of BIT_A
+    /// Get raw value of 'BIT_A'
     ///
     /// - Start bit: 26
     /// - Signal size: 1 bits
@@ -582,7 +582,7 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[26..27].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_A
+    /// Set value of 'BIT_A'
     #[inline(always)]
     pub fn set_bit_a(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.rs
@@ -84,7 +84,7 @@ impl Shared {
     pub const S1_MAX: i8 = 0_i8;
     pub const S0_MIN: i8 = 0_i8;
     pub const S0_MAX: i8 = 0_i8;
-    /// Construct new Shared from values
+    /// Construct new 'Shared' from values
     pub fn new(s0: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s0(s0)?;
@@ -94,7 +94,7 @@ impl Shared {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of S0
+    /// Get raw value of 'S0'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -121,7 +121,7 @@ impl Shared {
             }
         }
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     fn set_s0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -140,7 +140,7 @@ impl Shared {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m1(&mut self, value: SharedS0M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -149,7 +149,7 @@ impl Shared {
         self.set_s0(1)?;
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m2(&mut self, value: SharedS0M2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -237,7 +237,7 @@ impl SharedS0M1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S1
+    /// Get value of 'S1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -247,7 +247,7 @@ impl SharedS0M1 {
     pub fn s1(&self) -> i8 {
         self.s1_raw()
     }
-    /// Get raw value of S1
+    /// Get raw value of 'S1'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -262,7 +262,7 @@ impl SharedS0M1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S1
+    /// Set value of 'S1'
     #[inline(always)]
     pub fn set_s1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -308,7 +308,7 @@ impl SharedS0M2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S2
+    /// Get value of 'S2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -318,7 +318,7 @@ impl SharedS0M2 {
     pub fn s2(&self) -> i8 {
         self.s2_raw()
     }
-    /// Get raw value of S2
+    /// Get raw value of 'S2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -333,7 +333,7 @@ impl SharedS0M2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S2
+    /// Set value of 'S2'
     #[inline(always)]
     pub fn set_s2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -381,7 +381,7 @@ impl Normal {
     pub const S1_MAX: i8 = 0_i8;
     pub const S0_MIN: i8 = 0_i8;
     pub const S0_MAX: i8 = 0_i8;
-    /// Construct new Normal from values
+    /// Construct new 'Normal' from values
     pub fn new(s0: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s0(s0)?;
@@ -391,7 +391,7 @@ impl Normal {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of S0
+    /// Get raw value of 'S0'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -418,7 +418,7 @@ impl Normal {
             }
         }
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     fn set_s0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -437,7 +437,7 @@ impl Normal {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m0(&mut self, value: NormalS0M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -446,7 +446,7 @@ impl Normal {
         self.set_s0(0)?;
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m1(&mut self, value: NormalS0M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -534,7 +534,7 @@ impl NormalS0M0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S1
+    /// Get value of 'S1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -544,7 +544,7 @@ impl NormalS0M0 {
     pub fn s1(&self) -> i8 {
         self.s1_raw()
     }
-    /// Get raw value of S1
+    /// Get raw value of 'S1'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -559,7 +559,7 @@ impl NormalS0M0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S1
+    /// Set value of 'S1'
     #[inline(always)]
     pub fn set_s1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -605,7 +605,7 @@ impl NormalS0M1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S2
+    /// Get value of 'S2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -615,7 +615,7 @@ impl NormalS0M1 {
     pub fn s2(&self) -> i8 {
         self.s2_raw()
     }
-    /// Get raw value of S2
+    /// Get raw value of 'S2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -630,7 +630,7 @@ impl NormalS0M1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S2
+    /// Set value of 'S2'
     #[inline(always)]
     pub fn set_s2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -690,7 +690,7 @@ impl Extended {
     pub const S1_MAX: i8 = 0_i8;
     pub const S0_MIN: i8 = 0_i8;
     pub const S0_MAX: i8 = 0_i8;
-    /// Construct new Extended from values
+    /// Construct new 'Extended' from values
     pub fn new(s6: i8, s0: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s6(s6)?;
@@ -701,7 +701,7 @@ impl Extended {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of S6
+    /// Get raw value of 'S6'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -729,7 +729,7 @@ impl Extended {
             }
         }
     }
-    /// Set value of S6
+    /// Set value of 'S6'
     #[inline(always)]
     fn set_s6(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -748,7 +748,7 @@ impl Extended {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// Set value of S6
+    /// Set value of 'S6'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -757,7 +757,7 @@ impl Extended {
         self.set_s6(0)?;
         Ok(())
     }
-    /// Set value of S6
+    /// Set value of 'S6'
     #[inline(always)]
     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -766,7 +766,7 @@ impl Extended {
         self.set_s6(1)?;
         Ok(())
     }
-    /// Set value of S6
+    /// Set value of 'S6'
     #[inline(always)]
     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -775,7 +775,7 @@ impl Extended {
         self.set_s6(2)?;
         Ok(())
     }
-    /// Get raw value of S0
+    /// Get raw value of 'S0'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -803,7 +803,7 @@ impl Extended {
             }
         }
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     fn set_s0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -822,7 +822,7 @@ impl Extended {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -831,7 +831,7 @@ impl Extended {
         self.set_s0(0)?;
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -840,7 +840,7 @@ impl Extended {
         self.set_s0(1)?;
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -929,7 +929,7 @@ impl ExtendedS6M0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S3
+    /// Get value of 'S3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -939,7 +939,7 @@ impl ExtendedS6M0 {
     pub fn s3(&self) -> i16 {
         self.s3_raw()
     }
-    /// Get raw value of S3
+    /// Get raw value of 'S3'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -954,7 +954,7 @@ impl ExtendedS6M0 {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S3
+    /// Set value of 'S3'
     #[inline(always)]
     pub fn set_s3(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 0_i16 < value {
@@ -973,7 +973,7 @@ impl ExtendedS6M0 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// S2
+    /// Get value of 'S2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -983,7 +983,7 @@ impl ExtendedS6M0 {
     pub fn s2(&self) -> i8 {
         self.s2_raw()
     }
-    /// Get raw value of S2
+    /// Get raw value of 'S2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -998,7 +998,7 @@ impl ExtendedS6M0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S2
+    /// Set value of 'S2'
     #[inline(always)]
     pub fn set_s2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -1044,7 +1044,7 @@ impl ExtendedS6M1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S7
+    /// Get value of 'S7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1054,7 +1054,7 @@ impl ExtendedS6M1 {
     pub fn s7(&self) -> i32 {
         self.s7_raw()
     }
-    /// Get raw value of S7
+    /// Get raw value of 'S7'
     ///
     /// - Start bit: 40
     /// - Signal size: 24 bits
@@ -1069,7 +1069,7 @@ impl ExtendedS6M1 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S7
+    /// Set value of 'S7'
     #[inline(always)]
     pub fn set_s7(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -1088,7 +1088,7 @@ impl ExtendedS6M1 {
         self.raw.view_bits_mut::<Lsb0>()[40..64].store_le(value);
         Ok(())
     }
-    /// S5
+    /// Get value of 'S5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1098,7 +1098,7 @@ impl ExtendedS6M1 {
     pub fn s5(&self) -> i32 {
         self.s5_raw()
     }
-    /// Get raw value of S5
+    /// Get raw value of 'S5'
     ///
     /// - Start bit: 4
     /// - Signal size: 28 bits
@@ -1113,7 +1113,7 @@ impl ExtendedS6M1 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S5
+    /// Set value of 'S5'
     #[inline(always)]
     pub fn set_s5(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -1159,7 +1159,7 @@ impl ExtendedS6M2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S8
+    /// Get value of 'S8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1169,7 +1169,7 @@ impl ExtendedS6M2 {
     pub fn s8(&self) -> i8 {
         self.s8_raw()
     }
-    /// Get raw value of S8
+    /// Get raw value of 'S8'
     ///
     /// - Start bit: 40
     /// - Signal size: 8 bits
@@ -1184,7 +1184,7 @@ impl ExtendedS6M2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S8
+    /// Set value of 'S8'
     #[inline(always)]
     pub fn set_s8(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -1203,7 +1203,7 @@ impl ExtendedS6M2 {
         self.raw.view_bits_mut::<Lsb0>()[40..48].store_le(value);
         Ok(())
     }
-    /// S4
+    /// Get value of 'S4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1213,7 +1213,7 @@ impl ExtendedS6M2 {
     pub fn s4(&self) -> i32 {
         self.s4_raw()
     }
-    /// Get raw value of S4
+    /// Get raw value of 'S4'
     ///
     /// - Start bit: 8
     /// - Signal size: 24 bits
@@ -1228,7 +1228,7 @@ impl ExtendedS6M2 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S4
+    /// Set value of 'S4'
     #[inline(always)]
     pub fn set_s4(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -1278,7 +1278,7 @@ impl ExtendedTypes {
     pub const S0_MAX: i8 = 0_i8;
     pub const S11_MIN: u8 = 2_u8;
     pub const S11_MAX: u8 = 6_u8;
-    /// Construct new ExtendedTypes from values
+    /// Construct new 'ExtendedTypes' from values
     pub fn new(s11: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s11(s11)?;
@@ -1288,7 +1288,7 @@ impl ExtendedTypes {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of S11
+    /// Get raw value of 'S11'
     ///
     /// - Start bit: 0
     /// - Signal size: 5 bits
@@ -1326,7 +1326,7 @@ impl ExtendedTypes {
             }
         }
     }
-    /// Set value of S11
+    /// Set value of 'S11'
     #[inline(always)]
     fn set_s11(&mut self, value: u8) -> Result<(), CanError> {
         if value < 2_u8 || 6_u8 < value {
@@ -1344,7 +1344,7 @@ impl ExtendedTypes {
         self.raw.view_bits_mut::<Lsb0>()[0..5].store_le(value);
         Ok(())
     }
-    /// Set value of S11
+    /// Set value of 'S11'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -1353,7 +1353,7 @@ impl ExtendedTypes {
         self.set_s11(0)?;
         Ok(())
     }
-    /// Set value of S11
+    /// Set value of 'S11'
     #[inline(always)]
     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -1441,7 +1441,7 @@ impl ExtendedTypesS11M0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S10
+    /// Get value of 'S10'
     ///
     /// - Min: -340000000000000000000000000000000000000
     /// - Max: 340000000000000000000000000000000000000
@@ -1451,7 +1451,7 @@ impl ExtendedTypesS11M0 {
     pub fn s10(&self) -> i32 {
         self.s10_raw()
     }
-    /// Get raw value of S10
+    /// Get raw value of 'S10'
     ///
     /// - Start bit: 16
     /// - Signal size: 32 bits
@@ -1466,7 +1466,7 @@ impl ExtendedTypesS11M0 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S10
+    /// Set value of 'S10'
     #[inline(always)]
     pub fn set_s10(&mut self, value: i32) -> Result<(), CanError> {
         if value < -340000000000000000000000000000000000000_i32
@@ -1514,7 +1514,7 @@ impl ExtendedTypesS11M5 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S9
+    /// Get value of 'S9'
     ///
     /// - Min: -1.34
     /// - Max: 1235
@@ -1524,7 +1524,7 @@ impl ExtendedTypesS11M5 {
     pub fn s9(&self) -> i32 {
         self.s9_raw()
     }
-    /// Get raw value of S9
+    /// Get raw value of 'S9'
     ///
     /// - Start bit: 24
     /// - Signal size: 32 bits
@@ -1539,7 +1539,7 @@ impl ExtendedTypesS11M5 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S9
+    /// Set value of 'S9'
     #[inline(always)]
     pub fn set_s9(&mut self, value: i32) -> Result<(), CanError> {
         if value < -1.34_i32 || 1235_i32 < value {

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
@@ -21,91 +21,55 @@ error[E0422]: cannot find struct, variant or union type `ExtendedS0M0` in this s
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:795:41
     |
 795 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |                                         ^^^^^^^^^^^^
+    |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
 ...
 916 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
-    |
-help: a struct with a similar name exists
-    |
-795 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-795 +             0 => Ok(ExtendedS0Index::M0(ExtendedS6M0 { raw: self.raw })),
-    |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:796:41
      |
  796 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^
+     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
 ...
 1031 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
-     |
-help: a struct with a similar name exists
-     |
- 796 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
- 796 +             1 => Ok(ExtendedS0Index::M1(ExtendedS6M1 { raw: self.raw })),
-     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:797:41
      |
  797 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^
+     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
 ...
 1146 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
-     |
-help: a struct with a similar name exists
-     |
- 797 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
- 797 +             2 => Ok(ExtendedS0Index::M2(ExtendedS6M2 { raw: self.raw })),
-     |
 
 error[E0425]: cannot find type `ExtendedS0M0` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:827:37
     |
 827 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^
+    |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
 ...
 916 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
-    |
-help: a struct with a similar name exists
-    |
-827 -     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
-827 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
-    |
 
 error[E0425]: cannot find type `ExtendedS0M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:836:37
      |
  836 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^
+     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
 ...
 1031 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
-     |
-help: a struct with a similar name exists
-     |
- 836 -     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
- 836 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
-     |
 
 error[E0425]: cannot find type `ExtendedS0M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:845:37
      |
  845 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^
+     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
 ...
 1146 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
-     |
-help: a struct with a similar name exists
-     |
- 845 -     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
- 845 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
-     |
 
 error: invalid suffix `i32` for float literal
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:1273:30
@@ -150,38 +114,29 @@ error[E0592]: duplicate definitions with name `set_m2`
 845 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m2`
 
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:795:21
     |
 795 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-795 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-795 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |
+    |                     ^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtendedS0Index`
+    |                     help: an enum with a similar name exists: `ExtendedS6Index`
 
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:796:21
     |
 796 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-796 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-796 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
-    |
+    |                     ^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtendedS0Index`
+    |                     help: an enum with a similar name exists: `ExtendedS6Index`
 
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:797:21
     |
 797 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-797 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-797 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
-    |
+    |                     ^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtendedS0Index`
+    |                     help: an enum with a similar name exists: `ExtendedS6Index`

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
@@ -21,55 +21,91 @@ error[E0422]: cannot find struct, variant or union type `ExtendedS0M0` in this s
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:795:41
     |
 795 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
+    |                                         ^^^^^^^^^^^^
 ...
 916 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
+    |
+help: a struct with a similar name exists
+    |
+795 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+795 +             0 => Ok(ExtendedS0Index::M0(ExtendedS6M0 { raw: self.raw })),
+    |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:796:41
      |
  796 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
+     |                                         ^^^^^^^^^^^^
 ...
 1031 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 796 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+ 796 +             1 => Ok(ExtendedS0Index::M1(ExtendedS6M1 { raw: self.raw })),
+     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:797:41
      |
  797 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
+     |                                         ^^^^^^^^^^^^
 ...
 1146 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 797 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+ 797 +             2 => Ok(ExtendedS0Index::M2(ExtendedS6M2 { raw: self.raw })),
+     |
 
 error[E0425]: cannot find type `ExtendedS0M0` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:827:37
     |
 827 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
+    |                                     ^^^^^^^^^^^^
 ...
 916 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
+    |
+help: a struct with a similar name exists
+    |
+827 -     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
+827 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
+    |
 
 error[E0425]: cannot find type `ExtendedS0M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:836:37
      |
  836 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
+     |                                     ^^^^^^^^^^^^
 ...
 1031 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 836 -     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
+ 836 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
+     |
 
 error[E0425]: cannot find type `ExtendedS0M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:845:37
      |
  845 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
+     |                                     ^^^^^^^^^^^^
 ...
 1146 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 845 -     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
+ 845 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
+     |
 
 error: invalid suffix `i32` for float literal
     --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:1273:30
@@ -114,29 +150,38 @@ error[E0592]: duplicate definitions with name `set_m2`
 845 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m2`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:795:21
     |
 795 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtendedS0Index`
-    |                     help: an enum with a similar name exists: `ExtendedS6Index`
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+795 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+795 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:796:21
     |
 796 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtendedS0Index`
-    |                     help: an enum with a similar name exists: `ExtendedS6Index`
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+796 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+796 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:797:21
     |
 797 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtendedS0Index`
-    |                     help: an enum with a similar name exists: `ExtendedS6Index`
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+797 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+797 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
+    |

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs
@@ -84,7 +84,7 @@ impl Shared {
     pub const S1_MAX: i8 = 0_i8;
     pub const S0_MIN: i8 = 0_i8;
     pub const S0_MAX: i8 = 0_i8;
-    /// Construct new Shared from values
+    /// Construct new 'Shared' from values
     pub fn new(s0: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s0(s0)?;
@@ -94,7 +94,7 @@ impl Shared {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of S0
+    /// Get raw value of 'S0'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -121,7 +121,7 @@ impl Shared {
             }
         }
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     fn set_s0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -140,7 +140,7 @@ impl Shared {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m1(&mut self, value: SharedS0M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -149,7 +149,7 @@ impl Shared {
         self.set_s0(1)?;
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m2(&mut self, value: SharedS0M2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -237,7 +237,7 @@ impl SharedS0M1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S1
+    /// Get value of 'S1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -247,7 +247,7 @@ impl SharedS0M1 {
     pub fn s1(&self) -> i8 {
         self.s1_raw()
     }
-    /// Get raw value of S1
+    /// Get raw value of 'S1'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -262,7 +262,7 @@ impl SharedS0M1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S1
+    /// Set value of 'S1'
     #[inline(always)]
     pub fn set_s1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -308,7 +308,7 @@ impl SharedS0M2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S2
+    /// Get value of 'S2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -318,7 +318,7 @@ impl SharedS0M2 {
     pub fn s2(&self) -> i8 {
         self.s2_raw()
     }
-    /// Get raw value of S2
+    /// Get raw value of 'S2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -333,7 +333,7 @@ impl SharedS0M2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S2
+    /// Set value of 'S2'
     #[inline(always)]
     pub fn set_s2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -381,7 +381,7 @@ impl Normal {
     pub const S1_MAX: i8 = 0_i8;
     pub const S0_MIN: i8 = 0_i8;
     pub const S0_MAX: i8 = 0_i8;
-    /// Construct new Normal from values
+    /// Construct new 'Normal' from values
     pub fn new(s0: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s0(s0)?;
@@ -391,7 +391,7 @@ impl Normal {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of S0
+    /// Get raw value of 'S0'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -418,7 +418,7 @@ impl Normal {
             }
         }
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     fn set_s0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -437,7 +437,7 @@ impl Normal {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m0(&mut self, value: NormalS0M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -446,7 +446,7 @@ impl Normal {
         self.set_s0(0)?;
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m1(&mut self, value: NormalS0M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -534,7 +534,7 @@ impl NormalS0M0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S1
+    /// Get value of 'S1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -544,7 +544,7 @@ impl NormalS0M0 {
     pub fn s1(&self) -> i8 {
         self.s1_raw()
     }
-    /// Get raw value of S1
+    /// Get raw value of 'S1'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -559,7 +559,7 @@ impl NormalS0M0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S1
+    /// Set value of 'S1'
     #[inline(always)]
     pub fn set_s1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -605,7 +605,7 @@ impl NormalS0M1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S2
+    /// Get value of 'S2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -615,7 +615,7 @@ impl NormalS0M1 {
     pub fn s2(&self) -> i8 {
         self.s2_raw()
     }
-    /// Get raw value of S2
+    /// Get raw value of 'S2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -630,7 +630,7 @@ impl NormalS0M1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S2
+    /// Set value of 'S2'
     #[inline(always)]
     pub fn set_s2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -690,7 +690,7 @@ impl Extended {
     pub const S5_MAX: i32 = 0_i32;
     pub const S0_MIN: i8 = 0_i8;
     pub const S0_MAX: i8 = 0_i8;
-    /// Construct new Extended from values
+    /// Construct new 'Extended' from values
     pub fn new(s6: i8, s1: i8, s0: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s6(s6)?;
@@ -702,7 +702,7 @@ impl Extended {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of S6
+    /// Get raw value of 'S6'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -730,7 +730,7 @@ impl Extended {
             }
         }
     }
-    /// Set value of S6
+    /// Set value of 'S6'
     #[inline(always)]
     fn set_s6(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -749,7 +749,7 @@ impl Extended {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// Set value of S6
+    /// Set value of 'S6'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -758,7 +758,7 @@ impl Extended {
         self.set_s6(0)?;
         Ok(())
     }
-    /// Set value of S6
+    /// Set value of 'S6'
     #[inline(always)]
     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -767,7 +767,7 @@ impl Extended {
         self.set_s6(1)?;
         Ok(())
     }
-    /// Set value of S6
+    /// Set value of 'S6'
     #[inline(always)]
     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -776,7 +776,7 @@ impl Extended {
         self.set_s6(2)?;
         Ok(())
     }
-    /// Get raw value of S1
+    /// Get raw value of 'S1'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -804,7 +804,7 @@ impl Extended {
             }
         }
     }
-    /// Set value of S1
+    /// Set value of 'S1'
     #[inline(always)]
     fn set_s1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -823,7 +823,7 @@ impl Extended {
         self.raw.view_bits_mut::<Lsb0>()[4..8].store_le(value);
         Ok(())
     }
-    /// Set value of S1
+    /// Set value of 'S1'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -832,7 +832,7 @@ impl Extended {
         self.set_s1(0)?;
         Ok(())
     }
-    /// Set value of S1
+    /// Set value of 'S1'
     #[inline(always)]
     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -841,7 +841,7 @@ impl Extended {
         self.set_s1(1)?;
         Ok(())
     }
-    /// Set value of S1
+    /// Set value of 'S1'
     #[inline(always)]
     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -850,7 +850,7 @@ impl Extended {
         self.set_s1(2)?;
         Ok(())
     }
-    /// Get raw value of S0
+    /// Get raw value of 'S0'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -878,7 +878,7 @@ impl Extended {
             }
         }
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     fn set_s0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -897,7 +897,7 @@ impl Extended {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -906,7 +906,7 @@ impl Extended {
         self.set_s0(0)?;
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -915,7 +915,7 @@ impl Extended {
         self.set_s0(1)?;
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -1004,7 +1004,7 @@ impl ExtendedS6M0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S3
+    /// Get value of 'S3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1014,7 +1014,7 @@ impl ExtendedS6M0 {
     pub fn s3(&self) -> i16 {
         self.s3_raw()
     }
-    /// Get raw value of S3
+    /// Get raw value of 'S3'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -1029,7 +1029,7 @@ impl ExtendedS6M0 {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S3
+    /// Set value of 'S3'
     #[inline(always)]
     pub fn set_s3(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 0_i16 < value {
@@ -1048,7 +1048,7 @@ impl ExtendedS6M0 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// S2
+    /// Get value of 'S2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1058,7 +1058,7 @@ impl ExtendedS6M0 {
     pub fn s2(&self) -> i8 {
         self.s2_raw()
     }
-    /// Get raw value of S2
+    /// Get raw value of 'S2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -1073,7 +1073,7 @@ impl ExtendedS6M0 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S2
+    /// Set value of 'S2'
     #[inline(always)]
     pub fn set_s2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -1119,7 +1119,7 @@ impl ExtendedS6M1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S7
+    /// Get value of 'S7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1129,7 +1129,7 @@ impl ExtendedS6M1 {
     pub fn s7(&self) -> i32 {
         self.s7_raw()
     }
-    /// Get raw value of S7
+    /// Get raw value of 'S7'
     ///
     /// - Start bit: 40
     /// - Signal size: 24 bits
@@ -1144,7 +1144,7 @@ impl ExtendedS6M1 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S7
+    /// Set value of 'S7'
     #[inline(always)]
     pub fn set_s7(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -1163,7 +1163,7 @@ impl ExtendedS6M1 {
         self.raw.view_bits_mut::<Lsb0>()[40..64].store_le(value);
         Ok(())
     }
-    /// S5
+    /// Get value of 'S5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1173,7 +1173,7 @@ impl ExtendedS6M1 {
     pub fn s5(&self) -> i32 {
         self.s5_raw()
     }
-    /// Get raw value of S5
+    /// Get raw value of 'S5'
     ///
     /// - Start bit: 4
     /// - Signal size: 28 bits
@@ -1188,7 +1188,7 @@ impl ExtendedS6M1 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S5
+    /// Set value of 'S5'
     #[inline(always)]
     pub fn set_s5(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -1234,7 +1234,7 @@ impl ExtendedS6M2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S8
+    /// Get value of 'S8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1244,7 +1244,7 @@ impl ExtendedS6M2 {
     pub fn s8(&self) -> i8 {
         self.s8_raw()
     }
-    /// Get raw value of S8
+    /// Get raw value of 'S8'
     ///
     /// - Start bit: 40
     /// - Signal size: 8 bits
@@ -1259,7 +1259,7 @@ impl ExtendedS6M2 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S8
+    /// Set value of 'S8'
     #[inline(always)]
     pub fn set_s8(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -1278,7 +1278,7 @@ impl ExtendedS6M2 {
         self.raw.view_bits_mut::<Lsb0>()[40..48].store_le(value);
         Ok(())
     }
-    /// S4
+    /// Get value of 'S4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1288,7 +1288,7 @@ impl ExtendedS6M2 {
     pub fn s4(&self) -> i32 {
         self.s4_raw()
     }
-    /// Get raw value of S4
+    /// Get raw value of 'S4'
     ///
     /// - Start bit: 8
     /// - Signal size: 24 bits
@@ -1303,7 +1303,7 @@ impl ExtendedS6M2 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S4
+    /// Set value of 'S4'
     #[inline(always)]
     pub fn set_s4(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -1353,7 +1353,7 @@ impl ExtendedTypes {
     pub const S0_MAX: i8 = 0_i8;
     pub const S11_MIN: u8 = 2_u8;
     pub const S11_MAX: u8 = 6_u8;
-    /// Construct new ExtendedTypes from values
+    /// Construct new 'ExtendedTypes' from values
     pub fn new(s0: i8, s11: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s0(s0)?;
@@ -1364,7 +1364,7 @@ impl ExtendedTypes {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of S0
+    /// Get raw value of 'S0'
     ///
     /// - Start bit: 8
     /// - Signal size: 4 bits
@@ -1391,7 +1391,7 @@ impl ExtendedTypes {
             }
         }
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     fn set_s0(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -1410,7 +1410,7 @@ impl ExtendedTypes {
         self.raw.view_bits_mut::<Lsb0>()[8..12].store_le(value);
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtendedTypesS0M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -1419,7 +1419,7 @@ impl ExtendedTypes {
         self.set_s0(0)?;
         Ok(())
     }
-    /// Set value of S0
+    /// Set value of 'S0'
     #[inline(always)]
     pub fn set_m5(&mut self, value: ExtendedTypesS0M5) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -1428,7 +1428,7 @@ impl ExtendedTypes {
         self.set_s0(5)?;
         Ok(())
     }
-    /// Get raw value of S11
+    /// Get raw value of 'S11'
     ///
     /// - Start bit: 0
     /// - Signal size: 5 bits
@@ -1466,7 +1466,7 @@ impl ExtendedTypes {
             }
         }
     }
-    /// Set value of S11
+    /// Set value of 'S11'
     #[inline(always)]
     fn set_s11(&mut self, value: u8) -> Result<(), CanError> {
         if value < 2_u8 || 6_u8 < value {
@@ -1484,7 +1484,7 @@ impl ExtendedTypes {
         self.raw.view_bits_mut::<Lsb0>()[0..5].store_le(value);
         Ok(())
     }
-    /// Set value of S11
+    /// Set value of 'S11'
     #[inline(always)]
     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -1493,7 +1493,7 @@ impl ExtendedTypes {
         self.set_s11(0)?;
         Ok(())
     }
-    /// Set value of S11
+    /// Set value of 'S11'
     #[inline(always)]
     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -1581,7 +1581,7 @@ impl ExtendedTypesS0M0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S10
+    /// Get value of 'S10'
     ///
     /// - Min: -340000000000000000000000000000000000000
     /// - Max: 340000000000000000000000000000000000000
@@ -1591,7 +1591,7 @@ impl ExtendedTypesS0M0 {
     pub fn s10(&self) -> i32 {
         self.s10_raw()
     }
-    /// Get raw value of S10
+    /// Get raw value of 'S10'
     ///
     /// - Start bit: 16
     /// - Signal size: 32 bits
@@ -1606,7 +1606,7 @@ impl ExtendedTypesS0M0 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S10
+    /// Set value of 'S10'
     #[inline(always)]
     pub fn set_s10(&mut self, value: i32) -> Result<(), CanError> {
         if value < -340000000000000000000000000000000000000_i32
@@ -1654,7 +1654,7 @@ impl ExtendedTypesS0M5 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// S9
+    /// Get value of 'S9'
     ///
     /// - Min: -1.34
     /// - Max: 1235
@@ -1664,7 +1664,7 @@ impl ExtendedTypesS0M5 {
     pub fn s9(&self) -> i32 {
         self.s9_raw()
     }
-    /// Get raw value of S9
+    /// Get raw value of 'S9'
     ///
     /// - Start bit: 24
     /// - Signal size: 32 bits
@@ -1679,7 +1679,7 @@ impl ExtendedTypesS0M5 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of S9
+    /// Set value of 'S9'
     #[inline(always)]
     pub fn set_s9(&mut self, value: i32) -> Result<(), CanError> {
         if value < -1.34_i32 || 1235_i32 < value {

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
@@ -21,91 +21,55 @@ error[E0422]: cannot find struct, variant or union type `ExtendedS1M0` in this s
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:796:41
     |
 796 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-    |                                         ^^^^^^^^^^^^
+    |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
 ...
 991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
-    |
-help: a struct with a similar name exists
-    |
-796 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-796 +             0 => Ok(ExtendedS1Index::M0(ExtendedS6M0 { raw: self.raw })),
-    |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS1M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:797:41
      |
  797 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^
+     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
 ...
 1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
-     |
-help: a struct with a similar name exists
-     |
- 797 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
- 797 +             1 => Ok(ExtendedS1Index::M1(ExtendedS6M1 { raw: self.raw })),
-     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS1M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:798:41
      |
  798 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^
+     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
 ...
 1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
-     |
-help: a struct with a similar name exists
-     |
- 798 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
- 798 +             2 => Ok(ExtendedS1Index::M2(ExtendedS6M2 { raw: self.raw })),
-     |
 
 error[E0425]: cannot find type `ExtendedS1M0` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:828:37
     |
 828 |     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^
+    |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
 ...
 991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
-    |
-help: a struct with a similar name exists
-    |
-828 -     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
-828 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
-    |
 
 error[E0425]: cannot find type `ExtendedS1M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:837:37
      |
  837 |     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^
+     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
 ...
 1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
-     |
-help: a struct with a similar name exists
-     |
- 837 -     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
- 837 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
-     |
 
 error[E0425]: cannot find type `ExtendedS1M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:846:37
      |
  846 |     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^
+     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
 ...
 1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
-     |
-help: a struct with a similar name exists
-     |
- 846 -     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
- 846 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
-     |
 
 error[E0425]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:868:36
@@ -130,91 +94,55 @@ error[E0422]: cannot find struct, variant or union type `ExtendedS0M0` in this s
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:870:41
     |
 870 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |                                         ^^^^^^^^^^^^
+    |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
 ...
 991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
-    |
-help: a struct with a similar name exists
-    |
-870 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-870 +             0 => Ok(ExtendedS0Index::M0(ExtendedS6M0 { raw: self.raw })),
-    |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:871:41
      |
  871 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^
+     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
 ...
 1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
-     |
-help: a struct with a similar name exists
-     |
- 871 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
- 871 +             1 => Ok(ExtendedS0Index::M1(ExtendedS6M1 { raw: self.raw })),
-     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:872:41
      |
  872 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^
+     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
 ...
 1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
-     |
-help: a struct with a similar name exists
-     |
- 872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
- 872 +             2 => Ok(ExtendedS0Index::M2(ExtendedS6M2 { raw: self.raw })),
-     |
 
 error[E0425]: cannot find type `ExtendedS0M0` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:902:37
     |
 902 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^
+    |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
 ...
 991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
-    |
-help: a struct with a similar name exists
-    |
-902 -     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
-902 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
-    |
 
 error[E0425]: cannot find type `ExtendedS0M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:911:37
      |
  911 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^
+     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
 ...
 1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
-     |
-help: a struct with a similar name exists
-     |
- 911 -     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
- 911 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
-     |
 
 error[E0425]: cannot find type `ExtendedS0M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:920:37
      |
  920 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^
+     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
 ...
 1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
-     |
-help: a struct with a similar name exists
-     |
- 920 -     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
- 920 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
-     |
 
 error[E0425]: cannot find type `ExtendedTypesS11Index` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1445:37
@@ -239,61 +167,37 @@ error[E0422]: cannot find struct, variant or union type `ExtendedTypesS11M0` in 
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1449:47
      |
 1449 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-     |                                               ^^^^^^^^^^^^^^^^^^
+     |                                               ^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedTypesS0M0`
 ...
 1568 | pub struct ExtendedTypesS0M0 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M0` defined here
-     |
-help: a struct with a similar name exists
-     |
-1449 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-1449 +                     ExtendedTypesS11Index::M0(ExtendedTypesS0M0 {
-     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedTypesS11M5` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1456:47
      |
 1456 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
-     |                                               ^^^^^^^^^^^^^^^^^^
+     |                                               ^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedTypesS0M5`
 ...
 1641 | pub struct ExtendedTypesS0M5 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M5` defined here
-     |
-help: a struct with a similar name exists
-     |
-1456 -                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
-1456 +                     ExtendedTypesS11Index::M5(ExtendedTypesS0M5 {
-     |
 
 error[E0425]: cannot find type `ExtendedTypesS11M0` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1489:37
      |
 1489 |     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^^^^^^^
+     |                                     ^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedTypesS0M0`
 ...
 1568 | pub struct ExtendedTypesS0M0 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M0` defined here
-     |
-help: a struct with a similar name exists
-     |
-1489 -     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
-1489 +     pub fn set_m0(&mut self, value: ExtendedTypesS0M0) -> Result<(), CanError> {
-     |
 
 error[E0425]: cannot find type `ExtendedTypesS11M5` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1498:37
      |
 1498 |     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^^^^^^^
+     |                                     ^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedTypesS0M5`
 ...
 1641 | pub struct ExtendedTypesS0M5 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M5` defined here
-     |
-help: a struct with a similar name exists
-     |
-1498 -     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
-1498 +     pub fn set_m5(&mut self, value: ExtendedTypesS0M5) -> Result<(), CanError> {
-     |
 
 error: invalid suffix `i32` for float literal
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1348:30
@@ -383,98 +287,74 @@ error[E0592]: duplicate definitions with name `set_m5`
 1498 |     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m5`
 
-error[E0433]: cannot find type `ExtendedS1Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedS1Index`
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:796:21
     |
 796 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
-    |
-help: an enum with a similar name exists
-    |
-796 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-796 +             0 => Ok(ExtendedS6Index::M0(ExtendedS1M0 { raw: self.raw })),
-    |
+    |                     ^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtendedS1Index`
+    |                     help: an enum with a similar name exists: `ExtendedS6Index`
 
-error[E0433]: cannot find type `ExtendedS1Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedS1Index`
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:797:21
     |
 797 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
-    |
-help: an enum with a similar name exists
-    |
-797 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
-797 +             1 => Ok(ExtendedS6Index::M1(ExtendedS1M1 { raw: self.raw })),
-    |
+    |                     ^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtendedS1Index`
+    |                     help: an enum with a similar name exists: `ExtendedS6Index`
 
-error[E0433]: cannot find type `ExtendedS1Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedS1Index`
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:798:21
     |
 798 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
-    |
-help: an enum with a similar name exists
-    |
-798 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
-798 +             2 => Ok(ExtendedS6Index::M2(ExtendedS1M2 { raw: self.raw })),
-    |
+    |                     ^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtendedS1Index`
+    |                     help: an enum with a similar name exists: `ExtendedS6Index`
 
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:870:21
     |
 870 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-870 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-870 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |
+    |                     ^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtendedS0Index`
+    |                     help: an enum with a similar name exists: `ExtendedS6Index`
 
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:871:21
     |
 871 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-871 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-871 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
-    |
+    |                     ^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtendedS0Index`
+    |                     help: an enum with a similar name exists: `ExtendedS6Index`
 
-error[E0433]: cannot find type `ExtendedS0Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:872:21
     |
 872 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
-    |
-help: an enum with a similar name exists
-    |
-872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-872 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
-    |
+    |                     ^^^^^^^^^^^^^^^
+    |                     |
+    |                     use of undeclared type `ExtendedS0Index`
+    |                     help: an enum with a similar name exists: `ExtendedS6Index`
 
-error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedTypesS11Index`
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1449:21
      |
 1449 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-     |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
-     |
-help: an enum with a similar name exists
-     |
-1449 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-1449 +                     ExtendedTypesS0Index::M0(ExtendedTypesS11M0 {
-     |
+     |                     ^^^^^^^^^^^^^^^^^^^^^
+     |                     |
+     |                     use of undeclared type `ExtendedTypesS11Index`
+     |                     help: an enum with a similar name exists: `ExtendedTypesS0Index`
 
-error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
+error[E0433]: failed to resolve: use of undeclared type `ExtendedTypesS11Index`
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1456:21
      |
 1456 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
-     |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
-     |
-help: an enum with a similar name exists
-     |
-1456 -                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
-1456 +                     ExtendedTypesS0Index::M5(ExtendedTypesS11M5 {
-     |
+     |                     ^^^^^^^^^^^^^^^^^^^^^
+     |                     |
+     |                     use of undeclared type `ExtendedTypesS11Index`
+     |                     help: an enum with a similar name exists: `ExtendedTypesS0Index`

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
@@ -21,55 +21,91 @@ error[E0422]: cannot find struct, variant or union type `ExtendedS1M0` in this s
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:796:41
     |
 796 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-    |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
+    |                                         ^^^^^^^^^^^^
 ...
 991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
+    |
+help: a struct with a similar name exists
+    |
+796 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
+796 +             0 => Ok(ExtendedS1Index::M0(ExtendedS6M0 { raw: self.raw })),
+    |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS1M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:797:41
      |
  797 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
+     |                                         ^^^^^^^^^^^^
 ...
 1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 797 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
+ 797 +             1 => Ok(ExtendedS1Index::M1(ExtendedS6M1 { raw: self.raw })),
+     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS1M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:798:41
      |
  798 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
+     |                                         ^^^^^^^^^^^^
 ...
 1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 798 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
+ 798 +             2 => Ok(ExtendedS1Index::M2(ExtendedS6M2 { raw: self.raw })),
+     |
 
 error[E0425]: cannot find type `ExtendedS1M0` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:828:37
     |
 828 |     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
+    |                                     ^^^^^^^^^^^^
 ...
 991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
+    |
+help: a struct with a similar name exists
+    |
+828 -     pub fn set_m0(&mut self, value: ExtendedS1M0) -> Result<(), CanError> {
+828 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
+    |
 
 error[E0425]: cannot find type `ExtendedS1M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:837:37
      |
  837 |     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
+     |                                     ^^^^^^^^^^^^
 ...
 1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 837 -     pub fn set_m1(&mut self, value: ExtendedS1M1) -> Result<(), CanError> {
+ 837 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
+     |
 
 error[E0425]: cannot find type `ExtendedS1M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:846:37
      |
  846 |     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
+     |                                     ^^^^^^^^^^^^
 ...
 1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 846 -     pub fn set_m2(&mut self, value: ExtendedS1M2) -> Result<(), CanError> {
+ 846 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
+     |
 
 error[E0425]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:868:36
@@ -94,55 +130,91 @@ error[E0422]: cannot find struct, variant or union type `ExtendedS0M0` in this s
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:870:41
     |
 870 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
+    |                                         ^^^^^^^^^^^^
 ...
 991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
+    |
+help: a struct with a similar name exists
+    |
+870 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+870 +             0 => Ok(ExtendedS0Index::M0(ExtendedS6M0 { raw: self.raw })),
+    |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:871:41
      |
  871 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
+     |                                         ^^^^^^^^^^^^
 ...
 1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 871 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+ 871 +             1 => Ok(ExtendedS0Index::M1(ExtendedS6M1 { raw: self.raw })),
+     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedS0M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:872:41
      |
  872 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-     |                                         ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
+     |                                         ^^^^^^^^^^^^
 ...
 1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+ 872 +             2 => Ok(ExtendedS0Index::M2(ExtendedS6M2 { raw: self.raw })),
+     |
 
 error[E0425]: cannot find type `ExtendedS0M0` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:902:37
     |
 902 |     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
-    |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M0`
+    |                                     ^^^^^^^^^^^^
 ...
 991 | pub struct ExtendedS6M0 {
     | ----------------------- similarly named struct `ExtendedS6M0` defined here
+    |
+help: a struct with a similar name exists
+    |
+902 -     pub fn set_m0(&mut self, value: ExtendedS0M0) -> Result<(), CanError> {
+902 +     pub fn set_m0(&mut self, value: ExtendedS6M0) -> Result<(), CanError> {
+    |
 
 error[E0425]: cannot find type `ExtendedS0M1` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:911:37
      |
  911 |     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M1`
+     |                                     ^^^^^^^^^^^^
 ...
 1106 | pub struct ExtendedS6M1 {
      | ----------------------- similarly named struct `ExtendedS6M1` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 911 -     pub fn set_m1(&mut self, value: ExtendedS0M1) -> Result<(), CanError> {
+ 911 +     pub fn set_m1(&mut self, value: ExtendedS6M1) -> Result<(), CanError> {
+     |
 
 error[E0425]: cannot find type `ExtendedS0M2` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:920:37
      |
  920 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedS6M2`
+     |                                     ^^^^^^^^^^^^
 ...
 1221 | pub struct ExtendedS6M2 {
      | ----------------------- similarly named struct `ExtendedS6M2` defined here
+     |
+help: a struct with a similar name exists
+     |
+ 920 -     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
+ 920 +     pub fn set_m2(&mut self, value: ExtendedS6M2) -> Result<(), CanError> {
+     |
 
 error[E0425]: cannot find type `ExtendedTypesS11Index` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1445:37
@@ -167,37 +239,61 @@ error[E0422]: cannot find struct, variant or union type `ExtendedTypesS11M0` in 
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1449:47
      |
 1449 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-     |                                               ^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedTypesS0M0`
+     |                                               ^^^^^^^^^^^^^^^^^^
 ...
 1568 | pub struct ExtendedTypesS0M0 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M0` defined here
+     |
+help: a struct with a similar name exists
+     |
+1449 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
+1449 +                     ExtendedTypesS11Index::M0(ExtendedTypesS0M0 {
+     |
 
 error[E0422]: cannot find struct, variant or union type `ExtendedTypesS11M5` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1456:47
      |
 1456 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
-     |                                               ^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedTypesS0M5`
+     |                                               ^^^^^^^^^^^^^^^^^^
 ...
 1641 | pub struct ExtendedTypesS0M5 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M5` defined here
+     |
+help: a struct with a similar name exists
+     |
+1456 -                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
+1456 +                     ExtendedTypesS11Index::M5(ExtendedTypesS0M5 {
+     |
 
 error[E0425]: cannot find type `ExtendedTypesS11M0` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1489:37
      |
 1489 |     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedTypesS0M0`
+     |                                     ^^^^^^^^^^^^^^^^^^
 ...
 1568 | pub struct ExtendedTypesS0M0 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M0` defined here
+     |
+help: a struct with a similar name exists
+     |
+1489 -     pub fn set_m0(&mut self, value: ExtendedTypesS11M0) -> Result<(), CanError> {
+1489 +     pub fn set_m0(&mut self, value: ExtendedTypesS0M0) -> Result<(), CanError> {
+     |
 
 error[E0425]: cannot find type `ExtendedTypesS11M5` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1498:37
      |
 1498 |     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
-     |                                     ^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `ExtendedTypesS0M5`
+     |                                     ^^^^^^^^^^^^^^^^^^
 ...
 1641 | pub struct ExtendedTypesS0M5 {
      | ---------------------------- similarly named struct `ExtendedTypesS0M5` defined here
+     |
+help: a struct with a similar name exists
+     |
+1498 -     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
+1498 +     pub fn set_m5(&mut self, value: ExtendedTypesS0M5) -> Result<(), CanError> {
+     |
 
 error: invalid suffix `i32` for float literal
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1348:30
@@ -287,74 +383,98 @@ error[E0592]: duplicate definitions with name `set_m5`
 1498 |     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m5`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS1Index`
+error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:796:21
     |
 796 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtendedS1Index`
-    |                     help: an enum with a similar name exists: `ExtendedS6Index`
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
+    |
+help: an enum with a similar name exists
+    |
+796 -             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
+796 +             0 => Ok(ExtendedS6Index::M0(ExtendedS1M0 { raw: self.raw })),
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS1Index`
+error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:797:21
     |
 797 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtendedS1Index`
-    |                     help: an enum with a similar name exists: `ExtendedS6Index`
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
+    |
+help: an enum with a similar name exists
+    |
+797 -             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
+797 +             1 => Ok(ExtendedS6Index::M1(ExtendedS1M1 { raw: self.raw })),
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS1Index`
+error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:798:21
     |
 798 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtendedS1Index`
-    |                     help: an enum with a similar name exists: `ExtendedS6Index`
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS1Index`
+    |
+help: an enum with a similar name exists
+    |
+798 -             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
+798 +             2 => Ok(ExtendedS6Index::M2(ExtendedS1M2 { raw: self.raw })),
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:870:21
     |
 870 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtendedS0Index`
-    |                     help: an enum with a similar name exists: `ExtendedS6Index`
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+870 -             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
+870 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:871:21
     |
 871 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtendedS0Index`
-    |                     help: an enum with a similar name exists: `ExtendedS6Index`
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+871 -             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
+871 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:872:21
     |
 872 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
-    |                     ^^^^^^^^^^^^^^^
-    |                     |
-    |                     use of undeclared type `ExtendedS0Index`
-    |                     help: an enum with a similar name exists: `ExtendedS6Index`
+    |                     ^^^^^^^^^^^^^^^ use of undeclared type `ExtendedS0Index`
+    |
+help: an enum with a similar name exists
+    |
+872 -             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
+872 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
+    |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedTypesS11Index`
+error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1449:21
      |
 1449 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
-     |                     ^^^^^^^^^^^^^^^^^^^^^
-     |                     |
-     |                     use of undeclared type `ExtendedTypesS11Index`
-     |                     help: an enum with a similar name exists: `ExtendedTypesS0Index`
+     |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
+     |
+help: an enum with a similar name exists
+     |
+1449 -                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
+1449 +                     ExtendedTypesS0Index::M0(ExtendedTypesS11M0 {
+     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedTypesS11Index`
+error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1456:21
      |
 1456 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
-     |                     ^^^^^^^^^^^^^^^^^^^^^
-     |                     |
-     |                     use of undeclared type `ExtendedTypesS11Index`
-     |                     help: an enum with a similar name exists: `ExtendedTypesS0Index`
+     |                     ^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `ExtendedTypesS11Index`
+     |
+help: an enum with a similar name exists
+     |
+1456 -                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {
+1456 +                     ExtendedTypesS0Index::M5(ExtendedTypesS11M5 {
+     |

--- a/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
@@ -321,11 +321,7 @@ impl Message1MultiplexorM8 {
     /// Set value of 'BIT_L'
     #[inline(always)]
     pub fn set_bit_l(&mut self, value: Message1BitL) -> Result<(), CanError> {
-        self.set_bit_l_raw(bool::from(value))
-    }
-    /// Set raw value of 'BIT_L'
-    #[inline(always)]
-    pub fn set_bit_l_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices.snap.rs
@@ -75,7 +75,7 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new(multiplexor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_multiplexor(multiplexor)?;
@@ -85,7 +85,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Multiplexor
+    /// Get raw value of 'Multiplexor'
     ///
     /// - Start bit: 2
     /// - Signal size: 6 bits
@@ -123,7 +123,7 @@ impl Message1 {
             }
         }
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     fn set_multiplexor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -141,7 +141,7 @@ impl Message1 {
         self.raw.view_bits_mut::<Lsb0>()[2..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m8(&mut self, value: Message1MultiplexorM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -150,7 +150,7 @@ impl Message1 {
         self.set_multiplexor(8)?;
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m24(&mut self, value: Message1MultiplexorM24) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -290,7 +290,7 @@ impl Message1MultiplexorM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_L
+    /// Get value of 'BIT_L'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -305,7 +305,7 @@ impl Message1MultiplexorM8 {
             _ => Message1BitL::_Other(self.bit_l_raw()),
         }
     }
-    /// Get raw value of BIT_L
+    /// Get raw value of 'BIT_L'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -318,14 +318,19 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_L
+    /// Set value of 'BIT_L'
     #[inline(always)]
-    pub fn set_bit_l(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_bit_l(&mut self, value: Message1BitL) -> Result<(), CanError> {
+        self.set_bit_l_raw(bool::from(value))
+    }
+    /// Set raw value of 'BIT_L'
+    #[inline(always)]
+    pub fn set_bit_l_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// BIT_G
+    /// Get value of 'BIT_G'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -335,7 +340,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_g(&self) -> bool {
         self.bit_g_raw()
     }
-    /// Get raw value of BIT_G
+    /// Get raw value of 'BIT_G'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -348,14 +353,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_G
+    /// Set value of 'BIT_G'
     #[inline(always)]
     pub fn set_bit_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// BIT_C
+    /// Get value of 'BIT_C'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -365,7 +370,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_c(&self) -> bool {
         self.bit_c_raw()
     }
-    /// Get raw value of BIT_C
+    /// Get raw value of 'BIT_C'
     ///
     /// - Start bit: 19
     /// - Signal size: 1 bits
@@ -378,14 +383,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[19..20].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_C
+    /// Set value of 'BIT_C'
     #[inline(always)]
     pub fn set_bit_c(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[19..20].store_le(value);
         Ok(())
     }
-    /// BIT_J
+    /// Get value of 'BIT_J'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -395,7 +400,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_j(&self) -> bool {
         self.bit_j_raw()
     }
-    /// Get raw value of BIT_J
+    /// Get raw value of 'BIT_J'
     ///
     /// - Start bit: 18
     /// - Signal size: 1 bits
@@ -408,7 +413,7 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[18..19].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_J
+    /// Set value of 'BIT_J'
     #[inline(always)]
     pub fn set_bit_j(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -442,7 +447,7 @@ impl Message1MultiplexorM24 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_K
+    /// Get value of 'BIT_K'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -452,7 +457,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_k(&self) -> bool {
         self.bit_k_raw()
     }
-    /// Get raw value of BIT_K
+    /// Get raw value of 'BIT_K'
     ///
     /// - Start bit: 28
     /// - Signal size: 1 bits
@@ -465,14 +470,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[28..29].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_K
+    /// Set value of 'BIT_K'
     #[inline(always)]
     pub fn set_bit_k(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[28..29].store_le(value);
         Ok(())
     }
-    /// BIT_D
+    /// Get value of 'BIT_D'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -482,7 +487,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_d(&self) -> bool {
         self.bit_d_raw()
     }
-    /// Get raw value of BIT_D
+    /// Get raw value of 'BIT_D'
     ///
     /// - Start bit: 32
     /// - Signal size: 1 bits
@@ -495,14 +500,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[32..33].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_D
+    /// Set value of 'BIT_D'
     #[inline(always)]
     pub fn set_bit_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[32..33].store_le(value);
         Ok(())
     }
-    /// BIT_B
+    /// Get value of 'BIT_B'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -512,7 +517,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_b(&self) -> bool {
         self.bit_b_raw()
     }
-    /// Get raw value of BIT_B
+    /// Get raw value of 'BIT_B'
     ///
     /// - Start bit: 33
     /// - Signal size: 1 bits
@@ -525,14 +530,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[33..34].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_B
+    /// Set value of 'BIT_B'
     #[inline(always)]
     pub fn set_bit_b(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[33..34].store_le(value);
         Ok(())
     }
-    /// BIT_F
+    /// Get value of 'BIT_F'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -542,7 +547,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_f(&self) -> bool {
         self.bit_f_raw()
     }
-    /// Get raw value of BIT_F
+    /// Get raw value of 'BIT_F'
     ///
     /// - Start bit: 39
     /// - Signal size: 1 bits
@@ -555,14 +560,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[39..40].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_F
+    /// Set value of 'BIT_F'
     #[inline(always)]
     pub fn set_bit_f(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[39..40].store_le(value);
         Ok(())
     }
-    /// BIT_H
+    /// Get value of 'BIT_H'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -572,7 +577,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_h(&self) -> bool {
         self.bit_h_raw()
     }
-    /// Get raw value of BIT_H
+    /// Get raw value of 'BIT_H'
     ///
     /// - Start bit: 38
     /// - Signal size: 1 bits
@@ -585,14 +590,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[38..39].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_H
+    /// Set value of 'BIT_H'
     #[inline(always)]
     pub fn set_bit_h(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[38..39].store_le(value);
         Ok(())
     }
-    /// BIT_E
+    /// Get value of 'BIT_E'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -602,7 +607,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_e(&self) -> bool {
         self.bit_e_raw()
     }
-    /// Get raw value of BIT_E
+    /// Get raw value of 'BIT_E'
     ///
     /// - Start bit: 29
     /// - Signal size: 1 bits
@@ -615,14 +620,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[29..30].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_E
+    /// Set value of 'BIT_E'
     #[inline(always)]
     pub fn set_bit_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[29..30].store_le(value);
         Ok(())
     }
-    /// BIT_A
+    /// Get value of 'BIT_A'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -632,7 +637,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_a(&self) -> bool {
         self.bit_a_raw()
     }
-    /// Get raw value of BIT_A
+    /// Get raw value of 'BIT_A'
     ///
     /// - Start bit: 26
     /// - Signal size: 1 bits
@@ -645,7 +650,7 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[26..27].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_A
+    /// Set value of 'BIT_A'
     #[inline(always)]
     pub fn set_bit_a(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -677,7 +682,7 @@ impl Message2 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
-    /// Construct new Message2 from values
+    /// Construct new 'Message2' from values
     pub fn new(multiplexor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_multiplexor(multiplexor)?;
@@ -687,7 +692,7 @@ impl Message2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Multiplexor
+    /// Get raw value of 'Multiplexor'
     ///
     /// - Start bit: 2
     /// - Signal size: 6 bits
@@ -725,7 +730,7 @@ impl Message2 {
             }
         }
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     fn set_multiplexor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -743,7 +748,7 @@ impl Message2 {
         self.raw.view_bits_mut::<Lsb0>()[2..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m8(&mut self, value: Message2MultiplexorM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -752,7 +757,7 @@ impl Message2 {
         self.set_multiplexor(8)?;
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m24(&mut self, value: Message2MultiplexorM24) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -869,7 +874,7 @@ impl Message2MultiplexorM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_L
+    /// Get value of 'BIT_L'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -879,7 +884,7 @@ impl Message2MultiplexorM8 {
     pub fn bit_l(&self) -> bool {
         self.bit_l_raw()
     }
-    /// Get raw value of BIT_L
+    /// Get raw value of 'BIT_L'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -892,14 +897,14 @@ impl Message2MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_L
+    /// Set value of 'BIT_L'
     #[inline(always)]
     pub fn set_bit_l(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// BIT_G
+    /// Get value of 'BIT_G'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -909,7 +914,7 @@ impl Message2MultiplexorM8 {
     pub fn bit_g(&self) -> bool {
         self.bit_g_raw()
     }
-    /// Get raw value of BIT_G
+    /// Get raw value of 'BIT_G'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -922,14 +927,14 @@ impl Message2MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_G
+    /// Set value of 'BIT_G'
     #[inline(always)]
     pub fn set_bit_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// BIT_C
+    /// Get value of 'BIT_C'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -939,7 +944,7 @@ impl Message2MultiplexorM8 {
     pub fn bit_c(&self) -> bool {
         self.bit_c_raw()
     }
-    /// Get raw value of BIT_C
+    /// Get raw value of 'BIT_C'
     ///
     /// - Start bit: 19
     /// - Signal size: 1 bits
@@ -952,14 +957,14 @@ impl Message2MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[19..20].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_C
+    /// Set value of 'BIT_C'
     #[inline(always)]
     pub fn set_bit_c(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[19..20].store_le(value);
         Ok(())
     }
-    /// BIT_J
+    /// Get value of 'BIT_J'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -969,7 +974,7 @@ impl Message2MultiplexorM8 {
     pub fn bit_j(&self) -> bool {
         self.bit_j_raw()
     }
-    /// Get raw value of BIT_J
+    /// Get raw value of 'BIT_J'
     ///
     /// - Start bit: 18
     /// - Signal size: 1 bits
@@ -982,7 +987,7 @@ impl Message2MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[18..19].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_J
+    /// Set value of 'BIT_J'
     #[inline(always)]
     pub fn set_bit_j(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -1016,7 +1021,7 @@ impl Message2MultiplexorM24 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_K
+    /// Get value of 'BIT_K'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1026,7 +1031,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_k(&self) -> bool {
         self.bit_k_raw()
     }
-    /// Get raw value of BIT_K
+    /// Get raw value of 'BIT_K'
     ///
     /// - Start bit: 28
     /// - Signal size: 1 bits
@@ -1039,14 +1044,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[28..29].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_K
+    /// Set value of 'BIT_K'
     #[inline(always)]
     pub fn set_bit_k(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[28..29].store_le(value);
         Ok(())
     }
-    /// BIT_D
+    /// Get value of 'BIT_D'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1056,7 +1061,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_d(&self) -> bool {
         self.bit_d_raw()
     }
-    /// Get raw value of BIT_D
+    /// Get raw value of 'BIT_D'
     ///
     /// - Start bit: 32
     /// - Signal size: 1 bits
@@ -1069,14 +1074,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[32..33].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_D
+    /// Set value of 'BIT_D'
     #[inline(always)]
     pub fn set_bit_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[32..33].store_le(value);
         Ok(())
     }
-    /// BIT_B
+    /// Get value of 'BIT_B'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1086,7 +1091,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_b(&self) -> bool {
         self.bit_b_raw()
     }
-    /// Get raw value of BIT_B
+    /// Get raw value of 'BIT_B'
     ///
     /// - Start bit: 33
     /// - Signal size: 1 bits
@@ -1099,14 +1104,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[33..34].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_B
+    /// Set value of 'BIT_B'
     #[inline(always)]
     pub fn set_bit_b(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[33..34].store_le(value);
         Ok(())
     }
-    /// BIT_F
+    /// Get value of 'BIT_F'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1116,7 +1121,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_f(&self) -> bool {
         self.bit_f_raw()
     }
-    /// Get raw value of BIT_F
+    /// Get raw value of 'BIT_F'
     ///
     /// - Start bit: 39
     /// - Signal size: 1 bits
@@ -1129,14 +1134,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[39..40].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_F
+    /// Set value of 'BIT_F'
     #[inline(always)]
     pub fn set_bit_f(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[39..40].store_le(value);
         Ok(())
     }
-    /// BIT_H
+    /// Get value of 'BIT_H'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1146,7 +1151,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_h(&self) -> bool {
         self.bit_h_raw()
     }
-    /// Get raw value of BIT_H
+    /// Get raw value of 'BIT_H'
     ///
     /// - Start bit: 38
     /// - Signal size: 1 bits
@@ -1159,14 +1164,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[38..39].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_H
+    /// Set value of 'BIT_H'
     #[inline(always)]
     pub fn set_bit_h(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[38..39].store_le(value);
         Ok(())
     }
-    /// BIT_E
+    /// Get value of 'BIT_E'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1176,7 +1181,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_e(&self) -> bool {
         self.bit_e_raw()
     }
-    /// Get raw value of BIT_E
+    /// Get raw value of 'BIT_E'
     ///
     /// - Start bit: 29
     /// - Signal size: 1 bits
@@ -1189,14 +1194,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[29..30].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_E
+    /// Set value of 'BIT_E'
     #[inline(always)]
     pub fn set_bit_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[29..30].store_le(value);
         Ok(())
     }
-    /// BIT_A
+    /// Get value of 'BIT_A'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1206,7 +1211,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_a(&self) -> bool {
         self.bit_a_raw()
     }
-    /// Get raw value of BIT_A
+    /// Get raw value of 'BIT_A'
     ///
     /// - Start bit: 26
     /// - Signal size: 1 bits
@@ -1219,7 +1224,7 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[26..27].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_A
+    /// Set value of 'BIT_A'
     #[inline(always)]
     pub fn set_bit_a(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -1251,7 +1256,7 @@ impl Message3 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
-    /// Construct new Message3 from values
+    /// Construct new 'Message3' from values
     pub fn new(multiplexor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_multiplexor(multiplexor)?;
@@ -1261,7 +1266,7 @@ impl Message3 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Multiplexor
+    /// Get raw value of 'Multiplexor'
     ///
     /// - Start bit: 2
     /// - Signal size: 6 bits
@@ -1292,7 +1297,7 @@ impl Message3 {
             }
         }
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     fn set_multiplexor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -1310,7 +1315,7 @@ impl Message3 {
         self.raw.view_bits_mut::<Lsb0>()[2..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m8(&mut self, value: Message3MultiplexorM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -1397,7 +1402,7 @@ impl Message3MultiplexorM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_L
+    /// Get value of 'BIT_L'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1407,7 +1412,7 @@ impl Message3MultiplexorM8 {
     pub fn bit_l(&self) -> bool {
         self.bit_l_raw()
     }
-    /// Get raw value of BIT_L
+    /// Get raw value of 'BIT_L'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -1420,14 +1425,14 @@ impl Message3MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_L
+    /// Set value of 'BIT_L'
     #[inline(always)]
     pub fn set_bit_l(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// BIT_G
+    /// Get value of 'BIT_G'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1437,7 +1442,7 @@ impl Message3MultiplexorM8 {
     pub fn bit_g(&self) -> bool {
         self.bit_g_raw()
     }
-    /// Get raw value of BIT_G
+    /// Get raw value of 'BIT_G'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -1450,14 +1455,14 @@ impl Message3MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_G
+    /// Set value of 'BIT_G'
     #[inline(always)]
     pub fn set_bit_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// BIT_C
+    /// Get value of 'BIT_C'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1467,7 +1472,7 @@ impl Message3MultiplexorM8 {
     pub fn bit_c(&self) -> bool {
         self.bit_c_raw()
     }
-    /// Get raw value of BIT_C
+    /// Get raw value of 'BIT_C'
     ///
     /// - Start bit: 19
     /// - Signal size: 1 bits
@@ -1480,14 +1485,14 @@ impl Message3MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[19..20].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_C
+    /// Set value of 'BIT_C'
     #[inline(always)]
     pub fn set_bit_c(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[19..20].store_le(value);
         Ok(())
     }
-    /// BIT_J
+    /// Get value of 'BIT_J'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1497,7 +1502,7 @@ impl Message3MultiplexorM8 {
     pub fn bit_j(&self) -> bool {
         self.bit_j_raw()
     }
-    /// Get raw value of BIT_J
+    /// Get raw value of 'BIT_J'
     ///
     /// - Start bit: 18
     /// - Signal size: 1 bits
@@ -1510,7 +1515,7 @@ impl Message3MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[18..19].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_J
+    /// Set value of 'BIT_J'
     #[inline(always)]
     pub fn set_bit_j(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;

--- a/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
@@ -321,11 +321,7 @@ impl Message1MultiplexorM8 {
     /// Set value of 'BIT_L'
     #[inline(always)]
     pub fn set_bit_l(&mut self, value: Message1BitL) -> Result<(), CanError> {
-        self.set_bit_l_raw(bool::from(value))
-    }
-    /// Set raw value of 'BIT_L'
-    #[inline(always)]
-    pub fn set_bit_l_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())

--- a/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_choices_dumped.snap.rs
@@ -75,7 +75,7 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new(multiplexor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_multiplexor(multiplexor)?;
@@ -85,7 +85,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Multiplexor
+    /// Get raw value of 'Multiplexor'
     ///
     /// - Start bit: 2
     /// - Signal size: 6 bits
@@ -123,7 +123,7 @@ impl Message1 {
             }
         }
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     fn set_multiplexor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -141,7 +141,7 @@ impl Message1 {
         self.raw.view_bits_mut::<Lsb0>()[2..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m8(&mut self, value: Message1MultiplexorM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -150,7 +150,7 @@ impl Message1 {
         self.set_multiplexor(8)?;
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m24(&mut self, value: Message1MultiplexorM24) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -290,7 +290,7 @@ impl Message1MultiplexorM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_L
+    /// Get value of 'BIT_L'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -305,7 +305,7 @@ impl Message1MultiplexorM8 {
             _ => Message1BitL::_Other(self.bit_l_raw()),
         }
     }
-    /// Get raw value of BIT_L
+    /// Get raw value of 'BIT_L'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -318,14 +318,19 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_L
+    /// Set value of 'BIT_L'
     #[inline(always)]
-    pub fn set_bit_l(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_bit_l(&mut self, value: Message1BitL) -> Result<(), CanError> {
+        self.set_bit_l_raw(bool::from(value))
+    }
+    /// Set raw value of 'BIT_L'
+    #[inline(always)]
+    pub fn set_bit_l_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// BIT_G
+    /// Get value of 'BIT_G'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -335,7 +340,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_g(&self) -> bool {
         self.bit_g_raw()
     }
-    /// Get raw value of BIT_G
+    /// Get raw value of 'BIT_G'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -348,14 +353,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_G
+    /// Set value of 'BIT_G'
     #[inline(always)]
     pub fn set_bit_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// BIT_C
+    /// Get value of 'BIT_C'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -365,7 +370,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_c(&self) -> bool {
         self.bit_c_raw()
     }
-    /// Get raw value of BIT_C
+    /// Get raw value of 'BIT_C'
     ///
     /// - Start bit: 19
     /// - Signal size: 1 bits
@@ -378,14 +383,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[19..20].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_C
+    /// Set value of 'BIT_C'
     #[inline(always)]
     pub fn set_bit_c(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[19..20].store_le(value);
         Ok(())
     }
-    /// BIT_J
+    /// Get value of 'BIT_J'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -395,7 +400,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_j(&self) -> bool {
         self.bit_j_raw()
     }
-    /// Get raw value of BIT_J
+    /// Get raw value of 'BIT_J'
     ///
     /// - Start bit: 18
     /// - Signal size: 1 bits
@@ -408,7 +413,7 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[18..19].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_J
+    /// Set value of 'BIT_J'
     #[inline(always)]
     pub fn set_bit_j(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -442,7 +447,7 @@ impl Message1MultiplexorM24 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_F
+    /// Get value of 'BIT_F'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -452,7 +457,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_f(&self) -> bool {
         self.bit_f_raw()
     }
-    /// Get raw value of BIT_F
+    /// Get raw value of 'BIT_F'
     ///
     /// - Start bit: 39
     /// - Signal size: 1 bits
@@ -465,14 +470,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[39..40].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_F
+    /// Set value of 'BIT_F'
     #[inline(always)]
     pub fn set_bit_f(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[39..40].store_le(value);
         Ok(())
     }
-    /// BIT_H
+    /// Get value of 'BIT_H'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -482,7 +487,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_h(&self) -> bool {
         self.bit_h_raw()
     }
-    /// Get raw value of BIT_H
+    /// Get raw value of 'BIT_H'
     ///
     /// - Start bit: 38
     /// - Signal size: 1 bits
@@ -495,14 +500,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[38..39].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_H
+    /// Set value of 'BIT_H'
     #[inline(always)]
     pub fn set_bit_h(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[38..39].store_le(value);
         Ok(())
     }
-    /// BIT_B
+    /// Get value of 'BIT_B'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -512,7 +517,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_b(&self) -> bool {
         self.bit_b_raw()
     }
-    /// Get raw value of BIT_B
+    /// Get raw value of 'BIT_B'
     ///
     /// - Start bit: 33
     /// - Signal size: 1 bits
@@ -525,14 +530,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[33..34].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_B
+    /// Set value of 'BIT_B'
     #[inline(always)]
     pub fn set_bit_b(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[33..34].store_le(value);
         Ok(())
     }
-    /// BIT_D
+    /// Get value of 'BIT_D'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -542,7 +547,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_d(&self) -> bool {
         self.bit_d_raw()
     }
-    /// Get raw value of BIT_D
+    /// Get raw value of 'BIT_D'
     ///
     /// - Start bit: 32
     /// - Signal size: 1 bits
@@ -555,14 +560,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[32..33].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_D
+    /// Set value of 'BIT_D'
     #[inline(always)]
     pub fn set_bit_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[32..33].store_le(value);
         Ok(())
     }
-    /// BIT_E
+    /// Get value of 'BIT_E'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -572,7 +577,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_e(&self) -> bool {
         self.bit_e_raw()
     }
-    /// Get raw value of BIT_E
+    /// Get raw value of 'BIT_E'
     ///
     /// - Start bit: 29
     /// - Signal size: 1 bits
@@ -585,14 +590,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[29..30].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_E
+    /// Set value of 'BIT_E'
     #[inline(always)]
     pub fn set_bit_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[29..30].store_le(value);
         Ok(())
     }
-    /// BIT_K
+    /// Get value of 'BIT_K'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -602,7 +607,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_k(&self) -> bool {
         self.bit_k_raw()
     }
-    /// Get raw value of BIT_K
+    /// Get raw value of 'BIT_K'
     ///
     /// - Start bit: 28
     /// - Signal size: 1 bits
@@ -615,14 +620,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[28..29].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_K
+    /// Set value of 'BIT_K'
     #[inline(always)]
     pub fn set_bit_k(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[28..29].store_le(value);
         Ok(())
     }
-    /// BIT_A
+    /// Get value of 'BIT_A'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -632,7 +637,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_a(&self) -> bool {
         self.bit_a_raw()
     }
-    /// Get raw value of BIT_A
+    /// Get raw value of 'BIT_A'
     ///
     /// - Start bit: 26
     /// - Signal size: 1 bits
@@ -645,7 +650,7 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[26..27].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_A
+    /// Set value of 'BIT_A'
     #[inline(always)]
     pub fn set_bit_a(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -677,7 +682,7 @@ impl Message2 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
-    /// Construct new Message2 from values
+    /// Construct new 'Message2' from values
     pub fn new(multiplexor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_multiplexor(multiplexor)?;
@@ -687,7 +692,7 @@ impl Message2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Multiplexor
+    /// Get raw value of 'Multiplexor'
     ///
     /// - Start bit: 2
     /// - Signal size: 6 bits
@@ -725,7 +730,7 @@ impl Message2 {
             }
         }
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     fn set_multiplexor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -743,7 +748,7 @@ impl Message2 {
         self.raw.view_bits_mut::<Lsb0>()[2..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m8(&mut self, value: Message2MultiplexorM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -752,7 +757,7 @@ impl Message2 {
         self.set_multiplexor(8)?;
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m24(&mut self, value: Message2MultiplexorM24) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -869,7 +874,7 @@ impl Message2MultiplexorM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_L
+    /// Get value of 'BIT_L'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -879,7 +884,7 @@ impl Message2MultiplexorM8 {
     pub fn bit_l(&self) -> bool {
         self.bit_l_raw()
     }
-    /// Get raw value of BIT_L
+    /// Get raw value of 'BIT_L'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -892,14 +897,14 @@ impl Message2MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_L
+    /// Set value of 'BIT_L'
     #[inline(always)]
     pub fn set_bit_l(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// BIT_G
+    /// Get value of 'BIT_G'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -909,7 +914,7 @@ impl Message2MultiplexorM8 {
     pub fn bit_g(&self) -> bool {
         self.bit_g_raw()
     }
-    /// Get raw value of BIT_G
+    /// Get raw value of 'BIT_G'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -922,14 +927,14 @@ impl Message2MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_G
+    /// Set value of 'BIT_G'
     #[inline(always)]
     pub fn set_bit_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// BIT_C
+    /// Get value of 'BIT_C'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -939,7 +944,7 @@ impl Message2MultiplexorM8 {
     pub fn bit_c(&self) -> bool {
         self.bit_c_raw()
     }
-    /// Get raw value of BIT_C
+    /// Get raw value of 'BIT_C'
     ///
     /// - Start bit: 19
     /// - Signal size: 1 bits
@@ -952,14 +957,14 @@ impl Message2MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[19..20].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_C
+    /// Set value of 'BIT_C'
     #[inline(always)]
     pub fn set_bit_c(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[19..20].store_le(value);
         Ok(())
     }
-    /// BIT_J
+    /// Get value of 'BIT_J'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -969,7 +974,7 @@ impl Message2MultiplexorM8 {
     pub fn bit_j(&self) -> bool {
         self.bit_j_raw()
     }
-    /// Get raw value of BIT_J
+    /// Get raw value of 'BIT_J'
     ///
     /// - Start bit: 18
     /// - Signal size: 1 bits
@@ -982,7 +987,7 @@ impl Message2MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[18..19].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_J
+    /// Set value of 'BIT_J'
     #[inline(always)]
     pub fn set_bit_j(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -1016,7 +1021,7 @@ impl Message2MultiplexorM24 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_F
+    /// Get value of 'BIT_F'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1026,7 +1031,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_f(&self) -> bool {
         self.bit_f_raw()
     }
-    /// Get raw value of BIT_F
+    /// Get raw value of 'BIT_F'
     ///
     /// - Start bit: 39
     /// - Signal size: 1 bits
@@ -1039,14 +1044,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[39..40].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_F
+    /// Set value of 'BIT_F'
     #[inline(always)]
     pub fn set_bit_f(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[39..40].store_le(value);
         Ok(())
     }
-    /// BIT_H
+    /// Get value of 'BIT_H'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1056,7 +1061,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_h(&self) -> bool {
         self.bit_h_raw()
     }
-    /// Get raw value of BIT_H
+    /// Get raw value of 'BIT_H'
     ///
     /// - Start bit: 38
     /// - Signal size: 1 bits
@@ -1069,14 +1074,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[38..39].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_H
+    /// Set value of 'BIT_H'
     #[inline(always)]
     pub fn set_bit_h(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[38..39].store_le(value);
         Ok(())
     }
-    /// BIT_B
+    /// Get value of 'BIT_B'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1086,7 +1091,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_b(&self) -> bool {
         self.bit_b_raw()
     }
-    /// Get raw value of BIT_B
+    /// Get raw value of 'BIT_B'
     ///
     /// - Start bit: 33
     /// - Signal size: 1 bits
@@ -1099,14 +1104,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[33..34].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_B
+    /// Set value of 'BIT_B'
     #[inline(always)]
     pub fn set_bit_b(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[33..34].store_le(value);
         Ok(())
     }
-    /// BIT_D
+    /// Get value of 'BIT_D'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1116,7 +1121,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_d(&self) -> bool {
         self.bit_d_raw()
     }
-    /// Get raw value of BIT_D
+    /// Get raw value of 'BIT_D'
     ///
     /// - Start bit: 32
     /// - Signal size: 1 bits
@@ -1129,14 +1134,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[32..33].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_D
+    /// Set value of 'BIT_D'
     #[inline(always)]
     pub fn set_bit_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[32..33].store_le(value);
         Ok(())
     }
-    /// BIT_E
+    /// Get value of 'BIT_E'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1146,7 +1151,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_e(&self) -> bool {
         self.bit_e_raw()
     }
-    /// Get raw value of BIT_E
+    /// Get raw value of 'BIT_E'
     ///
     /// - Start bit: 29
     /// - Signal size: 1 bits
@@ -1159,14 +1164,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[29..30].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_E
+    /// Set value of 'BIT_E'
     #[inline(always)]
     pub fn set_bit_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[29..30].store_le(value);
         Ok(())
     }
-    /// BIT_K
+    /// Get value of 'BIT_K'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1176,7 +1181,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_k(&self) -> bool {
         self.bit_k_raw()
     }
-    /// Get raw value of BIT_K
+    /// Get raw value of 'BIT_K'
     ///
     /// - Start bit: 28
     /// - Signal size: 1 bits
@@ -1189,14 +1194,14 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[28..29].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_K
+    /// Set value of 'BIT_K'
     #[inline(always)]
     pub fn set_bit_k(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[28..29].store_le(value);
         Ok(())
     }
-    /// BIT_A
+    /// Get value of 'BIT_A'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1206,7 +1211,7 @@ impl Message2MultiplexorM24 {
     pub fn bit_a(&self) -> bool {
         self.bit_a_raw()
     }
-    /// Get raw value of BIT_A
+    /// Get raw value of 'BIT_A'
     ///
     /// - Start bit: 26
     /// - Signal size: 1 bits
@@ -1219,7 +1224,7 @@ impl Message2MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[26..27].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_A
+    /// Set value of 'BIT_A'
     #[inline(always)]
     pub fn set_bit_a(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -1251,7 +1256,7 @@ impl Message3 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
-    /// Construct new Message3 from values
+    /// Construct new 'Message3' from values
     pub fn new(multiplexor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_multiplexor(multiplexor)?;
@@ -1261,7 +1266,7 @@ impl Message3 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Multiplexor
+    /// Get raw value of 'Multiplexor'
     ///
     /// - Start bit: 2
     /// - Signal size: 6 bits
@@ -1292,7 +1297,7 @@ impl Message3 {
             }
         }
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     fn set_multiplexor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -1310,7 +1315,7 @@ impl Message3 {
         self.raw.view_bits_mut::<Lsb0>()[2..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m8(&mut self, value: Message3MultiplexorM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -1397,7 +1402,7 @@ impl Message3MultiplexorM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_L
+    /// Get value of 'BIT_L'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1407,7 +1412,7 @@ impl Message3MultiplexorM8 {
     pub fn bit_l(&self) -> bool {
         self.bit_l_raw()
     }
-    /// Get raw value of BIT_L
+    /// Get raw value of 'BIT_L'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -1420,14 +1425,14 @@ impl Message3MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_L
+    /// Set value of 'BIT_L'
     #[inline(always)]
     pub fn set_bit_l(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// BIT_G
+    /// Get value of 'BIT_G'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1437,7 +1442,7 @@ impl Message3MultiplexorM8 {
     pub fn bit_g(&self) -> bool {
         self.bit_g_raw()
     }
-    /// Get raw value of BIT_G
+    /// Get raw value of 'BIT_G'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -1450,14 +1455,14 @@ impl Message3MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_G
+    /// Set value of 'BIT_G'
     #[inline(always)]
     pub fn set_bit_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// BIT_C
+    /// Get value of 'BIT_C'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1467,7 +1472,7 @@ impl Message3MultiplexorM8 {
     pub fn bit_c(&self) -> bool {
         self.bit_c_raw()
     }
-    /// Get raw value of BIT_C
+    /// Get raw value of 'BIT_C'
     ///
     /// - Start bit: 19
     /// - Signal size: 1 bits
@@ -1480,14 +1485,14 @@ impl Message3MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[19..20].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_C
+    /// Set value of 'BIT_C'
     #[inline(always)]
     pub fn set_bit_c(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[19..20].store_le(value);
         Ok(())
     }
-    /// BIT_J
+    /// Get value of 'BIT_J'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1497,7 +1502,7 @@ impl Message3MultiplexorM8 {
     pub fn bit_j(&self) -> bool {
         self.bit_j_raw()
     }
-    /// Get raw value of BIT_J
+    /// Get raw value of 'BIT_J'
     ///
     /// - Start bit: 18
     /// - Signal size: 1 bits
@@ -1510,7 +1515,7 @@ impl Message3MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[18..19].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_J
+    /// Set value of 'BIT_J'
     #[inline(always)]
     pub fn set_bit_j(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;

--- a/tests-snapshots/dbc-cantools/multiplex_dumped.snap.rs
+++ b/tests-snapshots/dbc-cantools/multiplex_dumped.snap.rs
@@ -69,7 +69,7 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const MULTIPLEXOR_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_MAX: u8 = 0_u8;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new(multiplexor: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_multiplexor(multiplexor)?;
@@ -79,7 +79,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Multiplexor
+    /// Get raw value of 'Multiplexor'
     ///
     /// - Start bit: 2
     /// - Signal size: 6 bits
@@ -117,7 +117,7 @@ impl Message1 {
             }
         }
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     fn set_multiplexor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -135,7 +135,7 @@ impl Message1 {
         self.raw.view_bits_mut::<Lsb0>()[2..8].store_le(value);
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m8(&mut self, value: Message1MultiplexorM8) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -144,7 +144,7 @@ impl Message1 {
         self.set_multiplexor(8)?;
         Ok(())
     }
-    /// Set value of Multiplexor
+    /// Set value of 'Multiplexor'
     #[inline(always)]
     pub fn set_m24(&mut self, value: Message1MultiplexorM24) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -232,7 +232,7 @@ impl Message1MultiplexorM8 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_L
+    /// Get value of 'BIT_L'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -242,7 +242,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_l(&self) -> bool {
         self.bit_l_raw()
     }
-    /// Get raw value of BIT_L
+    /// Get raw value of 'BIT_L'
     ///
     /// - Start bit: 24
     /// - Signal size: 1 bits
@@ -255,14 +255,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[24..25].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_L
+    /// Set value of 'BIT_L'
     #[inline(always)]
     pub fn set_bit_l(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[24..25].store_le(value);
         Ok(())
     }
-    /// BIT_G
+    /// Get value of 'BIT_G'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -272,7 +272,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_g(&self) -> bool {
         self.bit_g_raw()
     }
-    /// Get raw value of BIT_G
+    /// Get raw value of 'BIT_G'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -285,14 +285,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_G
+    /// Set value of 'BIT_G'
     #[inline(always)]
     pub fn set_bit_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// BIT_C
+    /// Get value of 'BIT_C'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -302,7 +302,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_c(&self) -> bool {
         self.bit_c_raw()
     }
-    /// Get raw value of BIT_C
+    /// Get raw value of 'BIT_C'
     ///
     /// - Start bit: 19
     /// - Signal size: 1 bits
@@ -315,14 +315,14 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[19..20].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_C
+    /// Set value of 'BIT_C'
     #[inline(always)]
     pub fn set_bit_c(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[19..20].store_le(value);
         Ok(())
     }
-    /// BIT_J
+    /// Get value of 'BIT_J'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -332,7 +332,7 @@ impl Message1MultiplexorM8 {
     pub fn bit_j(&self) -> bool {
         self.bit_j_raw()
     }
-    /// Get raw value of BIT_J
+    /// Get raw value of 'BIT_J'
     ///
     /// - Start bit: 18
     /// - Signal size: 1 bits
@@ -345,7 +345,7 @@ impl Message1MultiplexorM8 {
         let signal = self.raw.view_bits::<Lsb0>()[18..19].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_J
+    /// Set value of 'BIT_J'
     #[inline(always)]
     pub fn set_bit_j(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -379,7 +379,7 @@ impl Message1MultiplexorM24 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// BIT_F
+    /// Get value of 'BIT_F'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -389,7 +389,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_f(&self) -> bool {
         self.bit_f_raw()
     }
-    /// Get raw value of BIT_F
+    /// Get raw value of 'BIT_F'
     ///
     /// - Start bit: 39
     /// - Signal size: 1 bits
@@ -402,14 +402,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[39..40].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_F
+    /// Set value of 'BIT_F'
     #[inline(always)]
     pub fn set_bit_f(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[39..40].store_le(value);
         Ok(())
     }
-    /// BIT_H
+    /// Get value of 'BIT_H'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -419,7 +419,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_h(&self) -> bool {
         self.bit_h_raw()
     }
-    /// Get raw value of BIT_H
+    /// Get raw value of 'BIT_H'
     ///
     /// - Start bit: 38
     /// - Signal size: 1 bits
@@ -432,14 +432,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[38..39].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_H
+    /// Set value of 'BIT_H'
     #[inline(always)]
     pub fn set_bit_h(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[38..39].store_le(value);
         Ok(())
     }
-    /// BIT_B
+    /// Get value of 'BIT_B'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -449,7 +449,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_b(&self) -> bool {
         self.bit_b_raw()
     }
-    /// Get raw value of BIT_B
+    /// Get raw value of 'BIT_B'
     ///
     /// - Start bit: 33
     /// - Signal size: 1 bits
@@ -462,14 +462,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[33..34].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_B
+    /// Set value of 'BIT_B'
     #[inline(always)]
     pub fn set_bit_b(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[33..34].store_le(value);
         Ok(())
     }
-    /// BIT_D
+    /// Get value of 'BIT_D'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -479,7 +479,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_d(&self) -> bool {
         self.bit_d_raw()
     }
-    /// Get raw value of BIT_D
+    /// Get raw value of 'BIT_D'
     ///
     /// - Start bit: 32
     /// - Signal size: 1 bits
@@ -492,14 +492,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[32..33].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_D
+    /// Set value of 'BIT_D'
     #[inline(always)]
     pub fn set_bit_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[32..33].store_le(value);
         Ok(())
     }
-    /// BIT_E
+    /// Get value of 'BIT_E'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -509,7 +509,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_e(&self) -> bool {
         self.bit_e_raw()
     }
-    /// Get raw value of BIT_E
+    /// Get raw value of 'BIT_E'
     ///
     /// - Start bit: 29
     /// - Signal size: 1 bits
@@ -522,14 +522,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[29..30].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_E
+    /// Set value of 'BIT_E'
     #[inline(always)]
     pub fn set_bit_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[29..30].store_le(value);
         Ok(())
     }
-    /// BIT_K
+    /// Get value of 'BIT_K'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -539,7 +539,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_k(&self) -> bool {
         self.bit_k_raw()
     }
-    /// Get raw value of BIT_K
+    /// Get raw value of 'BIT_K'
     ///
     /// - Start bit: 28
     /// - Signal size: 1 bits
@@ -552,14 +552,14 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[28..29].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_K
+    /// Set value of 'BIT_K'
     #[inline(always)]
     pub fn set_bit_k(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[28..29].store_le(value);
         Ok(())
     }
-    /// BIT_A
+    /// Get value of 'BIT_A'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -569,7 +569,7 @@ impl Message1MultiplexorM24 {
     pub fn bit_a(&self) -> bool {
         self.bit_a_raw()
     }
-    /// Get raw value of BIT_A
+    /// Get raw value of 'BIT_A'
     ///
     /// - Start bit: 26
     /// - Signal size: 1 bits
@@ -582,7 +582,7 @@ impl Message1MultiplexorM24 {
         let signal = self.raw.view_bits::<Lsb0>()[26..27].load_le::<u8>();
         signal == 1
     }
-    /// Set value of BIT_A
+    /// Set value of 'BIT_A'
     #[inline(always)]
     pub fn set_bit_a(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;

--- a/tests-snapshots/dbc-cantools/no_sender.snap.rs
+++ b/tests-snapshots/dbc-cantools/no_sender.snap.rs
@@ -71,7 +71,7 @@ impl Foo {
     pub const MESSAGE_SIZE: usize = 1;
     pub const SIGNAL_WITHOUT_SENDER_MIN: i8 = 0_i8;
     pub const SIGNAL_WITHOUT_SENDER_MAX: i8 = 0_i8;
-    /// Construct new Foo from values
+    /// Construct new 'Foo' from values
     pub fn new(signal_without_sender: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_signal_without_sender(signal_without_sender)?;
@@ -81,7 +81,7 @@ impl Foo {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// signal_without_sender
+    /// Get value of 'signal_without_sender'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -91,7 +91,7 @@ impl Foo {
     pub fn signal_without_sender(&self) -> i8 {
         self.signal_without_sender_raw()
     }
-    /// Get raw value of signal_without_sender
+    /// Get raw value of 'signal_without_sender'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -106,7 +106,7 @@ impl Foo {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of signal_without_sender
+    /// Set value of 'signal_without_sender'
     #[inline(always)]
     pub fn set_signal_without_sender(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/no_signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/no_signals.snap.rs
@@ -71,7 +71,7 @@ impl Message1 {
         StandardId::new_unchecked(0x400)
     });
     pub const MESSAGE_SIZE: usize = 5;
-    /// Construct new Message1 from values
+    /// Construct new 'Message1' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 5] };
         Ok(res)
@@ -142,7 +142,7 @@ impl Message2 {
         StandardId::new_unchecked(0x401)
     });
     pub const MESSAGE_SIZE: usize = 0;
-    /// Construct new Message2 from values
+    /// Construct new 'Message2' from values
     pub fn new() -> Result<Self, CanError> {
         let res = Self { raw: [0x00; 0] };
         Ok(res)

--- a/tests-snapshots/dbc-cantools/open_actuator.snap.rs
+++ b/tests-snapshots/dbc-cantools/open_actuator.snap.rs
@@ -290,11 +290,7 @@ impl ControlCmd {
         &mut self,
         value: ControlCmdTargetMode,
     ) -> Result<(), CanError> {
-        self.set_target_mode_raw(u8::from(value))
-    }
-    /// Set raw value of 'TargetMode'
-    #[inline(always)]
-    pub fn set_target_mode_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: ControlCmd::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/open_actuator.snap.rs
+++ b/tests-snapshots/dbc-cantools/open_actuator.snap.rs
@@ -102,12 +102,12 @@ impl ControlCmd {
     pub const TORQUE_COMMAND_8_MAX: f32 = 8_f32;
     pub const TORQUE_CLOSE_LOOP_MAX_32_MIN: f32 = 0_f32;
     pub const TORQUE_CLOSE_LOOP_MAX_32_MAX: f32 = 8_f32;
-    /// Construct new ControlCmd from values
+    /// Construct new 'ControlCmd' from values
     pub fn new(
         crc8_cmd1: u8,
         counter_cmd1: u8,
         target_motor_id_cmd1: u8,
-        target_mode: u8,
+        target_mode: ControlCmdTargetMode,
         position_cmd_64: f32,
         torque_command_8: f32,
         torque_close_loop_max_32: f32,
@@ -126,7 +126,7 @@ impl ControlCmd {
     pub fn raw(&self) -> &[u8; 7] {
         &self.raw
     }
-    /// CRC8_CMD1
+    /// Get value of 'CRC8_CMD1'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -136,7 +136,7 @@ impl ControlCmd {
     pub fn crc8_cmd1(&self) -> u8 {
         self.crc8_cmd1_raw()
     }
-    /// Get raw value of CRC8_CMD1
+    /// Get raw value of 'CRC8_CMD1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -150,7 +150,7 @@ impl ControlCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of CRC8_CMD1
+    /// Set value of 'CRC8_CMD1'
     #[inline(always)]
     pub fn set_crc8_cmd1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -168,7 +168,7 @@ impl ControlCmd {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Counter_CMD1
+    /// Get value of 'Counter_CMD1'
     ///
     /// - Min: 0
     /// - Max: 15
@@ -178,7 +178,7 @@ impl ControlCmd {
     pub fn counter_cmd1(&self) -> u8 {
         self.counter_cmd1_raw()
     }
-    /// Get raw value of Counter_CMD1
+    /// Get raw value of 'Counter_CMD1'
     ///
     /// - Start bit: 48
     /// - Signal size: 4 bits
@@ -192,7 +192,7 @@ impl ControlCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Counter_CMD1
+    /// Set value of 'Counter_CMD1'
     #[inline(always)]
     pub fn set_counter_cmd1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {
@@ -210,7 +210,7 @@ impl ControlCmd {
         self.raw.view_bits_mut::<Lsb0>()[48..52].store_le(value);
         Ok(())
     }
-    /// TargetMotorID_CMD1
+    /// Get value of 'TargetMotorID_CMD1'
     ///
     /// - Min: 0
     /// - Max: 3
@@ -220,7 +220,7 @@ impl ControlCmd {
     pub fn target_motor_id_cmd1(&self) -> u8 {
         self.target_motor_id_cmd1_raw()
     }
-    /// Get raw value of TargetMotorID_CMD1
+    /// Get raw value of 'TargetMotorID_CMD1'
     ///
     /// - Start bit: 12
     /// - Signal size: 2 bits
@@ -234,7 +234,7 @@ impl ControlCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TargetMotorID_CMD1
+    /// Set value of 'TargetMotorID_CMD1'
     #[inline(always)]
     pub fn set_target_motor_id_cmd1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
@@ -252,7 +252,7 @@ impl ControlCmd {
         self.raw.view_bits_mut::<Lsb0>()[12..14].store_le(value);
         Ok(())
     }
-    /// TargetMode
+    /// Get value of 'TargetMode'
     ///
     /// - Min: 0
     /// - Max: 3
@@ -270,7 +270,7 @@ impl ControlCmd {
             _ => ControlCmdTargetMode::_Other(self.target_mode_raw()),
         }
     }
-    /// Get raw value of TargetMode
+    /// Get raw value of 'TargetMode'
     ///
     /// - Start bit: 8
     /// - Signal size: 3 bits
@@ -284,9 +284,17 @@ impl ControlCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TargetMode
+    /// Set value of 'TargetMode'
     #[inline(always)]
-    pub fn set_target_mode(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_target_mode(
+        &mut self,
+        value: ControlCmdTargetMode,
+    ) -> Result<(), CanError> {
+        self.set_target_mode_raw(u8::from(value))
+    }
+    /// Set raw value of 'TargetMode'
+    #[inline(always)]
+    pub fn set_target_mode_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 3_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: ControlCmd::MESSAGE_ID,
@@ -302,7 +310,7 @@ impl ControlCmd {
         self.raw.view_bits_mut::<Lsb0>()[8..11].store_le(value);
         Ok(())
     }
-    /// PositionCmd_64
+    /// Get value of 'PositionCmd_64'
     ///
     /// Output relative position.
     /// Alternative usage - absolute output position
@@ -316,7 +324,7 @@ impl ControlCmd {
     pub fn position_cmd_64(&self) -> f32 {
         self.position_cmd_64_raw()
     }
-    /// Get raw value of PositionCmd_64
+    /// Get raw value of 'PositionCmd_64'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -331,7 +339,7 @@ impl ControlCmd {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of PositionCmd_64
+    /// Set value of 'PositionCmd_64'
     #[inline(always)]
     pub fn set_position_cmd_64(&mut self, value: f32) -> Result<(), CanError> {
         if value < -450_f32 || 450_f32 < value {
@@ -346,7 +354,7 @@ impl ControlCmd {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// TorqueCommand_8
+    /// Get value of 'TorqueCommand_8'
     ///
     /// Factor:
     /// 8_const * 1A/1000mA * MotorRatedTorque / MotorRatedCurrent * GearboxRatio * FinalGearRatio
@@ -359,7 +367,7 @@ impl ControlCmd {
     pub fn torque_command_8(&self) -> f32 {
         self.torque_command_8_raw()
     }
-    /// Get raw value of TorqueCommand_8
+    /// Get raw value of 'TorqueCommand_8'
     ///
     /// - Start bit: 32
     /// - Signal size: 10 bits
@@ -374,7 +382,7 @@ impl ControlCmd {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of TorqueCommand_8
+    /// Set value of 'TorqueCommand_8'
     #[inline(always)]
     pub fn set_torque_command_8(&mut self, value: f32) -> Result<(), CanError> {
         if value < -8_f32 || 8_f32 < value {
@@ -389,7 +397,7 @@ impl ControlCmd {
         self.raw.view_bits_mut::<Lsb0>()[32..42].store_le(value);
         Ok(())
     }
-    /// TorqueCloseLoopMax_32
+    /// Get value of 'TorqueCloseLoopMax_32'
     ///
     /// For TorqueCmd > 0
     /// Max positive close loop torque on top of TorqueCmd (outward torque) and below 0 (centering torque).
@@ -406,7 +414,7 @@ impl ControlCmd {
     pub fn torque_close_loop_max_32(&self) -> f32 {
         self.torque_close_loop_max_32_raw()
     }
-    /// Get raw value of TorqueCloseLoopMax_32
+    /// Get raw value of 'TorqueCloseLoopMax_32'
     ///
     /// - Start bit: 42
     /// - Signal size: 6 bits
@@ -421,7 +429,7 @@ impl ControlCmd {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of TorqueCloseLoopMax_32
+    /// Set value of 'TorqueCloseLoopMax_32'
     #[inline(always)]
     pub fn set_torque_close_loop_max_32(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 8_f32 < value {
@@ -536,7 +544,7 @@ impl LimitsCmd {
     pub const VELOCITY_LIMIT_MAX: u16 = 0_u16;
     pub const ACCEL_LIMIT_MIN: u16 = 0_u16;
     pub const ACCEL_LIMIT_MAX: u16 = 0_u16;
-    /// Construct new LimitsCmd from values
+    /// Construct new 'LimitsCmd' from values
     pub fn new(
         crc8_cmd2: u8,
         counter_cmd2: u8,
@@ -554,7 +562,7 @@ impl LimitsCmd {
     pub fn raw(&self) -> &[u8; 6] {
         &self.raw
     }
-    /// CRC8_CMD2
+    /// Get value of 'CRC8_CMD2'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -564,7 +572,7 @@ impl LimitsCmd {
     pub fn crc8_cmd2(&self) -> u8 {
         self.crc8_cmd2_raw()
     }
-    /// Get raw value of CRC8_CMD2
+    /// Get raw value of 'CRC8_CMD2'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -578,7 +586,7 @@ impl LimitsCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of CRC8_CMD2
+    /// Set value of 'CRC8_CMD2'
     #[inline(always)]
     pub fn set_crc8_cmd2(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -596,7 +604,7 @@ impl LimitsCmd {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Counter_CMD2
+    /// Get value of 'Counter_CMD2'
     ///
     /// - Min: 0
     /// - Max: 15
@@ -606,7 +614,7 @@ impl LimitsCmd {
     pub fn counter_cmd2(&self) -> u8 {
         self.counter_cmd2_raw()
     }
-    /// Get raw value of Counter_CMD2
+    /// Get raw value of 'Counter_CMD2'
     ///
     /// - Start bit: 12
     /// - Signal size: 4 bits
@@ -620,7 +628,7 @@ impl LimitsCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Counter_CMD2
+    /// Set value of 'Counter_CMD2'
     #[inline(always)]
     pub fn set_counter_cmd2(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {
@@ -638,7 +646,7 @@ impl LimitsCmd {
         self.raw.view_bits_mut::<Lsb0>()[12..16].store_le(value);
         Ok(())
     }
-    /// VelocityLimit
+    /// Get value of 'VelocityLimit'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -648,7 +656,7 @@ impl LimitsCmd {
     pub fn velocity_limit(&self) -> u16 {
         self.velocity_limit_raw()
     }
-    /// Get raw value of VelocityLimit
+    /// Get raw value of 'VelocityLimit'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -662,7 +670,7 @@ impl LimitsCmd {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of VelocityLimit
+    /// Set value of 'VelocityLimit'
     #[inline(always)]
     pub fn set_velocity_limit(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -680,7 +688,7 @@ impl LimitsCmd {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// AccelLimit
+    /// Get value of 'AccelLimit'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -690,7 +698,7 @@ impl LimitsCmd {
     pub fn accel_limit(&self) -> u16 {
         self.accel_limit_raw()
     }
-    /// Get raw value of AccelLimit
+    /// Get raw value of 'AccelLimit'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -704,7 +712,7 @@ impl LimitsCmd {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of AccelLimit
+    /// Set value of 'AccelLimit'
     #[inline(always)]
     pub fn set_accel_limit(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -792,7 +800,7 @@ impl ControlStatus {
     pub const TORQUE_ACTUAL_MAX: f32 = 8_f32;
     pub const TORQUE_CLOSE_LOOP_ACTUAL_MIN: f32 = 0_f32;
     pub const TORQUE_CLOSE_LOOP_ACTUAL_MAX: f32 = 8_f32;
-    /// Construct new ControlStatus from values
+    /// Construct new 'ControlStatus' from values
     pub fn new(
         crc8_stat1: u8,
         counter_stat1: u8,
@@ -810,7 +818,7 @@ impl ControlStatus {
     pub fn raw(&self) -> &[u8; 4] {
         &self.raw
     }
-    /// CRC8_STAT1
+    /// Get value of 'CRC8_STAT1'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -820,7 +828,7 @@ impl ControlStatus {
     pub fn crc8_stat1(&self) -> u8 {
         self.crc8_stat1_raw()
     }
-    /// Get raw value of CRC8_STAT1
+    /// Get raw value of 'CRC8_STAT1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -834,7 +842,7 @@ impl ControlStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of CRC8_STAT1
+    /// Set value of 'CRC8_STAT1'
     #[inline(always)]
     pub fn set_crc8_stat1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -852,7 +860,7 @@ impl ControlStatus {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Counter_STAT1
+    /// Get value of 'Counter_STAT1'
     ///
     /// - Min: 0
     /// - Max: 15
@@ -862,7 +870,7 @@ impl ControlStatus {
     pub fn counter_stat1(&self) -> u8 {
         self.counter_stat1_raw()
     }
-    /// Get raw value of Counter_STAT1
+    /// Get raw value of 'Counter_STAT1'
     ///
     /// - Start bit: 12
     /// - Signal size: 4 bits
@@ -876,7 +884,7 @@ impl ControlStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Counter_STAT1
+    /// Set value of 'Counter_STAT1'
     #[inline(always)]
     pub fn set_counter_stat1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {
@@ -894,7 +902,7 @@ impl ControlStatus {
         self.raw.view_bits_mut::<Lsb0>()[12..16].store_le(value);
         Ok(())
     }
-    /// TorqueActual
+    /// Get value of 'TorqueActual'
     ///
     /// - Min: -8
     /// - Max: 8
@@ -904,7 +912,7 @@ impl ControlStatus {
     pub fn torque_actual(&self) -> f32 {
         self.torque_actual_raw()
     }
-    /// Get raw value of TorqueActual
+    /// Get raw value of 'TorqueActual'
     ///
     /// - Start bit: 16
     /// - Signal size: 10 bits
@@ -919,7 +927,7 @@ impl ControlStatus {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of TorqueActual
+    /// Set value of 'TorqueActual'
     #[inline(always)]
     pub fn set_torque_actual(&mut self, value: f32) -> Result<(), CanError> {
         if value < -8_f32 || 8_f32 < value {
@@ -934,7 +942,7 @@ impl ControlStatus {
         self.raw.view_bits_mut::<Lsb0>()[16..26].store_le(value);
         Ok(())
     }
-    /// TorqueCloseLoopActual
+    /// Get value of 'TorqueCloseLoopActual'
     ///
     /// - Min: 0
     /// - Max: 8
@@ -944,7 +952,7 @@ impl ControlStatus {
     pub fn torque_close_loop_actual(&self) -> f32 {
         self.torque_close_loop_actual_raw()
     }
-    /// Get raw value of TorqueCloseLoopActual
+    /// Get raw value of 'TorqueCloseLoopActual'
     ///
     /// - Start bit: 26
     /// - Signal size: 6 bits
@@ -959,7 +967,7 @@ impl ControlStatus {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of TorqueCloseLoopActual
+    /// Set value of 'TorqueCloseLoopActual'
     #[inline(always)]
     pub fn set_torque_close_loop_actual(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 8_f32 < value {
@@ -1041,7 +1049,7 @@ impl SystemStatus {
     pub const COUNTER_STAT2_MAX: u8 = 15_u8;
     pub const CHIP_TEMP_MIN: i16 = -60_i16;
     pub const CHIP_TEMP_MAX: i16 = 195_i16;
-    /// Construct new SystemStatus from values
+    /// Construct new 'SystemStatus' from values
     pub fn new(
         crc8_stat2: u8,
         counter_stat2: u8,
@@ -1057,7 +1065,7 @@ impl SystemStatus {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// CRC8_STAT2
+    /// Get value of 'CRC8_STAT2'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -1067,7 +1075,7 @@ impl SystemStatus {
     pub fn crc8_stat2(&self) -> u8 {
         self.crc8_stat2_raw()
     }
-    /// Get raw value of CRC8_STAT2
+    /// Get raw value of 'CRC8_STAT2'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -1081,7 +1089,7 @@ impl SystemStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of CRC8_STAT2
+    /// Set value of 'CRC8_STAT2'
     #[inline(always)]
     pub fn set_crc8_stat2(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -1099,7 +1107,7 @@ impl SystemStatus {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Counter_STAT2
+    /// Get value of 'Counter_STAT2'
     ///
     /// - Min: 0
     /// - Max: 15
@@ -1109,7 +1117,7 @@ impl SystemStatus {
     pub fn counter_stat2(&self) -> u8 {
         self.counter_stat2_raw()
     }
-    /// Get raw value of Counter_STAT2
+    /// Get raw value of 'Counter_STAT2'
     ///
     /// - Start bit: 12
     /// - Signal size: 4 bits
@@ -1123,7 +1131,7 @@ impl SystemStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Counter_STAT2
+    /// Set value of 'Counter_STAT2'
     #[inline(always)]
     pub fn set_counter_stat2(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {
@@ -1141,7 +1149,7 @@ impl SystemStatus {
         self.raw.view_bits_mut::<Lsb0>()[12..16].store_le(value);
         Ok(())
     }
-    /// ChipTemp
+    /// Get value of 'ChipTemp'
     ///
     /// - Min: -60
     /// - Max: 195
@@ -1151,7 +1159,7 @@ impl SystemStatus {
     pub fn chip_temp(&self) -> i16 {
         self.chip_temp_raw()
     }
-    /// Get raw value of ChipTemp
+    /// Get raw value of 'ChipTemp'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -1165,7 +1173,7 @@ impl SystemStatus {
         let factor = 1;
         i16::from(signal).saturating_mul(factor).saturating_sub(60)
     }
-    /// Set value of ChipTemp
+    /// Set value of 'ChipTemp'
     #[inline(always)]
     pub fn set_chip_temp(&mut self, value: i16) -> Result<(), CanError> {
         if value < -60_i16 || 195_i16 < value {
@@ -1251,7 +1259,7 @@ impl TorqueSensorData {
     pub const COUNTER_DATA1_MAX: u8 = 15_u8;
     pub const TORQUE_SENSE_MIN: f32 = -20_f32;
     pub const TORQUE_SENSE_MAX: f32 = 20_f32;
-    /// Construct new TorqueSensorData from values
+    /// Construct new 'TorqueSensorData' from values
     pub fn new(
         crc8_data1: u8,
         counter_data1: u8,
@@ -1267,7 +1275,7 @@ impl TorqueSensorData {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// CRC8_DATA1
+    /// Get value of 'CRC8_DATA1'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -1277,7 +1285,7 @@ impl TorqueSensorData {
     pub fn crc8_data1(&self) -> u8 {
         self.crc8_data1_raw()
     }
-    /// Get raw value of CRC8_DATA1
+    /// Get raw value of 'CRC8_DATA1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -1291,7 +1299,7 @@ impl TorqueSensorData {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of CRC8_DATA1
+    /// Set value of 'CRC8_DATA1'
     #[inline(always)]
     pub fn set_crc8_data1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -1309,7 +1317,7 @@ impl TorqueSensorData {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Counter_DATA1
+    /// Get value of 'Counter_DATA1'
     ///
     /// - Min: 0
     /// - Max: 15
@@ -1319,7 +1327,7 @@ impl TorqueSensorData {
     pub fn counter_data1(&self) -> u8 {
         self.counter_data1_raw()
     }
-    /// Get raw value of Counter_DATA1
+    /// Get raw value of 'Counter_DATA1'
     ///
     /// - Start bit: 8
     /// - Signal size: 4 bits
@@ -1333,7 +1341,7 @@ impl TorqueSensorData {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Counter_DATA1
+    /// Set value of 'Counter_DATA1'
     #[inline(always)]
     pub fn set_counter_data1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {
@@ -1351,7 +1359,7 @@ impl TorqueSensorData {
         self.raw.view_bits_mut::<Lsb0>()[8..12].store_le(value);
         Ok(())
     }
-    /// TorqueSense
+    /// Get value of 'TorqueSense'
     ///
     /// Strain gauge torque measured
     ///
@@ -1363,7 +1371,7 @@ impl TorqueSensorData {
     pub fn torque_sense(&self) -> f32 {
         self.torque_sense_raw()
     }
-    /// Get raw value of TorqueSense
+    /// Get raw value of 'TorqueSense'
     ///
     /// - Start bit: 12
     /// - Signal size: 12 bits
@@ -1378,7 +1386,7 @@ impl TorqueSensorData {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of TorqueSense
+    /// Set value of 'TorqueSense'
     #[inline(always)]
     pub fn set_torque_sense(&mut self, value: f32) -> Result<(), CanError> {
         if value < -20_f32 || 20_f32 < value {

--- a/tests-snapshots/dbc-cantools/padding_bit_order.snap.rs
+++ b/tests-snapshots/dbc-cantools/padding_bit_order.snap.rs
@@ -84,7 +84,7 @@ impl Msg0 {
     pub const A_MAX: u16 = 32767_u16;
     pub const C_MIN: u16 = 0_u16;
     pub const C_MAX: u16 = 32767_u16;
-    /// Construct new MSG0 from values
+    /// Construct new 'MSG0' from values
     pub fn new(a: u16, b: bool, c: u16, d: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_a(a)?;
@@ -97,7 +97,7 @@ impl Msg0 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// A
+    /// Get value of 'A'
     ///
     /// - Min: 0
     /// - Max: 32767
@@ -107,7 +107,7 @@ impl Msg0 {
     pub fn a(&self) -> u16 {
         self.a_raw()
     }
-    /// Get raw value of A
+    /// Get raw value of 'A'
     ///
     /// - Start bit: 6
     /// - Signal size: 15 bits
@@ -121,7 +121,7 @@ impl Msg0 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of A
+    /// Set value of 'A'
     #[inline(always)]
     pub fn set_a(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 32767_u16 < value {
@@ -139,7 +139,7 @@ impl Msg0 {
         self.raw.view_bits_mut::<Msb0>()[1..16].store_be(value);
         Ok(())
     }
-    /// B
+    /// Get value of 'B'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -149,7 +149,7 @@ impl Msg0 {
     pub fn b(&self) -> bool {
         self.b_raw()
     }
-    /// Get raw value of B
+    /// Get raw value of 'B'
     ///
     /// - Start bit: 7
     /// - Signal size: 1 bits
@@ -162,14 +162,14 @@ impl Msg0 {
         let signal = self.raw.view_bits::<Msb0>()[0..1].load_be::<u8>();
         signal == 1
     }
-    /// Set value of B
+    /// Set value of 'B'
     #[inline(always)]
     pub fn set_b(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Msb0>()[0..1].store_be(value);
         Ok(())
     }
-    /// C
+    /// Get value of 'C'
     ///
     /// - Min: 0
     /// - Max: 32767
@@ -179,7 +179,7 @@ impl Msg0 {
     pub fn c(&self) -> u16 {
         self.c_raw()
     }
-    /// Get raw value of C
+    /// Get raw value of 'C'
     ///
     /// - Start bit: 38
     /// - Signal size: 15 bits
@@ -193,7 +193,7 @@ impl Msg0 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of C
+    /// Set value of 'C'
     #[inline(always)]
     pub fn set_c(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 32767_u16 < value {
@@ -211,7 +211,7 @@ impl Msg0 {
         self.raw.view_bits_mut::<Msb0>()[33..48].store_be(value);
         Ok(())
     }
-    /// D
+    /// Get value of 'D'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -221,7 +221,7 @@ impl Msg0 {
     pub fn d(&self) -> bool {
         self.d_raw()
     }
-    /// Get raw value of D
+    /// Get raw value of 'D'
     ///
     /// - Start bit: 39
     /// - Signal size: 1 bits
@@ -234,7 +234,7 @@ impl Msg0 {
         let signal = self.raw.view_bits::<Msb0>()[32..33].load_be::<u8>();
         signal == 1
     }
-    /// Set value of D
+    /// Set value of 'D'
     #[inline(always)]
     pub fn set_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -307,7 +307,7 @@ impl Msg1 {
     pub const F_MAX: u16 = 32767_u16;
     pub const H_MIN: u16 = 0_u16;
     pub const H_MAX: u16 = 32767_u16;
-    /// Construct new MSG1 from values
+    /// Construct new 'MSG1' from values
     pub fn new(e: bool, f: u16, g: bool, h: u16) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_e(e)?;
@@ -320,7 +320,7 @@ impl Msg1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// E
+    /// Get value of 'E'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -330,7 +330,7 @@ impl Msg1 {
     pub fn e(&self) -> bool {
         self.e_raw()
     }
-    /// Get raw value of E
+    /// Get raw value of 'E'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -343,14 +343,14 @@ impl Msg1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of E
+    /// Set value of 'E'
     #[inline(always)]
     pub fn set_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[0..1].store_le(value);
         Ok(())
     }
-    /// F
+    /// Get value of 'F'
     ///
     /// - Min: 0
     /// - Max: 32767
@@ -360,7 +360,7 @@ impl Msg1 {
     pub fn f(&self) -> u16 {
         self.f_raw()
     }
-    /// Get raw value of F
+    /// Get raw value of 'F'
     ///
     /// - Start bit: 1
     /// - Signal size: 15 bits
@@ -374,7 +374,7 @@ impl Msg1 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of F
+    /// Set value of 'F'
     #[inline(always)]
     pub fn set_f(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 32767_u16 < value {
@@ -392,7 +392,7 @@ impl Msg1 {
         self.raw.view_bits_mut::<Lsb0>()[1..16].store_le(value);
         Ok(())
     }
-    /// G
+    /// Get value of 'G'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -402,7 +402,7 @@ impl Msg1 {
     pub fn g(&self) -> bool {
         self.g_raw()
     }
-    /// Get raw value of G
+    /// Get raw value of 'G'
     ///
     /// - Start bit: 32
     /// - Signal size: 1 bits
@@ -415,14 +415,14 @@ impl Msg1 {
         let signal = self.raw.view_bits::<Lsb0>()[32..33].load_le::<u8>();
         signal == 1
     }
-    /// Set value of G
+    /// Set value of 'G'
     #[inline(always)]
     pub fn set_g(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[32..33].store_le(value);
         Ok(())
     }
-    /// H
+    /// Get value of 'H'
     ///
     /// - Min: 0
     /// - Max: 32767
@@ -432,7 +432,7 @@ impl Msg1 {
     pub fn h(&self) -> u16 {
         self.h_raw()
     }
-    /// Get raw value of H
+    /// Get raw value of 'H'
     ///
     /// - Start bit: 33
     /// - Signal size: 15 bits
@@ -446,7 +446,7 @@ impl Msg1 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of H
+    /// Set value of 'H'
     #[inline(always)]
     pub fn set_h(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 32767_u16 < value {
@@ -532,7 +532,7 @@ impl Msg2 {
     pub const J_MAX: u8 = 15_u8;
     pub const K_MIN: u8 = 0_u8;
     pub const K_MAX: u8 = 15_u8;
-    /// Construct new MSG2 from values
+    /// Construct new 'MSG2' from values
     pub fn new(i: u8, j: u8, k: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_i(i)?;
@@ -544,7 +544,7 @@ impl Msg2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// I
+    /// Get value of 'I'
     ///
     /// - Min: 0
     /// - Max: 15
@@ -554,7 +554,7 @@ impl Msg2 {
     pub fn i(&self) -> u8 {
         self.i_raw()
     }
-    /// Get raw value of I
+    /// Get raw value of 'I'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -568,7 +568,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of I
+    /// Set value of 'I'
     #[inline(always)]
     pub fn set_i(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {
@@ -586,7 +586,7 @@ impl Msg2 {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// J
+    /// Get value of 'J'
     ///
     /// - Min: 0
     /// - Max: 15
@@ -596,7 +596,7 @@ impl Msg2 {
     pub fn j(&self) -> u8 {
         self.j_raw()
     }
-    /// Get raw value of J
+    /// Get raw value of 'J'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -610,7 +610,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of J
+    /// Set value of 'J'
     #[inline(always)]
     pub fn set_j(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {
@@ -628,7 +628,7 @@ impl Msg2 {
         self.raw.view_bits_mut::<Lsb0>()[4..8].store_le(value);
         Ok(())
     }
-    /// K
+    /// Get value of 'K'
     ///
     /// - Min: 0
     /// - Max: 15
@@ -638,7 +638,7 @@ impl Msg2 {
     pub fn k(&self) -> u8 {
         self.k_raw()
     }
-    /// Get raw value of K
+    /// Get raw value of 'K'
     ///
     /// - Start bit: 8
     /// - Signal size: 4 bits
@@ -652,7 +652,7 @@ impl Msg2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of K
+    /// Set value of 'K'
     #[inline(always)]
     pub fn set_k(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 15_u8 < value {
@@ -734,7 +734,7 @@ impl Msg3 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const L_MIN: u64 = 0_u64;
     pub const L_MAX: u64 = 18446744073709551615_u64;
-    /// Construct new MSG3 from values
+    /// Construct new 'MSG3' from values
     pub fn new(l: u64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_l(l)?;
@@ -744,7 +744,7 @@ impl Msg3 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// L
+    /// Get value of 'L'
     ///
     /// - Min: 0
     /// - Max: 18446744073709551615
@@ -754,7 +754,7 @@ impl Msg3 {
     pub fn l(&self) -> u64 {
         self.l_raw()
     }
-    /// Get raw value of L
+    /// Get raw value of 'L'
     ///
     /// - Start bit: 7
     /// - Signal size: 64 bits
@@ -768,7 +768,7 @@ impl Msg3 {
         let factor = 1;
         u64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of L
+    /// Set value of 'L'
     #[inline(always)]
     pub fn set_l(&mut self, value: u64) -> Result<(), CanError> {
         if value < 0_u64 || 18446744073709551615_u64 < value {
@@ -850,7 +850,7 @@ impl Msg4 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const M_MIN: u64 = 0_u64;
     pub const M_MAX: u64 = 18446744073709551615_u64;
-    /// Construct new MSG4 from values
+    /// Construct new 'MSG4' from values
     pub fn new(m: u64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_m(m)?;
@@ -860,7 +860,7 @@ impl Msg4 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// M
+    /// Get value of 'M'
     ///
     /// - Min: 0
     /// - Max: 18446744073709551615
@@ -870,7 +870,7 @@ impl Msg4 {
     pub fn m(&self) -> u64 {
         self.m_raw()
     }
-    /// Get raw value of M
+    /// Get raw value of 'M'
     ///
     /// - Start bit: 0
     /// - Signal size: 64 bits
@@ -884,7 +884,7 @@ impl Msg4 {
         let factor = 1;
         u64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of M
+    /// Set value of 'M'
     #[inline(always)]
     pub fn set_m(&mut self, value: u64) -> Result<(), CanError> {
         if value < 0_u64 || 18446744073709551615_u64 < value {

--- a/tests-snapshots/dbc-cantools/sig_groups.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups.snap.rs
@@ -79,7 +79,7 @@ impl Test {
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
-    /// Construct new Test from values
+    /// Construct new 'Test' from values
     pub fn new(test_sig: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_test_sig(test_sig)?;
@@ -89,7 +89,7 @@ impl Test {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TestSig
+    /// Get value of 'TestSig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -99,7 +99,7 @@ impl Test {
     pub fn test_sig(&self) -> i8 {
         self.test_sig_raw()
     }
-    /// Get raw value of TestSig
+    /// Get raw value of 'TestSig'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -114,7 +114,7 @@ impl Test {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TestSig
+    /// Set value of 'TestSig'
     #[inline(always)]
     pub fn set_test_sig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -202,7 +202,7 @@ impl SgMsgM {
     pub const SUB_SIG1_2_MAX: i8 = 0_i8;
     pub const SUB_SIG1_1_MIN: i8 = 0_i8;
     pub const SUB_SIG1_1_MAX: i8 = 0_i8;
-    /// Construct new SGMsg_m from values
+    /// Construct new 'SGMsg_m' from values
     pub fn new(
         dupsig: i8,
         sub_sig2_1: i8,
@@ -220,7 +220,7 @@ impl SgMsgM {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// dupsig
+    /// Get value of 'dupsig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -230,7 +230,7 @@ impl SgMsgM {
     pub fn dupsig(&self) -> i8 {
         self.dupsig_raw()
     }
-    /// Get raw value of dupsig
+    /// Get raw value of 'dupsig'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -245,7 +245,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of dupsig
+    /// Set value of 'dupsig'
     #[inline(always)]
     pub fn set_dupsig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -264,7 +264,7 @@ impl SgMsgM {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// subSig2_1
+    /// Get value of 'subSig2_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -274,7 +274,7 @@ impl SgMsgM {
     pub fn sub_sig2_1(&self) -> i8 {
         self.sub_sig2_1_raw()
     }
-    /// Get raw value of subSig2_1
+    /// Get raw value of 'subSig2_1'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -289,7 +289,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of subSig2_1
+    /// Set value of 'subSig2_1'
     #[inline(always)]
     pub fn set_sub_sig2_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -308,7 +308,7 @@ impl SgMsgM {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// subSig1_2
+    /// Get value of 'subSig1_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -318,7 +318,7 @@ impl SgMsgM {
     pub fn sub_sig1_2(&self) -> i8 {
         self.sub_sig1_2_raw()
     }
-    /// Get raw value of subSig1_2
+    /// Get raw value of 'subSig1_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -333,7 +333,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of subSig1_2
+    /// Set value of 'subSig1_2'
     #[inline(always)]
     pub fn set_sub_sig1_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -352,7 +352,7 @@ impl SgMsgM {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// subSig1_1
+    /// Get value of 'subSig1_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -362,7 +362,7 @@ impl SgMsgM {
     pub fn sub_sig1_1(&self) -> i8 {
         self.sub_sig1_1_raw()
     }
-    /// Get raw value of subSig1_1
+    /// Get raw value of 'subSig1_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -377,7 +377,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of subSig1_1
+    /// Set value of 'subSig1_1'
     #[inline(always)]
     pub fn set_sub_sig1_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -463,7 +463,7 @@ impl SgMsg {
     pub const SG2_MAX: i8 = 0_i8;
     pub const SG1_MIN: i8 = 0_i8;
     pub const SG1_MAX: i8 = 0_i8;
-    /// Construct new SGMsg from values
+    /// Construct new 'SGMsg' from values
     pub fn new(dupsig: i8, sg2: i8, sg1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_dupsig(dupsig)?;
@@ -475,7 +475,7 @@ impl SgMsg {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// dupsig
+    /// Get value of 'dupsig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -485,7 +485,7 @@ impl SgMsg {
     pub fn dupsig(&self) -> i8 {
         self.dupsig_raw()
     }
-    /// Get raw value of dupsig
+    /// Get raw value of 'dupsig'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -500,7 +500,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of dupsig
+    /// Set value of 'dupsig'
     #[inline(always)]
     pub fn set_dupsig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -519,7 +519,7 @@ impl SgMsg {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// SG2
+    /// Get value of 'SG2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -529,7 +529,7 @@ impl SgMsg {
     pub fn sg2(&self) -> i8 {
         self.sg2_raw()
     }
-    /// Get raw value of SG2
+    /// Get raw value of 'SG2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -544,7 +544,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SG2
+    /// Set value of 'SG2'
     #[inline(always)]
     pub fn set_sg2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -563,7 +563,7 @@ impl SgMsg {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// SG1
+    /// Get value of 'SG1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -573,7 +573,7 @@ impl SgMsg {
     pub fn sg1(&self) -> i8 {
         self.sg1_raw()
     }
-    /// Get raw value of SG1
+    /// Get raw value of 'SG1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -588,7 +588,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SG1
+    /// Set value of 'SG1'
     #[inline(always)]
     pub fn set_sg1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -672,7 +672,7 @@ impl NormalMsg {
     pub const SIG_2_MAX: i8 = 0_i8;
     pub const SIG_1_MIN: i8 = 0_i8;
     pub const SIG_1_MAX: i8 = 0_i8;
-    /// Construct new NormalMsg from values
+    /// Construct new 'NormalMsg' from values
     pub fn new(sig_2: i8, sig_1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_sig_2(sig_2)?;
@@ -683,7 +683,7 @@ impl NormalMsg {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Sig_2
+    /// Get value of 'Sig_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -693,7 +693,7 @@ impl NormalMsg {
     pub fn sig_2(&self) -> i8 {
         self.sig_2_raw()
     }
-    /// Get raw value of Sig_2
+    /// Get raw value of 'Sig_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -708,7 +708,7 @@ impl NormalMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_2
+    /// Set value of 'Sig_2'
     #[inline(always)]
     pub fn set_sig_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -727,7 +727,7 @@ impl NormalMsg {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Sig_1
+    /// Get value of 'Sig_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -737,7 +737,7 @@ impl NormalMsg {
     pub fn sig_1(&self) -> i8 {
         self.sig_1_raw()
     }
-    /// Get raw value of Sig_1
+    /// Get raw value of 'Sig_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -752,7 +752,7 @@ impl NormalMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_1
+    /// Set value of 'Sig_1'
     #[inline(always)]
     pub fn set_sig_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/sig_groups_del.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups_del.snap.rs
@@ -79,7 +79,7 @@ impl Test {
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
-    /// Construct new Test from values
+    /// Construct new 'Test' from values
     pub fn new(test_sig: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_test_sig(test_sig)?;
@@ -89,7 +89,7 @@ impl Test {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TestSig
+    /// Get value of 'TestSig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -99,7 +99,7 @@ impl Test {
     pub fn test_sig(&self) -> i8 {
         self.test_sig_raw()
     }
-    /// Get raw value of TestSig
+    /// Get raw value of 'TestSig'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -114,7 +114,7 @@ impl Test {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TestSig
+    /// Set value of 'TestSig'
     #[inline(always)]
     pub fn set_test_sig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -202,7 +202,7 @@ impl SgMsgM {
     pub const SUB_SIG1_2_MAX: i8 = 0_i8;
     pub const SUB_SIG1_1_MIN: i8 = 0_i8;
     pub const SUB_SIG1_1_MAX: i8 = 0_i8;
-    /// Construct new SGMsg_m from values
+    /// Construct new 'SGMsg_m' from values
     pub fn new(
         dupsig: i8,
         sub_sig2_1: i8,
@@ -220,7 +220,7 @@ impl SgMsgM {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// dupsig
+    /// Get value of 'dupsig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -230,7 +230,7 @@ impl SgMsgM {
     pub fn dupsig(&self) -> i8 {
         self.dupsig_raw()
     }
-    /// Get raw value of dupsig
+    /// Get raw value of 'dupsig'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -245,7 +245,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of dupsig
+    /// Set value of 'dupsig'
     #[inline(always)]
     pub fn set_dupsig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -264,7 +264,7 @@ impl SgMsgM {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// subSig2_1
+    /// Get value of 'subSig2_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -274,7 +274,7 @@ impl SgMsgM {
     pub fn sub_sig2_1(&self) -> i8 {
         self.sub_sig2_1_raw()
     }
-    /// Get raw value of subSig2_1
+    /// Get raw value of 'subSig2_1'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -289,7 +289,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of subSig2_1
+    /// Set value of 'subSig2_1'
     #[inline(always)]
     pub fn set_sub_sig2_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -308,7 +308,7 @@ impl SgMsgM {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// subSig1_2
+    /// Get value of 'subSig1_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -318,7 +318,7 @@ impl SgMsgM {
     pub fn sub_sig1_2(&self) -> i8 {
         self.sub_sig1_2_raw()
     }
-    /// Get raw value of subSig1_2
+    /// Get raw value of 'subSig1_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -333,7 +333,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of subSig1_2
+    /// Set value of 'subSig1_2'
     #[inline(always)]
     pub fn set_sub_sig1_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -352,7 +352,7 @@ impl SgMsgM {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// subSig1_1
+    /// Get value of 'subSig1_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -362,7 +362,7 @@ impl SgMsgM {
     pub fn sub_sig1_1(&self) -> i8 {
         self.sub_sig1_1_raw()
     }
-    /// Get raw value of subSig1_1
+    /// Get raw value of 'subSig1_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -377,7 +377,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of subSig1_1
+    /// Set value of 'subSig1_1'
     #[inline(always)]
     pub fn set_sub_sig1_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -463,7 +463,7 @@ impl SgMsg {
     pub const SG2_MAX: i8 = 0_i8;
     pub const SG1_MIN: i8 = 0_i8;
     pub const SG1_MAX: i8 = 0_i8;
-    /// Construct new SGMsg from values
+    /// Construct new 'SGMsg' from values
     pub fn new(dupsig: i8, sg2: i8, sg1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_dupsig(dupsig)?;
@@ -475,7 +475,7 @@ impl SgMsg {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// dupsig
+    /// Get value of 'dupsig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -485,7 +485,7 @@ impl SgMsg {
     pub fn dupsig(&self) -> i8 {
         self.dupsig_raw()
     }
-    /// Get raw value of dupsig
+    /// Get raw value of 'dupsig'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -500,7 +500,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of dupsig
+    /// Set value of 'dupsig'
     #[inline(always)]
     pub fn set_dupsig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -519,7 +519,7 @@ impl SgMsg {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// SG2
+    /// Get value of 'SG2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -529,7 +529,7 @@ impl SgMsg {
     pub fn sg2(&self) -> i8 {
         self.sg2_raw()
     }
-    /// Get raw value of SG2
+    /// Get raw value of 'SG2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -544,7 +544,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SG2
+    /// Set value of 'SG2'
     #[inline(always)]
     pub fn set_sg2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -563,7 +563,7 @@ impl SgMsg {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// SG1
+    /// Get value of 'SG1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -573,7 +573,7 @@ impl SgMsg {
     pub fn sg1(&self) -> i8 {
         self.sg1_raw()
     }
-    /// Get raw value of SG1
+    /// Get raw value of 'SG1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -588,7 +588,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SG1
+    /// Set value of 'SG1'
     #[inline(always)]
     pub fn set_sg1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -672,7 +672,7 @@ impl NormalMsg {
     pub const SIG_2_MAX: i8 = 0_i8;
     pub const SIG_1_MIN: i8 = 0_i8;
     pub const SIG_1_MAX: i8 = 0_i8;
-    /// Construct new NormalMsg from values
+    /// Construct new 'NormalMsg' from values
     pub fn new(sig_2: i8, sig_1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_sig_2(sig_2)?;
@@ -683,7 +683,7 @@ impl NormalMsg {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Sig_2
+    /// Get value of 'Sig_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -693,7 +693,7 @@ impl NormalMsg {
     pub fn sig_2(&self) -> i8 {
         self.sig_2_raw()
     }
-    /// Get raw value of Sig_2
+    /// Get raw value of 'Sig_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -708,7 +708,7 @@ impl NormalMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_2
+    /// Set value of 'Sig_2'
     #[inline(always)]
     pub fn set_sig_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -727,7 +727,7 @@ impl NormalMsg {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Sig_1
+    /// Get value of 'Sig_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -737,7 +737,7 @@ impl NormalMsg {
     pub fn sig_1(&self) -> i8 {
         self.sig_1_raw()
     }
-    /// Get raw value of Sig_1
+    /// Get raw value of 'Sig_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -752,7 +752,7 @@ impl NormalMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_1
+    /// Set value of 'Sig_1'
     #[inline(always)]
     pub fn set_sig_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/sig_groups_out.snap.rs
+++ b/tests-snapshots/dbc-cantools/sig_groups_out.snap.rs
@@ -79,7 +79,7 @@ impl Test {
     pub const MESSAGE_SIZE: usize = 8;
     pub const TEST_SIG_MIN: i8 = 0_i8;
     pub const TEST_SIG_MAX: i8 = 0_i8;
-    /// Construct new Test from values
+    /// Construct new 'Test' from values
     pub fn new(test_sig: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_test_sig(test_sig)?;
@@ -89,7 +89,7 @@ impl Test {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// TestSig
+    /// Get value of 'TestSig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -99,7 +99,7 @@ impl Test {
     pub fn test_sig(&self) -> i8 {
         self.test_sig_raw()
     }
-    /// Get raw value of TestSig
+    /// Get raw value of 'TestSig'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -114,7 +114,7 @@ impl Test {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of TestSig
+    /// Set value of 'TestSig'
     #[inline(always)]
     pub fn set_test_sig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -202,7 +202,7 @@ impl SgMsgM {
     pub const SUB_SIG1_2_MAX: i8 = 0_i8;
     pub const SUB_SIG1_1_MIN: i8 = 0_i8;
     pub const SUB_SIG1_1_MAX: i8 = 0_i8;
-    /// Construct new SGMsg_m from values
+    /// Construct new 'SGMsg_m' from values
     pub fn new(
         dupsig: i8,
         sub_sig2_1: i8,
@@ -220,7 +220,7 @@ impl SgMsgM {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// dupsig
+    /// Get value of 'dupsig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -230,7 +230,7 @@ impl SgMsgM {
     pub fn dupsig(&self) -> i8 {
         self.dupsig_raw()
     }
-    /// Get raw value of dupsig
+    /// Get raw value of 'dupsig'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -245,7 +245,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of dupsig
+    /// Set value of 'dupsig'
     #[inline(always)]
     pub fn set_dupsig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -264,7 +264,7 @@ impl SgMsgM {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// subSig2_1
+    /// Get value of 'subSig2_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -274,7 +274,7 @@ impl SgMsgM {
     pub fn sub_sig2_1(&self) -> i8 {
         self.sub_sig2_1_raw()
     }
-    /// Get raw value of subSig2_1
+    /// Get raw value of 'subSig2_1'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -289,7 +289,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of subSig2_1
+    /// Set value of 'subSig2_1'
     #[inline(always)]
     pub fn set_sub_sig2_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -308,7 +308,7 @@ impl SgMsgM {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// subSig1_2
+    /// Get value of 'subSig1_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -318,7 +318,7 @@ impl SgMsgM {
     pub fn sub_sig1_2(&self) -> i8 {
         self.sub_sig1_2_raw()
     }
-    /// Get raw value of subSig1_2
+    /// Get raw value of 'subSig1_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -333,7 +333,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of subSig1_2
+    /// Set value of 'subSig1_2'
     #[inline(always)]
     pub fn set_sub_sig1_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -352,7 +352,7 @@ impl SgMsgM {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// subSig1_1
+    /// Get value of 'subSig1_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -362,7 +362,7 @@ impl SgMsgM {
     pub fn sub_sig1_1(&self) -> i8 {
         self.sub_sig1_1_raw()
     }
-    /// Get raw value of subSig1_1
+    /// Get raw value of 'subSig1_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -377,7 +377,7 @@ impl SgMsgM {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of subSig1_1
+    /// Set value of 'subSig1_1'
     #[inline(always)]
     pub fn set_sub_sig1_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -463,7 +463,7 @@ impl SgMsg {
     pub const SG2_MAX: i8 = 0_i8;
     pub const SG1_MIN: i8 = 0_i8;
     pub const SG1_MAX: i8 = 0_i8;
-    /// Construct new SGMsg from values
+    /// Construct new 'SGMsg' from values
     pub fn new(dupsig: i8, sg2: i8, sg1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_dupsig(dupsig)?;
@@ -475,7 +475,7 @@ impl SgMsg {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// dupsig
+    /// Get value of 'dupsig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -485,7 +485,7 @@ impl SgMsg {
     pub fn dupsig(&self) -> i8 {
         self.dupsig_raw()
     }
-    /// Get raw value of dupsig
+    /// Get raw value of 'dupsig'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -500,7 +500,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of dupsig
+    /// Set value of 'dupsig'
     #[inline(always)]
     pub fn set_dupsig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -519,7 +519,7 @@ impl SgMsg {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// SG2
+    /// Get value of 'SG2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -529,7 +529,7 @@ impl SgMsg {
     pub fn sg2(&self) -> i8 {
         self.sg2_raw()
     }
-    /// Get raw value of SG2
+    /// Get raw value of 'SG2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -544,7 +544,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SG2
+    /// Set value of 'SG2'
     #[inline(always)]
     pub fn set_sg2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -563,7 +563,7 @@ impl SgMsg {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// SG1
+    /// Get value of 'SG1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -573,7 +573,7 @@ impl SgMsg {
     pub fn sg1(&self) -> i8 {
         self.sg1_raw()
     }
-    /// Get raw value of SG1
+    /// Get raw value of 'SG1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -588,7 +588,7 @@ impl SgMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SG1
+    /// Set value of 'SG1'
     #[inline(always)]
     pub fn set_sg1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -672,7 +672,7 @@ impl NormalMsg {
     pub const SIG_2_MAX: i8 = 0_i8;
     pub const SIG_1_MIN: i8 = 0_i8;
     pub const SIG_1_MAX: i8 = 0_i8;
-    /// Construct new NormalMsg from values
+    /// Construct new 'NormalMsg' from values
     pub fn new(sig_2: i8, sig_1: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_sig_2(sig_2)?;
@@ -683,7 +683,7 @@ impl NormalMsg {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Sig_2
+    /// Get value of 'Sig_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -693,7 +693,7 @@ impl NormalMsg {
     pub fn sig_2(&self) -> i8 {
         self.sig_2_raw()
     }
-    /// Get raw value of Sig_2
+    /// Get raw value of 'Sig_2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -708,7 +708,7 @@ impl NormalMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_2
+    /// Set value of 'Sig_2'
     #[inline(always)]
     pub fn set_sig_2(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -727,7 +727,7 @@ impl NormalMsg {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Sig_1
+    /// Get value of 'Sig_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -737,7 +737,7 @@ impl NormalMsg {
     pub fn sig_1(&self) -> i8 {
         self.sig_1_raw()
     }
-    /// Get raw value of Sig_1
+    /// Get raw value of 'Sig_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -752,7 +752,7 @@ impl NormalMsg {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Sig_1
+    /// Set value of 'Sig_1'
     #[inline(always)]
     pub fn set_sig_1(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/signed.snap.rs
+++ b/tests-snapshots/dbc-cantools/signed.snap.rs
@@ -127,7 +127,7 @@ impl Message378910 {
     pub const S8_MAX: i8 = 0_i8;
     pub const S7_MIN: i8 = 0_i8;
     pub const S7_MAX: i8 = 0_i8;
-    /// Construct new Message378910 from values
+    /// Construct new 'Message378910' from values
     pub fn new(
         s3big: i8,
         s3: i8,
@@ -153,7 +153,7 @@ impl Message378910 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s3big
+    /// Get value of 's3big'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -163,7 +163,7 @@ impl Message378910 {
     pub fn s3big(&self) -> i8 {
         self.s3big_raw()
     }
-    /// Get raw value of s3big
+    /// Get raw value of 's3big'
     ///
     /// - Start bit: 39
     /// - Signal size: 3 bits
@@ -178,7 +178,7 @@ impl Message378910 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s3big
+    /// Set value of 's3big'
     #[inline(always)]
     pub fn set_s3big(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -197,7 +197,7 @@ impl Message378910 {
         self.raw.view_bits_mut::<Msb0>()[32..35].store_be(value);
         Ok(())
     }
-    /// s3
+    /// Get value of 's3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -207,7 +207,7 @@ impl Message378910 {
     pub fn s3(&self) -> i8 {
         self.s3_raw()
     }
-    /// Get raw value of s3
+    /// Get raw value of 's3'
     ///
     /// - Start bit: 34
     /// - Signal size: 3 bits
@@ -222,7 +222,7 @@ impl Message378910 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s3
+    /// Set value of 's3'
     #[inline(always)]
     pub fn set_s3(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -241,7 +241,7 @@ impl Message378910 {
         self.raw.view_bits_mut::<Lsb0>()[34..37].store_le(value);
         Ok(())
     }
-    /// s10big
+    /// Get value of 's10big'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -251,7 +251,7 @@ impl Message378910 {
     pub fn s10big(&self) -> i16 {
         self.s10big_raw()
     }
-    /// Get raw value of s10big
+    /// Get raw value of 's10big'
     ///
     /// - Start bit: 40
     /// - Signal size: 10 bits
@@ -266,7 +266,7 @@ impl Message378910 {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s10big
+    /// Set value of 's10big'
     #[inline(always)]
     pub fn set_s10big(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 0_i16 < value {
@@ -285,7 +285,7 @@ impl Message378910 {
         self.raw.view_bits_mut::<Msb0>()[47..57].store_be(value);
         Ok(())
     }
-    /// s8big
+    /// Get value of 's8big'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -295,7 +295,7 @@ impl Message378910 {
     pub fn s8big(&self) -> i8 {
         self.s8big_raw()
     }
-    /// Get raw value of s8big
+    /// Get raw value of 's8big'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -310,7 +310,7 @@ impl Message378910 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s8big
+    /// Set value of 's8big'
     #[inline(always)]
     pub fn set_s8big(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -329,7 +329,7 @@ impl Message378910 {
         self.raw.view_bits_mut::<Msb0>()[7..15].store_be(value);
         Ok(())
     }
-    /// s7big
+    /// Get value of 's7big'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -339,7 +339,7 @@ impl Message378910 {
     pub fn s7big(&self) -> i8 {
         self.s7big_raw()
     }
-    /// Get raw value of s7big
+    /// Get raw value of 's7big'
     ///
     /// - Start bit: 62
     /// - Signal size: 7 bits
@@ -354,7 +354,7 @@ impl Message378910 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s7big
+    /// Set value of 's7big'
     #[inline(always)]
     pub fn set_s7big(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -373,7 +373,7 @@ impl Message378910 {
         self.raw.view_bits_mut::<Msb0>()[57..64].store_be(value);
         Ok(())
     }
-    /// s9
+    /// Get value of 's9'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -383,7 +383,7 @@ impl Message378910 {
     pub fn s9(&self) -> i16 {
         self.s9_raw()
     }
-    /// Get raw value of s9
+    /// Get raw value of 's9'
     ///
     /// - Start bit: 17
     /// - Signal size: 9 bits
@@ -398,7 +398,7 @@ impl Message378910 {
         let signal = signal as i16;
         i16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s9
+    /// Set value of 's9'
     #[inline(always)]
     pub fn set_s9(&mut self, value: i16) -> Result<(), CanError> {
         if value < 0_i16 || 0_i16 < value {
@@ -417,7 +417,7 @@ impl Message378910 {
         self.raw.view_bits_mut::<Lsb0>()[17..26].store_le(value);
         Ok(())
     }
-    /// s8
+    /// Get value of 's8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -427,7 +427,7 @@ impl Message378910 {
     pub fn s8(&self) -> i8 {
         self.s8_raw()
     }
-    /// Get raw value of s8
+    /// Get raw value of 's8'
     ///
     /// - Start bit: 26
     /// - Signal size: 8 bits
@@ -442,7 +442,7 @@ impl Message378910 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s8
+    /// Set value of 's8'
     #[inline(always)]
     pub fn set_s8(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -461,7 +461,7 @@ impl Message378910 {
         self.raw.view_bits_mut::<Lsb0>()[26..34].store_le(value);
         Ok(())
     }
-    /// s7
+    /// Get value of 's7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -471,7 +471,7 @@ impl Message378910 {
     pub fn s7(&self) -> i8 {
         self.s7_raw()
     }
-    /// Get raw value of s7
+    /// Get raw value of 's7'
     ///
     /// - Start bit: 1
     /// - Signal size: 7 bits
@@ -486,7 +486,7 @@ impl Message378910 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s7
+    /// Set value of 's7'
     #[inline(always)]
     pub fn set_s7(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -568,7 +568,7 @@ impl Message63big1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S63BIG_MIN: i64 = 0_i64;
     pub const S63BIG_MAX: i64 = 0_i64;
-    /// Construct new Message63big_1 from values
+    /// Construct new 'Message63big_1' from values
     pub fn new(s63big: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s63big(s63big)?;
@@ -578,7 +578,7 @@ impl Message63big1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s63big
+    /// Get value of 's63big'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -588,7 +588,7 @@ impl Message63big1 {
     pub fn s63big(&self) -> i64 {
         self.s63big_raw()
     }
-    /// Get raw value of s63big
+    /// Get raw value of 's63big'
     ///
     /// - Start bit: 6
     /// - Signal size: 63 bits
@@ -603,7 +603,7 @@ impl Message63big1 {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s63big
+    /// Set value of 's63big'
     #[inline(always)]
     pub fn set_s63big(&mut self, value: i64) -> Result<(), CanError> {
         if value < 0_i64 || 0_i64 < value {
@@ -685,7 +685,7 @@ impl Message631 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S63_MIN: i64 = 0_i64;
     pub const S63_MAX: i64 = 0_i64;
-    /// Construct new Message63_1 from values
+    /// Construct new 'Message63_1' from values
     pub fn new(s63: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s63(s63)?;
@@ -695,7 +695,7 @@ impl Message631 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s63
+    /// Get value of 's63'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -705,7 +705,7 @@ impl Message631 {
     pub fn s63(&self) -> i64 {
         self.s63_raw()
     }
-    /// Get raw value of s63
+    /// Get raw value of 's63'
     ///
     /// - Start bit: 1
     /// - Signal size: 63 bits
@@ -720,7 +720,7 @@ impl Message631 {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s63
+    /// Set value of 's63'
     #[inline(always)]
     pub fn set_s63(&mut self, value: i64) -> Result<(), CanError> {
         if value < 0_i64 || 0_i64 < value {
@@ -802,7 +802,7 @@ impl Message63big {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S63BIG_MIN: i64 = 0_i64;
     pub const S63BIG_MAX: i64 = 0_i64;
-    /// Construct new Message63big from values
+    /// Construct new 'Message63big' from values
     pub fn new(s63big: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s63big(s63big)?;
@@ -812,7 +812,7 @@ impl Message63big {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s63big
+    /// Get value of 's63big'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -822,7 +822,7 @@ impl Message63big {
     pub fn s63big(&self) -> i64 {
         self.s63big_raw()
     }
-    /// Get raw value of s63big
+    /// Get raw value of 's63big'
     ///
     /// - Start bit: 7
     /// - Signal size: 63 bits
@@ -837,7 +837,7 @@ impl Message63big {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s63big
+    /// Set value of 's63big'
     #[inline(always)]
     pub fn set_s63big(&mut self, value: i64) -> Result<(), CanError> {
         if value < 0_i64 || 0_i64 < value {
@@ -919,7 +919,7 @@ impl Message63 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S63_MIN: i64 = 0_i64;
     pub const S63_MAX: i64 = 0_i64;
-    /// Construct new Message63 from values
+    /// Construct new 'Message63' from values
     pub fn new(s63: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s63(s63)?;
@@ -929,7 +929,7 @@ impl Message63 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s63
+    /// Get value of 's63'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -939,7 +939,7 @@ impl Message63 {
     pub fn s63(&self) -> i64 {
         self.s63_raw()
     }
-    /// Get raw value of s63
+    /// Get raw value of 's63'
     ///
     /// - Start bit: 0
     /// - Signal size: 63 bits
@@ -954,7 +954,7 @@ impl Message63 {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s63
+    /// Set value of 's63'
     #[inline(always)]
     pub fn set_s63(&mut self, value: i64) -> Result<(), CanError> {
         if value < 0_i64 || 0_i64 < value {
@@ -1036,7 +1036,7 @@ impl Message32big {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S32BIG_MIN: i32 = 0_i32;
     pub const S32BIG_MAX: i32 = 0_i32;
-    /// Construct new Message32big from values
+    /// Construct new 'Message32big' from values
     pub fn new(s32big: i32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s32big(s32big)?;
@@ -1046,7 +1046,7 @@ impl Message32big {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s32big
+    /// Get value of 's32big'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1056,7 +1056,7 @@ impl Message32big {
     pub fn s32big(&self) -> i32 {
         self.s32big_raw()
     }
-    /// Get raw value of s32big
+    /// Get raw value of 's32big'
     ///
     /// - Start bit: 7
     /// - Signal size: 32 bits
@@ -1071,7 +1071,7 @@ impl Message32big {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s32big
+    /// Set value of 's32big'
     #[inline(always)]
     pub fn set_s32big(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {
@@ -1153,7 +1153,7 @@ impl Message33big {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S33BIG_MIN: i64 = 0_i64;
     pub const S33BIG_MAX: i64 = 0_i64;
-    /// Construct new Message33big from values
+    /// Construct new 'Message33big' from values
     pub fn new(s33big: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s33big(s33big)?;
@@ -1163,7 +1163,7 @@ impl Message33big {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s33big
+    /// Get value of 's33big'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1173,7 +1173,7 @@ impl Message33big {
     pub fn s33big(&self) -> i64 {
         self.s33big_raw()
     }
-    /// Get raw value of s33big
+    /// Get raw value of 's33big'
     ///
     /// - Start bit: 7
     /// - Signal size: 33 bits
@@ -1188,7 +1188,7 @@ impl Message33big {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s33big
+    /// Set value of 's33big'
     #[inline(always)]
     pub fn set_s33big(&mut self, value: i64) -> Result<(), CanError> {
         if value < 0_i64 || 0_i64 < value {
@@ -1270,7 +1270,7 @@ impl Message64big {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S64BIG_MIN: i64 = 0_i64;
     pub const S64BIG_MAX: i64 = 0_i64;
-    /// Construct new Message64big from values
+    /// Construct new 'Message64big' from values
     pub fn new(s64big: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s64big(s64big)?;
@@ -1280,7 +1280,7 @@ impl Message64big {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s64big
+    /// Get value of 's64big'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1290,7 +1290,7 @@ impl Message64big {
     pub fn s64big(&self) -> i64 {
         self.s64big_raw()
     }
-    /// Get raw value of s64big
+    /// Get raw value of 's64big'
     ///
     /// - Start bit: 7
     /// - Signal size: 64 bits
@@ -1305,7 +1305,7 @@ impl Message64big {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s64big
+    /// Set value of 's64big'
     #[inline(always)]
     pub fn set_s64big(&mut self, value: i64) -> Result<(), CanError> {
         if value < 0_i64 || 0_i64 < value {
@@ -1387,7 +1387,7 @@ impl Message64 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S64_MIN: i64 = -9223372036854780000_i64;
     pub const S64_MAX: i64 = 9223372036854780000_i64;
-    /// Construct new Message64 from values
+    /// Construct new 'Message64' from values
     pub fn new(s64: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s64(s64)?;
@@ -1397,7 +1397,7 @@ impl Message64 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s64
+    /// Get value of 's64'
     ///
     /// - Min: -9223372036854780000
     /// - Max: 9223372036854780000
@@ -1407,7 +1407,7 @@ impl Message64 {
     pub fn s64(&self) -> i64 {
         self.s64_raw()
     }
-    /// Get raw value of s64
+    /// Get raw value of 's64'
     ///
     /// - Start bit: 0
     /// - Signal size: 64 bits
@@ -1422,7 +1422,7 @@ impl Message64 {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s64
+    /// Set value of 's64'
     #[inline(always)]
     pub fn set_s64(&mut self, value: i64) -> Result<(), CanError> {
         if value < -9223372036854780000_i64 || 9223372036854780000_i64 < value {
@@ -1504,7 +1504,7 @@ impl Message33 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S33_MIN: i64 = -4294967296_i64;
     pub const S33_MAX: i64 = 4294967295_i64;
-    /// Construct new Message33 from values
+    /// Construct new 'Message33' from values
     pub fn new(s33: i64) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s33(s33)?;
@@ -1514,7 +1514,7 @@ impl Message33 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s33
+    /// Get value of 's33'
     ///
     /// - Min: -4294967296
     /// - Max: 4294967295
@@ -1524,7 +1524,7 @@ impl Message33 {
     pub fn s33(&self) -> i64 {
         self.s33_raw()
     }
-    /// Get raw value of s33
+    /// Get raw value of 's33'
     ///
     /// - Start bit: 0
     /// - Signal size: 33 bits
@@ -1539,7 +1539,7 @@ impl Message33 {
         let signal = signal as i64;
         i64::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s33
+    /// Set value of 's33'
     #[inline(always)]
     pub fn set_s33(&mut self, value: i64) -> Result<(), CanError> {
         if value < -4294967296_i64 || 4294967295_i64 < value {
@@ -1621,7 +1621,7 @@ impl Message32 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const S32_MIN: i32 = 0_i32;
     pub const S32_MAX: i32 = 0_i32;
-    /// Construct new Message32 from values
+    /// Construct new 'Message32' from values
     pub fn new(s32: i32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_s32(s32)?;
@@ -1631,7 +1631,7 @@ impl Message32 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// s32
+    /// Get value of 's32'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1641,7 +1641,7 @@ impl Message32 {
     pub fn s32(&self) -> i32 {
         self.s32_raw()
     }
-    /// Get raw value of s32
+    /// Get raw value of 's32'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -1656,7 +1656,7 @@ impl Message32 {
         let signal = signal as i32;
         i32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of s32
+    /// Set value of 's32'
     #[inline(always)]
     pub fn set_s32(&mut self, value: i32) -> Result<(), CanError> {
         if value < 0_i32 || 0_i32 < value {

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
@@ -143,11 +143,7 @@ impl DriverHeartbeat {
         &mut self,
         value: DriverHeartbeatDriverHeartbeatCmd,
     ) -> Result<(), CanError> {
-        self.set_driver_heartbeat_cmd_raw(u8::from(value))
-    }
-    /// Set raw value of 'DRIVER_HEARTBEAT_cmd'
-    #[inline(always)]
-    pub fn set_driver_heartbeat_cmd_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: DriverHeartbeat::MESSAGE_ID,
@@ -397,11 +393,7 @@ impl IoDebug {
         &mut self,
         value: IoDebugIoDebugTestEnum,
     ) -> Result<(), CanError> {
-        self.set_io_debug_test_enum_raw(u8::from(value))
-    }
-    /// Set raw value of 'IO_DEBUG_test_enum'
-    #[inline(always)]
-    pub fn set_io_debug_test_enum_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: IoDebug::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
@@ -91,8 +91,10 @@ impl DriverHeartbeat {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
-    /// Construct new DRIVER_HEARTBEAT from values
-    pub fn new(driver_heartbeat_cmd: u8) -> Result<Self, CanError> {
+    /// Construct new 'DRIVER_HEARTBEAT' from values
+    pub fn new(
+        driver_heartbeat_cmd: DriverHeartbeatDriverHeartbeatCmd,
+    ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_driver_heartbeat_cmd(driver_heartbeat_cmd)?;
         Ok(res)
@@ -101,7 +103,7 @@ impl DriverHeartbeat {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// DRIVER_HEARTBEAT_cmd
+    /// Get value of 'DRIVER_HEARTBEAT_cmd'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -121,7 +123,7 @@ impl DriverHeartbeat {
             }
         }
     }
-    /// Get raw value of DRIVER_HEARTBEAT_cmd
+    /// Get raw value of 'DRIVER_HEARTBEAT_cmd'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -135,9 +137,17 @@ impl DriverHeartbeat {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of DRIVER_HEARTBEAT_cmd
+    /// Set value of 'DRIVER_HEARTBEAT_cmd'
     #[inline(always)]
-    pub fn set_driver_heartbeat_cmd(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_driver_heartbeat_cmd(
+        &mut self,
+        value: DriverHeartbeatDriverHeartbeatCmd,
+    ) -> Result<(), CanError> {
+        self.set_driver_heartbeat_cmd_raw(u8::from(value))
+    }
+    /// Set raw value of 'DRIVER_HEARTBEAT_cmd'
+    #[inline(always)]
+    pub fn set_driver_heartbeat_cmd_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: DriverHeartbeat::MESSAGE_ID,
@@ -251,11 +261,11 @@ impl IoDebug {
     pub const IO_DEBUG_TEST_ENUM_MAX: u8 = 0_u8;
     pub const IO_DEBUG_TEST_UNSIGNED_MIN: u8 = 0_u8;
     pub const IO_DEBUG_TEST_UNSIGNED_MAX: u8 = 0_u8;
-    /// Construct new IO_DEBUG from values
+    /// Construct new 'IO_DEBUG' from values
     pub fn new(
         io_debug_test_float: f32,
         io_debug_test_signed: i8,
-        io_debug_test_enum: u8,
+        io_debug_test_enum: IoDebugIoDebugTestEnum,
         io_debug_test_unsigned: u8,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 4] };
@@ -269,7 +279,7 @@ impl IoDebug {
     pub fn raw(&self) -> &[u8; 4] {
         &self.raw
     }
-    /// IO_DEBUG_test_float
+    /// Get value of 'IO_DEBUG_test_float'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -279,7 +289,7 @@ impl IoDebug {
     pub fn io_debug_test_float(&self) -> f32 {
         self.io_debug_test_float_raw()
     }
-    /// Get raw value of IO_DEBUG_test_float
+    /// Get raw value of 'IO_DEBUG_test_float'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -294,7 +304,7 @@ impl IoDebug {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IO_DEBUG_test_float
+    /// Set value of 'IO_DEBUG_test_float'
     #[inline(always)]
     pub fn set_io_debug_test_float(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -308,7 +318,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_signed
+    /// Get value of 'IO_DEBUG_test_signed'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -318,7 +328,7 @@ impl IoDebug {
     pub fn io_debug_test_signed(&self) -> i8 {
         self.io_debug_test_signed_raw()
     }
-    /// Get raw value of IO_DEBUG_test_signed
+    /// Get raw value of 'IO_DEBUG_test_signed'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -333,7 +343,7 @@ impl IoDebug {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_signed
+    /// Set value of 'IO_DEBUG_test_signed'
     #[inline(always)]
     pub fn set_io_debug_test_signed(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -352,7 +362,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_enum
+    /// Get value of 'IO_DEBUG_test_enum'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -367,7 +377,7 @@ impl IoDebug {
             _ => IoDebugIoDebugTestEnum::_Other(self.io_debug_test_enum_raw()),
         }
     }
-    /// Get raw value of IO_DEBUG_test_enum
+    /// Get raw value of 'IO_DEBUG_test_enum'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -381,9 +391,17 @@ impl IoDebug {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_enum
+    /// Set value of 'IO_DEBUG_test_enum'
     #[inline(always)]
-    pub fn set_io_debug_test_enum(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_io_debug_test_enum(
+        &mut self,
+        value: IoDebugIoDebugTestEnum,
+    ) -> Result<(), CanError> {
+        self.set_io_debug_test_enum_raw(u8::from(value))
+    }
+    /// Set raw value of 'IO_DEBUG_test_enum'
+    #[inline(always)]
+    pub fn set_io_debug_test_enum_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: IoDebug::MESSAGE_ID,
@@ -399,7 +417,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_unsigned
+    /// Get value of 'IO_DEBUG_test_unsigned'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -409,7 +427,7 @@ impl IoDebug {
     pub fn io_debug_test_unsigned(&self) -> u8 {
         self.io_debug_test_unsigned_raw()
     }
-    /// Get raw value of IO_DEBUG_test_unsigned
+    /// Get raw value of 'IO_DEBUG_test_unsigned'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -423,7 +441,7 @@ impl IoDebug {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_unsigned
+    /// Set value of 'IO_DEBUG_test_unsigned'
     #[inline(always)]
     pub fn set_io_debug_test_unsigned(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -533,7 +551,7 @@ impl MotorCmd {
     pub const MOTOR_CMD_DRIVE_MAX: u8 = 9_u8;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
     pub const MOTOR_CMD_STEER_MAX: i8 = 5_i8;
-    /// Construct new MOTOR_CMD from values
+    /// Construct new 'MOTOR_CMD' from values
     pub fn new(motor_cmd_drive: u8, motor_cmd_steer: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_motor_cmd_drive(motor_cmd_drive)?;
@@ -544,7 +562,7 @@ impl MotorCmd {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// MOTOR_CMD_drive
+    /// Get value of 'MOTOR_CMD_drive'
     ///
     /// - Min: 0
     /// - Max: 9
@@ -554,7 +572,7 @@ impl MotorCmd {
     pub fn motor_cmd_drive(&self) -> u8 {
         self.motor_cmd_drive_raw()
     }
-    /// Get raw value of MOTOR_CMD_drive
+    /// Get raw value of 'MOTOR_CMD_drive'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -568,7 +586,7 @@ impl MotorCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MOTOR_CMD_drive
+    /// Set value of 'MOTOR_CMD_drive'
     #[inline(always)]
     pub fn set_motor_cmd_drive(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 9_u8 < value {
@@ -586,7 +604,7 @@ impl MotorCmd {
         self.raw.view_bits_mut::<Lsb0>()[4..8].store_le(value);
         Ok(())
     }
-    /// MOTOR_CMD_steer
+    /// Get value of 'MOTOR_CMD_steer'
     ///
     /// - Min: -5
     /// - Max: 5
@@ -596,7 +614,7 @@ impl MotorCmd {
     pub fn motor_cmd_steer(&self) -> i8 {
         self.motor_cmd_steer_raw()
     }
-    /// Get raw value of MOTOR_CMD_steer
+    /// Get raw value of 'MOTOR_CMD_steer'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -611,7 +629,7 @@ impl MotorCmd {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_sub(5)
     }
-    /// Set value of MOTOR_CMD_steer
+    /// Set value of 'MOTOR_CMD_steer'
     #[inline(always)]
     pub fn set_motor_cmd_steer(&mut self, value: i8) -> Result<(), CanError> {
         if value < -5_i8 || 5_i8 < value {
@@ -695,7 +713,7 @@ impl MotorStatus {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
-    /// Construct new MOTOR_STATUS from values
+    /// Construct new 'MOTOR_STATUS' from values
     pub fn new(
         motor_status_speed_kph: f32,
         motor_status_wheel_error: bool,
@@ -709,7 +727,7 @@ impl MotorStatus {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// MOTOR_STATUS_speed_kph
+    /// Get value of 'MOTOR_STATUS_speed_kph'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -719,7 +737,7 @@ impl MotorStatus {
     pub fn motor_status_speed_kph(&self) -> f32 {
         self.motor_status_speed_kph_raw()
     }
-    /// Get raw value of MOTOR_STATUS_speed_kph
+    /// Get raw value of 'MOTOR_STATUS_speed_kph'
     ///
     /// - Start bit: 8
     /// - Signal size: 16 bits
@@ -734,7 +752,7 @@ impl MotorStatus {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of MOTOR_STATUS_speed_kph
+    /// Set value of 'MOTOR_STATUS_speed_kph'
     #[inline(always)]
     pub fn set_motor_status_speed_kph(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -748,7 +766,7 @@ impl MotorStatus {
         self.raw.view_bits_mut::<Lsb0>()[8..24].store_le(value);
         Ok(())
     }
-    /// MOTOR_STATUS_wheel_error
+    /// Get value of 'MOTOR_STATUS_wheel_error'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -758,7 +776,7 @@ impl MotorStatus {
     pub fn motor_status_wheel_error(&self) -> bool {
         self.motor_status_wheel_error_raw()
     }
-    /// Get raw value of MOTOR_STATUS_wheel_error
+    /// Get raw value of 'MOTOR_STATUS_wheel_error'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -771,7 +789,7 @@ impl MotorStatus {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of MOTOR_STATUS_wheel_error
+    /// Set value of 'MOTOR_STATUS_wheel_error'
     #[inline(always)]
     pub fn set_motor_status_wheel_error(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -861,7 +879,7 @@ impl SensorSonars {
     pub const SENSOR_SONARS_ERR_COUNT_MAX: u16 = 0_u16;
     pub const SENSOR_SONARS_MUX_MIN: u8 = 0_u8;
     pub const SENSOR_SONARS_MUX_MAX: u8 = 0_u8;
-    /// Construct new SENSOR_SONARS from values
+    /// Construct new 'SENSOR_SONARS' from values
     pub fn new(
         sensor_sonars_err_count: u16,
         sensor_sonars_mux: u8,
@@ -875,7 +893,7 @@ impl SensorSonars {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SENSOR_SONARS_err_count
+    /// Get value of 'SENSOR_SONARS_err_count'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -885,7 +903,7 @@ impl SensorSonars {
     pub fn sensor_sonars_err_count(&self) -> u16 {
         self.sensor_sonars_err_count_raw()
     }
-    /// Get raw value of SENSOR_SONARS_err_count
+    /// Get raw value of 'SENSOR_SONARS_err_count'
     ///
     /// - Start bit: 4
     /// - Signal size: 12 bits
@@ -899,7 +917,7 @@ impl SensorSonars {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SENSOR_SONARS_err_count
+    /// Set value of 'SENSOR_SONARS_err_count'
     #[inline(always)]
     pub fn set_sensor_sonars_err_count(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -917,7 +935,7 @@ impl SensorSonars {
         self.raw.view_bits_mut::<Lsb0>()[4..16].store_le(value);
         Ok(())
     }
-    /// Get raw value of SENSOR_SONARS_mux
+    /// Get raw value of 'SENSOR_SONARS_mux'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -957,7 +975,7 @@ impl SensorSonars {
             }
         }
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     fn set_sensor_sonars_mux(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -975,7 +993,7 @@ impl SensorSonars {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -987,7 +1005,7 @@ impl SensorSonars {
         self.set_sensor_sonars_mux(0)?;
         Ok(())
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -1078,7 +1096,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SENSOR_SONARS_rear
+    /// Get value of 'SENSOR_SONARS_rear'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1088,7 +1106,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_rear(&self) -> f32 {
         self.sensor_sonars_rear_raw()
     }
-    /// Get raw value of SENSOR_SONARS_rear
+    /// Get raw value of 'SENSOR_SONARS_rear'
     ///
     /// - Start bit: 52
     /// - Signal size: 12 bits
@@ -1103,7 +1121,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_rear
+    /// Set value of 'SENSOR_SONARS_rear'
     #[inline(always)]
     pub fn set_sensor_sonars_rear(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1117,7 +1135,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[52..64].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_right
+    /// Get value of 'SENSOR_SONARS_right'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1127,7 +1145,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_right(&self) -> f32 {
         self.sensor_sonars_right_raw()
     }
-    /// Get raw value of SENSOR_SONARS_right
+    /// Get raw value of 'SENSOR_SONARS_right'
     ///
     /// - Start bit: 40
     /// - Signal size: 12 bits
@@ -1142,7 +1160,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_right
+    /// Set value of 'SENSOR_SONARS_right'
     #[inline(always)]
     pub fn set_sensor_sonars_right(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1156,7 +1174,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[40..52].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_middle
+    /// Get value of 'SENSOR_SONARS_middle'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1166,7 +1184,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_middle(&self) -> f32 {
         self.sensor_sonars_middle_raw()
     }
-    /// Get raw value of SENSOR_SONARS_middle
+    /// Get raw value of 'SENSOR_SONARS_middle'
     ///
     /// - Start bit: 28
     /// - Signal size: 12 bits
@@ -1181,7 +1199,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_middle
+    /// Set value of 'SENSOR_SONARS_middle'
     #[inline(always)]
     pub fn set_sensor_sonars_middle(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1195,7 +1213,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[28..40].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_left
+    /// Get value of 'SENSOR_SONARS_left'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1205,7 +1223,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_left(&self) -> f32 {
         self.sensor_sonars_left_raw()
     }
-    /// Get raw value of SENSOR_SONARS_left
+    /// Get raw value of 'SENSOR_SONARS_left'
     ///
     /// - Start bit: 16
     /// - Signal size: 12 bits
@@ -1220,7 +1238,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_left
+    /// Set value of 'SENSOR_SONARS_left'
     #[inline(always)]
     pub fn set_sensor_sonars_left(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1261,7 +1279,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SENSOR_SONARS_no_filt_rear
+    /// Get value of 'SENSOR_SONARS_no_filt_rear'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1271,7 +1289,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_rear(&self) -> f32 {
         self.sensor_sonars_no_filt_rear_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_rear
+    /// Get raw value of 'SENSOR_SONARS_no_filt_rear'
     ///
     /// - Start bit: 52
     /// - Signal size: 12 bits
@@ -1286,7 +1304,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_rear
+    /// Set value of 'SENSOR_SONARS_no_filt_rear'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_rear(
         &mut self,
@@ -1303,7 +1321,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[52..64].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_right
+    /// Get value of 'SENSOR_SONARS_no_filt_right'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1313,7 +1331,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_right(&self) -> f32 {
         self.sensor_sonars_no_filt_right_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_right
+    /// Get raw value of 'SENSOR_SONARS_no_filt_right'
     ///
     /// - Start bit: 40
     /// - Signal size: 12 bits
@@ -1328,7 +1346,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_right
+    /// Set value of 'SENSOR_SONARS_no_filt_right'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_right(
         &mut self,
@@ -1345,7 +1363,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[40..52].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_middle
+    /// Get value of 'SENSOR_SONARS_no_filt_middle'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1355,7 +1373,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_middle(&self) -> f32 {
         self.sensor_sonars_no_filt_middle_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_middle
+    /// Get raw value of 'SENSOR_SONARS_no_filt_middle'
     ///
     /// - Start bit: 28
     /// - Signal size: 12 bits
@@ -1370,7 +1388,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_middle
+    /// Set value of 'SENSOR_SONARS_no_filt_middle'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_middle(
         &mut self,
@@ -1387,7 +1405,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[28..40].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_left
+    /// Get value of 'SENSOR_SONARS_no_filt_left'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1397,7 +1415,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_left(&self) -> f32 {
         self.sensor_sonars_no_filt_left_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_left
+    /// Get raw value of 'SENSOR_SONARS_no_filt_left'
     ///
     /// - Start bit: 16
     /// - Signal size: 12 bits
@@ -1412,7 +1430,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_left
+    /// Set value of 'SENSOR_SONARS_no_filt_left'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_left(
         &mut self,

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
@@ -143,11 +143,7 @@ impl DriverHeartbeat {
         &mut self,
         value: DriverHeartbeatDriverHeartbeatCmd,
     ) -> Result<(), CanError> {
-        self.set_driver_heartbeat_cmd_raw(u8::from(value))
-    }
-    /// Set raw value of 'DRIVER_HEARTBEAT_cmd'
-    #[inline(always)]
-    pub fn set_driver_heartbeat_cmd_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: DriverHeartbeat::MESSAGE_ID,
@@ -314,11 +310,7 @@ impl IoDebug {
         &mut self,
         value: IoDebugIoDebugTestEnum,
     ) -> Result<(), CanError> {
-        self.set_io_debug_test_enum_raw(u8::from(value))
-    }
-    /// Set raw value of 'IO_DEBUG_test_enum'
-    #[inline(always)]
-    pub fn set_io_debug_test_enum_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: IoDebug::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
@@ -91,8 +91,10 @@ impl DriverHeartbeat {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
-    /// Construct new DRIVER_HEARTBEAT from values
-    pub fn new(driver_heartbeat_cmd: u8) -> Result<Self, CanError> {
+    /// Construct new 'DRIVER_HEARTBEAT' from values
+    pub fn new(
+        driver_heartbeat_cmd: DriverHeartbeatDriverHeartbeatCmd,
+    ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_driver_heartbeat_cmd(driver_heartbeat_cmd)?;
         Ok(res)
@@ -101,7 +103,7 @@ impl DriverHeartbeat {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// DRIVER_HEARTBEAT_cmd
+    /// Get value of 'DRIVER_HEARTBEAT_cmd'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -121,7 +123,7 @@ impl DriverHeartbeat {
             }
         }
     }
-    /// Get raw value of DRIVER_HEARTBEAT_cmd
+    /// Get raw value of 'DRIVER_HEARTBEAT_cmd'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -135,9 +137,17 @@ impl DriverHeartbeat {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of DRIVER_HEARTBEAT_cmd
+    /// Set value of 'DRIVER_HEARTBEAT_cmd'
     #[inline(always)]
-    pub fn set_driver_heartbeat_cmd(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_driver_heartbeat_cmd(
+        &mut self,
+        value: DriverHeartbeatDriverHeartbeatCmd,
+    ) -> Result<(), CanError> {
+        self.set_driver_heartbeat_cmd_raw(u8::from(value))
+    }
+    /// Set raw value of 'DRIVER_HEARTBEAT_cmd'
+    #[inline(always)]
+    pub fn set_driver_heartbeat_cmd_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: DriverHeartbeat::MESSAGE_ID,
@@ -251,9 +261,9 @@ impl IoDebug {
     pub const IO_DEBUG_TEST_SIGNED_MAX: i8 = 0_i8;
     pub const IO_DEBUG_TEST_UNSIGNED_MIN: u8 = 0_u8;
     pub const IO_DEBUG_TEST_UNSIGNED_MAX: u8 = 0_u8;
-    /// Construct new IO_DEBUG from values
+    /// Construct new 'IO_DEBUG' from values
     pub fn new(
-        io_debug_test_enum: u8,
+        io_debug_test_enum: IoDebugIoDebugTestEnum,
         io_debug_test_float: f32,
         io_debug_test_signed: i8,
         io_debug_test_unsigned: u8,
@@ -269,7 +279,7 @@ impl IoDebug {
     pub fn raw(&self) -> &[u8; 4] {
         &self.raw
     }
-    /// IO_DEBUG_test_enum
+    /// Get value of 'IO_DEBUG_test_enum'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -284,7 +294,7 @@ impl IoDebug {
             _ => IoDebugIoDebugTestEnum::_Other(self.io_debug_test_enum_raw()),
         }
     }
-    /// Get raw value of IO_DEBUG_test_enum
+    /// Get raw value of 'IO_DEBUG_test_enum'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -298,9 +308,17 @@ impl IoDebug {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_enum
+    /// Set value of 'IO_DEBUG_test_enum'
     #[inline(always)]
-    pub fn set_io_debug_test_enum(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_io_debug_test_enum(
+        &mut self,
+        value: IoDebugIoDebugTestEnum,
+    ) -> Result<(), CanError> {
+        self.set_io_debug_test_enum_raw(u8::from(value))
+    }
+    /// Set raw value of 'IO_DEBUG_test_enum'
+    #[inline(always)]
+    pub fn set_io_debug_test_enum_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: IoDebug::MESSAGE_ID,
@@ -316,7 +334,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_float
+    /// Get value of 'IO_DEBUG_test_float'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -326,7 +344,7 @@ impl IoDebug {
     pub fn io_debug_test_float(&self) -> f32 {
         self.io_debug_test_float_raw()
     }
-    /// Get raw value of IO_DEBUG_test_float
+    /// Get raw value of 'IO_DEBUG_test_float'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -341,7 +359,7 @@ impl IoDebug {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IO_DEBUG_test_float
+    /// Set value of 'IO_DEBUG_test_float'
     #[inline(always)]
     pub fn set_io_debug_test_float(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -355,7 +373,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_signed
+    /// Get value of 'IO_DEBUG_test_signed'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -365,7 +383,7 @@ impl IoDebug {
     pub fn io_debug_test_signed(&self) -> i8 {
         self.io_debug_test_signed_raw()
     }
-    /// Get raw value of IO_DEBUG_test_signed
+    /// Get raw value of 'IO_DEBUG_test_signed'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -380,7 +398,7 @@ impl IoDebug {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_signed
+    /// Set value of 'IO_DEBUG_test_signed'
     #[inline(always)]
     pub fn set_io_debug_test_signed(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -399,7 +417,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_unsigned
+    /// Get value of 'IO_DEBUG_test_unsigned'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -409,7 +427,7 @@ impl IoDebug {
     pub fn io_debug_test_unsigned(&self) -> u8 {
         self.io_debug_test_unsigned_raw()
     }
-    /// Get raw value of IO_DEBUG_test_unsigned
+    /// Get raw value of 'IO_DEBUG_test_unsigned'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -423,7 +441,7 @@ impl IoDebug {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_unsigned
+    /// Set value of 'IO_DEBUG_test_unsigned'
     #[inline(always)]
     pub fn set_io_debug_test_unsigned(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -533,7 +551,7 @@ impl MotorCmd {
     pub const MOTOR_CMD_DRIVE_MAX: u8 = 9_u8;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
     pub const MOTOR_CMD_STEER_MAX: i8 = 5_i8;
-    /// Construct new MOTOR_CMD from values
+    /// Construct new 'MOTOR_CMD' from values
     pub fn new(motor_cmd_drive: u8, motor_cmd_steer: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_motor_cmd_drive(motor_cmd_drive)?;
@@ -544,7 +562,7 @@ impl MotorCmd {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// MOTOR_CMD_drive
+    /// Get value of 'MOTOR_CMD_drive'
     ///
     /// - Min: 0
     /// - Max: 9
@@ -554,7 +572,7 @@ impl MotorCmd {
     pub fn motor_cmd_drive(&self) -> u8 {
         self.motor_cmd_drive_raw()
     }
-    /// Get raw value of MOTOR_CMD_drive
+    /// Get raw value of 'MOTOR_CMD_drive'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -568,7 +586,7 @@ impl MotorCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MOTOR_CMD_drive
+    /// Set value of 'MOTOR_CMD_drive'
     #[inline(always)]
     pub fn set_motor_cmd_drive(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 9_u8 < value {
@@ -586,7 +604,7 @@ impl MotorCmd {
         self.raw.view_bits_mut::<Lsb0>()[4..8].store_le(value);
         Ok(())
     }
-    /// MOTOR_CMD_steer
+    /// Get value of 'MOTOR_CMD_steer'
     ///
     /// - Min: -5
     /// - Max: 5
@@ -596,7 +614,7 @@ impl MotorCmd {
     pub fn motor_cmd_steer(&self) -> i8 {
         self.motor_cmd_steer_raw()
     }
-    /// Get raw value of MOTOR_CMD_steer
+    /// Get raw value of 'MOTOR_CMD_steer'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -611,7 +629,7 @@ impl MotorCmd {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_sub(5)
     }
-    /// Set value of MOTOR_CMD_steer
+    /// Set value of 'MOTOR_CMD_steer'
     #[inline(always)]
     pub fn set_motor_cmd_steer(&mut self, value: i8) -> Result<(), CanError> {
         if value < -5_i8 || 5_i8 < value {
@@ -695,7 +713,7 @@ impl MotorStatus {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
-    /// Construct new MOTOR_STATUS from values
+    /// Construct new 'MOTOR_STATUS' from values
     pub fn new(
         motor_status_speed_kph: f32,
         motor_status_wheel_error: bool,
@@ -709,7 +727,7 @@ impl MotorStatus {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// MOTOR_STATUS_speed_kph
+    /// Get value of 'MOTOR_STATUS_speed_kph'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -719,7 +737,7 @@ impl MotorStatus {
     pub fn motor_status_speed_kph(&self) -> f32 {
         self.motor_status_speed_kph_raw()
     }
-    /// Get raw value of MOTOR_STATUS_speed_kph
+    /// Get raw value of 'MOTOR_STATUS_speed_kph'
     ///
     /// - Start bit: 8
     /// - Signal size: 16 bits
@@ -734,7 +752,7 @@ impl MotorStatus {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of MOTOR_STATUS_speed_kph
+    /// Set value of 'MOTOR_STATUS_speed_kph'
     #[inline(always)]
     pub fn set_motor_status_speed_kph(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -748,7 +766,7 @@ impl MotorStatus {
         self.raw.view_bits_mut::<Lsb0>()[8..24].store_le(value);
         Ok(())
     }
-    /// MOTOR_STATUS_wheel_error
+    /// Get value of 'MOTOR_STATUS_wheel_error'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -758,7 +776,7 @@ impl MotorStatus {
     pub fn motor_status_wheel_error(&self) -> bool {
         self.motor_status_wheel_error_raw()
     }
-    /// Get raw value of MOTOR_STATUS_wheel_error
+    /// Get raw value of 'MOTOR_STATUS_wheel_error'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -771,7 +789,7 @@ impl MotorStatus {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of MOTOR_STATUS_wheel_error
+    /// Set value of 'MOTOR_STATUS_wheel_error'
     #[inline(always)]
     pub fn set_motor_status_wheel_error(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -861,7 +879,7 @@ impl SensorSonars {
     pub const SENSOR_SONARS_REAR_MAX: f32 = 0_f32;
     pub const SENSOR_SONARS_RIGHT_MIN: f32 = 0_f32;
     pub const SENSOR_SONARS_RIGHT_MAX: f32 = 0_f32;
-    /// Construct new SENSOR_SONARS from values
+    /// Construct new 'SENSOR_SONARS' from values
     pub fn new(
         sensor_sonars_err_count: u16,
         sensor_sonars_mux: u8,
@@ -875,7 +893,7 @@ impl SensorSonars {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SENSOR_SONARS_err_count
+    /// Get value of 'SENSOR_SONARS_err_count'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -885,7 +903,7 @@ impl SensorSonars {
     pub fn sensor_sonars_err_count(&self) -> u16 {
         self.sensor_sonars_err_count_raw()
     }
-    /// Get raw value of SENSOR_SONARS_err_count
+    /// Get raw value of 'SENSOR_SONARS_err_count'
     ///
     /// - Start bit: 4
     /// - Signal size: 12 bits
@@ -899,7 +917,7 @@ impl SensorSonars {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SENSOR_SONARS_err_count
+    /// Set value of 'SENSOR_SONARS_err_count'
     #[inline(always)]
     pub fn set_sensor_sonars_err_count(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -917,7 +935,7 @@ impl SensorSonars {
         self.raw.view_bits_mut::<Lsb0>()[4..16].store_le(value);
         Ok(())
     }
-    /// Get raw value of SENSOR_SONARS_mux
+    /// Get raw value of 'SENSOR_SONARS_mux'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -957,7 +975,7 @@ impl SensorSonars {
             }
         }
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     fn set_sensor_sonars_mux(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -975,7 +993,7 @@ impl SensorSonars {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -987,7 +1005,7 @@ impl SensorSonars {
         self.set_sensor_sonars_mux(0)?;
         Ok(())
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -1078,7 +1096,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SENSOR_SONARS_left
+    /// Get value of 'SENSOR_SONARS_left'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1088,7 +1106,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_left(&self) -> f32 {
         self.sensor_sonars_left_raw()
     }
-    /// Get raw value of SENSOR_SONARS_left
+    /// Get raw value of 'SENSOR_SONARS_left'
     ///
     /// - Start bit: 16
     /// - Signal size: 12 bits
@@ -1103,7 +1121,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_left
+    /// Set value of 'SENSOR_SONARS_left'
     #[inline(always)]
     pub fn set_sensor_sonars_left(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1117,7 +1135,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[16..28].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_middle
+    /// Get value of 'SENSOR_SONARS_middle'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1127,7 +1145,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_middle(&self) -> f32 {
         self.sensor_sonars_middle_raw()
     }
-    /// Get raw value of SENSOR_SONARS_middle
+    /// Get raw value of 'SENSOR_SONARS_middle'
     ///
     /// - Start bit: 28
     /// - Signal size: 12 bits
@@ -1142,7 +1160,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_middle
+    /// Set value of 'SENSOR_SONARS_middle'
     #[inline(always)]
     pub fn set_sensor_sonars_middle(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1156,7 +1174,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[28..40].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_rear
+    /// Get value of 'SENSOR_SONARS_rear'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1166,7 +1184,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_rear(&self) -> f32 {
         self.sensor_sonars_rear_raw()
     }
-    /// Get raw value of SENSOR_SONARS_rear
+    /// Get raw value of 'SENSOR_SONARS_rear'
     ///
     /// - Start bit: 52
     /// - Signal size: 12 bits
@@ -1181,7 +1199,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_rear
+    /// Set value of 'SENSOR_SONARS_rear'
     #[inline(always)]
     pub fn set_sensor_sonars_rear(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1195,7 +1213,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[52..64].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_right
+    /// Get value of 'SENSOR_SONARS_right'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1205,7 +1223,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_right(&self) -> f32 {
         self.sensor_sonars_right_raw()
     }
-    /// Get raw value of SENSOR_SONARS_right
+    /// Get raw value of 'SENSOR_SONARS_right'
     ///
     /// - Start bit: 40
     /// - Signal size: 12 bits
@@ -1220,7 +1238,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_right
+    /// Set value of 'SENSOR_SONARS_right'
     #[inline(always)]
     pub fn set_sensor_sonars_right(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1261,7 +1279,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SENSOR_SONARS_no_filt_left
+    /// Get value of 'SENSOR_SONARS_no_filt_left'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1271,7 +1289,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_left(&self) -> f32 {
         self.sensor_sonars_no_filt_left_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_left
+    /// Get raw value of 'SENSOR_SONARS_no_filt_left'
     ///
     /// - Start bit: 16
     /// - Signal size: 12 bits
@@ -1286,7 +1304,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_left
+    /// Set value of 'SENSOR_SONARS_no_filt_left'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_left(
         &mut self,
@@ -1303,7 +1321,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[16..28].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_middle
+    /// Get value of 'SENSOR_SONARS_no_filt_middle'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1313,7 +1331,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_middle(&self) -> f32 {
         self.sensor_sonars_no_filt_middle_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_middle
+    /// Get raw value of 'SENSOR_SONARS_no_filt_middle'
     ///
     /// - Start bit: 28
     /// - Signal size: 12 bits
@@ -1328,7 +1346,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_middle
+    /// Set value of 'SENSOR_SONARS_no_filt_middle'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_middle(
         &mut self,
@@ -1345,7 +1363,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[28..40].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_rear
+    /// Get value of 'SENSOR_SONARS_no_filt_rear'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1355,7 +1373,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_rear(&self) -> f32 {
         self.sensor_sonars_no_filt_rear_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_rear
+    /// Get raw value of 'SENSOR_SONARS_no_filt_rear'
     ///
     /// - Start bit: 52
     /// - Signal size: 12 bits
@@ -1370,7 +1388,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_rear
+    /// Set value of 'SENSOR_SONARS_no_filt_rear'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_rear(
         &mut self,
@@ -1387,7 +1405,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[52..64].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_right
+    /// Get value of 'SENSOR_SONARS_no_filt_right'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1397,7 +1415,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_right(&self) -> f32 {
         self.sensor_sonars_no_filt_right_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_right
+    /// Get raw value of 'SENSOR_SONARS_no_filt_right'
     ///
     /// - Start bit: 40
     /// - Signal size: 12 bits
@@ -1412,7 +1430,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_right
+    /// Set value of 'SENSOR_SONARS_no_filt_right'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_right(
         &mut self,

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
@@ -143,11 +143,7 @@ impl DriverHeartbeat {
         &mut self,
         value: DriverHeartbeatDriverHeartbeatCmd,
     ) -> Result<(), CanError> {
-        self.set_driver_heartbeat_cmd_raw(u8::from(value))
-    }
-    /// Set raw value of 'DRIVER_HEARTBEAT_cmd'
-    #[inline(always)]
-    pub fn set_driver_heartbeat_cmd_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: DriverHeartbeat::MESSAGE_ID,
@@ -356,11 +352,7 @@ impl IoDebug {
         &mut self,
         value: IoDebugIoDebugTestEnum,
     ) -> Result<(), CanError> {
-        self.set_io_debug_test_enum_raw(u8::from(value))
-    }
-    /// Set raw value of 'IO_DEBUG_test_enum'
-    #[inline(always)]
-    pub fn set_io_debug_test_enum_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: IoDebug::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
@@ -91,8 +91,10 @@ impl DriverHeartbeat {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
-    /// Construct new DRIVER_HEARTBEAT from values
-    pub fn new(driver_heartbeat_cmd: u8) -> Result<Self, CanError> {
+    /// Construct new 'DRIVER_HEARTBEAT' from values
+    pub fn new(
+        driver_heartbeat_cmd: DriverHeartbeatDriverHeartbeatCmd,
+    ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_driver_heartbeat_cmd(driver_heartbeat_cmd)?;
         Ok(res)
@@ -101,7 +103,7 @@ impl DriverHeartbeat {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// DRIVER_HEARTBEAT_cmd
+    /// Get value of 'DRIVER_HEARTBEAT_cmd'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -121,7 +123,7 @@ impl DriverHeartbeat {
             }
         }
     }
-    /// Get raw value of DRIVER_HEARTBEAT_cmd
+    /// Get raw value of 'DRIVER_HEARTBEAT_cmd'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -135,9 +137,17 @@ impl DriverHeartbeat {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of DRIVER_HEARTBEAT_cmd
+    /// Set value of 'DRIVER_HEARTBEAT_cmd'
     #[inline(always)]
-    pub fn set_driver_heartbeat_cmd(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_driver_heartbeat_cmd(
+        &mut self,
+        value: DriverHeartbeatDriverHeartbeatCmd,
+    ) -> Result<(), CanError> {
+        self.set_driver_heartbeat_cmd_raw(u8::from(value))
+    }
+    /// Set raw value of 'DRIVER_HEARTBEAT_cmd'
+    #[inline(always)]
+    pub fn set_driver_heartbeat_cmd_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: DriverHeartbeat::MESSAGE_ID,
@@ -251,10 +261,10 @@ impl IoDebug {
     pub const IO_DEBUG_TEST_SIGNED_MAX: i8 = 0_i8;
     pub const IO_DEBUG_TEST_FLOAT_MIN: f32 = 0_f32;
     pub const IO_DEBUG_TEST_FLOAT_MAX: f32 = 0_f32;
-    /// Construct new IO_DEBUG from values
+    /// Construct new 'IO_DEBUG' from values
     pub fn new(
         io_debug_test_unsigned: u8,
-        io_debug_test_enum: u8,
+        io_debug_test_enum: IoDebugIoDebugTestEnum,
         io_debug_test_signed: i8,
         io_debug_test_float: f32,
     ) -> Result<Self, CanError> {
@@ -269,7 +279,7 @@ impl IoDebug {
     pub fn raw(&self) -> &[u8; 4] {
         &self.raw
     }
-    /// IO_DEBUG_test_unsigned
+    /// Get value of 'IO_DEBUG_test_unsigned'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -279,7 +289,7 @@ impl IoDebug {
     pub fn io_debug_test_unsigned(&self) -> u8 {
         self.io_debug_test_unsigned_raw()
     }
-    /// Get raw value of IO_DEBUG_test_unsigned
+    /// Get raw value of 'IO_DEBUG_test_unsigned'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -293,7 +303,7 @@ impl IoDebug {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_unsigned
+    /// Set value of 'IO_DEBUG_test_unsigned'
     #[inline(always)]
     pub fn set_io_debug_test_unsigned(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -311,7 +321,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_enum
+    /// Get value of 'IO_DEBUG_test_enum'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -326,7 +336,7 @@ impl IoDebug {
             _ => IoDebugIoDebugTestEnum::_Other(self.io_debug_test_enum_raw()),
         }
     }
-    /// Get raw value of IO_DEBUG_test_enum
+    /// Get raw value of 'IO_DEBUG_test_enum'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -340,9 +350,17 @@ impl IoDebug {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_enum
+    /// Set value of 'IO_DEBUG_test_enum'
     #[inline(always)]
-    pub fn set_io_debug_test_enum(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_io_debug_test_enum(
+        &mut self,
+        value: IoDebugIoDebugTestEnum,
+    ) -> Result<(), CanError> {
+        self.set_io_debug_test_enum_raw(u8::from(value))
+    }
+    /// Set raw value of 'IO_DEBUG_test_enum'
+    #[inline(always)]
+    pub fn set_io_debug_test_enum_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: IoDebug::MESSAGE_ID,
@@ -358,7 +376,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_signed
+    /// Get value of 'IO_DEBUG_test_signed'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -368,7 +386,7 @@ impl IoDebug {
     pub fn io_debug_test_signed(&self) -> i8 {
         self.io_debug_test_signed_raw()
     }
-    /// Get raw value of IO_DEBUG_test_signed
+    /// Get raw value of 'IO_DEBUG_test_signed'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -383,7 +401,7 @@ impl IoDebug {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_signed
+    /// Set value of 'IO_DEBUG_test_signed'
     #[inline(always)]
     pub fn set_io_debug_test_signed(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -402,7 +420,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_float
+    /// Get value of 'IO_DEBUG_test_float'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -412,7 +430,7 @@ impl IoDebug {
     pub fn io_debug_test_float(&self) -> f32 {
         self.io_debug_test_float_raw()
     }
-    /// Get raw value of IO_DEBUG_test_float
+    /// Get raw value of 'IO_DEBUG_test_float'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -427,7 +445,7 @@ impl IoDebug {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IO_DEBUG_test_float
+    /// Set value of 'IO_DEBUG_test_float'
     #[inline(always)]
     pub fn set_io_debug_test_float(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -533,7 +551,7 @@ impl MotorCmd {
     pub const MOTOR_CMD_STEER_MAX: i8 = 5_i8;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
     pub const MOTOR_CMD_DRIVE_MAX: u8 = 9_u8;
-    /// Construct new MOTOR_CMD from values
+    /// Construct new 'MOTOR_CMD' from values
     pub fn new(motor_cmd_steer: i8, motor_cmd_drive: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_motor_cmd_steer(motor_cmd_steer)?;
@@ -544,7 +562,7 @@ impl MotorCmd {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// MOTOR_CMD_steer
+    /// Get value of 'MOTOR_CMD_steer'
     ///
     /// - Min: -5
     /// - Max: 5
@@ -554,7 +572,7 @@ impl MotorCmd {
     pub fn motor_cmd_steer(&self) -> i8 {
         self.motor_cmd_steer_raw()
     }
-    /// Get raw value of MOTOR_CMD_steer
+    /// Get raw value of 'MOTOR_CMD_steer'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -569,7 +587,7 @@ impl MotorCmd {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_sub(5)
     }
-    /// Set value of MOTOR_CMD_steer
+    /// Set value of 'MOTOR_CMD_steer'
     #[inline(always)]
     pub fn set_motor_cmd_steer(&mut self, value: i8) -> Result<(), CanError> {
         if value < -5_i8 || 5_i8 < value {
@@ -588,7 +606,7 @@ impl MotorCmd {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// MOTOR_CMD_drive
+    /// Get value of 'MOTOR_CMD_drive'
     ///
     /// - Min: 0
     /// - Max: 9
@@ -598,7 +616,7 @@ impl MotorCmd {
     pub fn motor_cmd_drive(&self) -> u8 {
         self.motor_cmd_drive_raw()
     }
-    /// Get raw value of MOTOR_CMD_drive
+    /// Get raw value of 'MOTOR_CMD_drive'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -612,7 +630,7 @@ impl MotorCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MOTOR_CMD_drive
+    /// Set value of 'MOTOR_CMD_drive'
     #[inline(always)]
     pub fn set_motor_cmd_drive(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 9_u8 < value {
@@ -695,7 +713,7 @@ impl MotorStatus {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
-    /// Construct new MOTOR_STATUS from values
+    /// Construct new 'MOTOR_STATUS' from values
     pub fn new(
         motor_status_wheel_error: bool,
         motor_status_speed_kph: f32,
@@ -709,7 +727,7 @@ impl MotorStatus {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// MOTOR_STATUS_wheel_error
+    /// Get value of 'MOTOR_STATUS_wheel_error'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -719,7 +737,7 @@ impl MotorStatus {
     pub fn motor_status_wheel_error(&self) -> bool {
         self.motor_status_wheel_error_raw()
     }
-    /// Get raw value of MOTOR_STATUS_wheel_error
+    /// Get raw value of 'MOTOR_STATUS_wheel_error'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -732,14 +750,14 @@ impl MotorStatus {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of MOTOR_STATUS_wheel_error
+    /// Set value of 'MOTOR_STATUS_wheel_error'
     #[inline(always)]
     pub fn set_motor_status_wheel_error(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[0..1].store_le(value);
         Ok(())
     }
-    /// MOTOR_STATUS_speed_kph
+    /// Get value of 'MOTOR_STATUS_speed_kph'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -749,7 +767,7 @@ impl MotorStatus {
     pub fn motor_status_speed_kph(&self) -> f32 {
         self.motor_status_speed_kph_raw()
     }
-    /// Get raw value of MOTOR_STATUS_speed_kph
+    /// Get raw value of 'MOTOR_STATUS_speed_kph'
     ///
     /// - Start bit: 8
     /// - Signal size: 16 bits
@@ -764,7 +782,7 @@ impl MotorStatus {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of MOTOR_STATUS_speed_kph
+    /// Set value of 'MOTOR_STATUS_speed_kph'
     #[inline(always)]
     pub fn set_motor_status_speed_kph(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -861,7 +879,7 @@ impl SensorSonars {
     pub const SENSOR_SONARS_NO_FILT_RIGHT_MAX: f32 = 0_f32;
     pub const SENSOR_SONARS_NO_FILT_REAR_MIN: f32 = 0_f32;
     pub const SENSOR_SONARS_NO_FILT_REAR_MAX: f32 = 0_f32;
-    /// Construct new SENSOR_SONARS from values
+    /// Construct new 'SENSOR_SONARS' from values
     pub fn new(
         sensor_sonars_mux: u8,
         sensor_sonars_err_count: u16,
@@ -875,7 +893,7 @@ impl SensorSonars {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of SENSOR_SONARS_mux
+    /// Get raw value of 'SENSOR_SONARS_mux'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -915,7 +933,7 @@ impl SensorSonars {
             }
         }
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     fn set_sensor_sonars_mux(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -933,7 +951,7 @@ impl SensorSonars {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -945,7 +963,7 @@ impl SensorSonars {
         self.set_sensor_sonars_mux(0)?;
         Ok(())
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -957,7 +975,7 @@ impl SensorSonars {
         self.set_sensor_sonars_mux(1)?;
         Ok(())
     }
-    /// SENSOR_SONARS_err_count
+    /// Get value of 'SENSOR_SONARS_err_count'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -967,7 +985,7 @@ impl SensorSonars {
     pub fn sensor_sonars_err_count(&self) -> u16 {
         self.sensor_sonars_err_count_raw()
     }
-    /// Get raw value of SENSOR_SONARS_err_count
+    /// Get raw value of 'SENSOR_SONARS_err_count'
     ///
     /// - Start bit: 4
     /// - Signal size: 12 bits
@@ -981,7 +999,7 @@ impl SensorSonars {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SENSOR_SONARS_err_count
+    /// Set value of 'SENSOR_SONARS_err_count'
     #[inline(always)]
     pub fn set_sensor_sonars_err_count(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1078,7 +1096,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SENSOR_SONARS_left
+    /// Get value of 'SENSOR_SONARS_left'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1088,7 +1106,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_left(&self) -> f32 {
         self.sensor_sonars_left_raw()
     }
-    /// Get raw value of SENSOR_SONARS_left
+    /// Get raw value of 'SENSOR_SONARS_left'
     ///
     /// - Start bit: 16
     /// - Signal size: 12 bits
@@ -1103,7 +1121,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_left
+    /// Set value of 'SENSOR_SONARS_left'
     #[inline(always)]
     pub fn set_sensor_sonars_left(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1117,7 +1135,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[16..28].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_middle
+    /// Get value of 'SENSOR_SONARS_middle'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1127,7 +1145,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_middle(&self) -> f32 {
         self.sensor_sonars_middle_raw()
     }
-    /// Get raw value of SENSOR_SONARS_middle
+    /// Get raw value of 'SENSOR_SONARS_middle'
     ///
     /// - Start bit: 28
     /// - Signal size: 12 bits
@@ -1142,7 +1160,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_middle
+    /// Set value of 'SENSOR_SONARS_middle'
     #[inline(always)]
     pub fn set_sensor_sonars_middle(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1156,7 +1174,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[28..40].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_right
+    /// Get value of 'SENSOR_SONARS_right'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1166,7 +1184,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_right(&self) -> f32 {
         self.sensor_sonars_right_raw()
     }
-    /// Get raw value of SENSOR_SONARS_right
+    /// Get raw value of 'SENSOR_SONARS_right'
     ///
     /// - Start bit: 40
     /// - Signal size: 12 bits
@@ -1181,7 +1199,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_right
+    /// Set value of 'SENSOR_SONARS_right'
     #[inline(always)]
     pub fn set_sensor_sonars_right(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1195,7 +1213,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[40..52].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_rear
+    /// Get value of 'SENSOR_SONARS_rear'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1205,7 +1223,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_rear(&self) -> f32 {
         self.sensor_sonars_rear_raw()
     }
-    /// Get raw value of SENSOR_SONARS_rear
+    /// Get raw value of 'SENSOR_SONARS_rear'
     ///
     /// - Start bit: 52
     /// - Signal size: 12 bits
@@ -1220,7 +1238,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_rear
+    /// Set value of 'SENSOR_SONARS_rear'
     #[inline(always)]
     pub fn set_sensor_sonars_rear(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1261,7 +1279,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SENSOR_SONARS_no_filt_left
+    /// Get value of 'SENSOR_SONARS_no_filt_left'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1271,7 +1289,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_left(&self) -> f32 {
         self.sensor_sonars_no_filt_left_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_left
+    /// Get raw value of 'SENSOR_SONARS_no_filt_left'
     ///
     /// - Start bit: 16
     /// - Signal size: 12 bits
@@ -1286,7 +1304,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_left
+    /// Set value of 'SENSOR_SONARS_no_filt_left'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_left(
         &mut self,
@@ -1303,7 +1321,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[16..28].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_middle
+    /// Get value of 'SENSOR_SONARS_no_filt_middle'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1313,7 +1331,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_middle(&self) -> f32 {
         self.sensor_sonars_no_filt_middle_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_middle
+    /// Get raw value of 'SENSOR_SONARS_no_filt_middle'
     ///
     /// - Start bit: 28
     /// - Signal size: 12 bits
@@ -1328,7 +1346,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_middle
+    /// Set value of 'SENSOR_SONARS_no_filt_middle'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_middle(
         &mut self,
@@ -1345,7 +1363,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[28..40].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_right
+    /// Get value of 'SENSOR_SONARS_no_filt_right'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1355,7 +1373,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_right(&self) -> f32 {
         self.sensor_sonars_no_filt_right_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_right
+    /// Get raw value of 'SENSOR_SONARS_no_filt_right'
     ///
     /// - Start bit: 40
     /// - Signal size: 12 bits
@@ -1370,7 +1388,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_right
+    /// Set value of 'SENSOR_SONARS_no_filt_right'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_right(
         &mut self,
@@ -1387,7 +1405,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[40..52].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_rear
+    /// Get value of 'SENSOR_SONARS_no_filt_rear'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1397,7 +1415,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_rear(&self) -> f32 {
         self.sensor_sonars_no_filt_rear_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_rear
+    /// Get raw value of 'SENSOR_SONARS_no_filt_rear'
     ///
     /// - Start bit: 52
     /// - Signal size: 12 bits
@@ -1412,7 +1430,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_rear
+    /// Set value of 'SENSOR_SONARS_no_filt_rear'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_rear(
         &mut self,

--- a/tests-snapshots/dbc-cantools/socialledge.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge.snap.rs
@@ -143,11 +143,7 @@ impl DriverHeartbeat {
         &mut self,
         value: DriverHeartbeatDriverHeartbeatCmd,
     ) -> Result<(), CanError> {
-        self.set_driver_heartbeat_cmd_raw(u8::from(value))
-    }
-    /// Set raw value of 'DRIVER_HEARTBEAT_cmd'
-    #[inline(always)]
-    pub fn set_driver_heartbeat_cmd_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: DriverHeartbeat::MESSAGE_ID,
@@ -356,11 +352,7 @@ impl IoDebug {
         &mut self,
         value: IoDebugIoDebugTestEnum,
     ) -> Result<(), CanError> {
-        self.set_io_debug_test_enum_raw(u8::from(value))
-    }
-    /// Set raw value of 'IO_DEBUG_test_enum'
-    #[inline(always)]
-    pub fn set_io_debug_test_enum_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: IoDebug::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/socialledge.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge.snap.rs
@@ -91,8 +91,10 @@ impl DriverHeartbeat {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
-    /// Construct new DRIVER_HEARTBEAT from values
-    pub fn new(driver_heartbeat_cmd: u8) -> Result<Self, CanError> {
+    /// Construct new 'DRIVER_HEARTBEAT' from values
+    pub fn new(
+        driver_heartbeat_cmd: DriverHeartbeatDriverHeartbeatCmd,
+    ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_driver_heartbeat_cmd(driver_heartbeat_cmd)?;
         Ok(res)
@@ -101,7 +103,7 @@ impl DriverHeartbeat {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// DRIVER_HEARTBEAT_cmd
+    /// Get value of 'DRIVER_HEARTBEAT_cmd'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -121,7 +123,7 @@ impl DriverHeartbeat {
             }
         }
     }
-    /// Get raw value of DRIVER_HEARTBEAT_cmd
+    /// Get raw value of 'DRIVER_HEARTBEAT_cmd'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -135,9 +137,17 @@ impl DriverHeartbeat {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of DRIVER_HEARTBEAT_cmd
+    /// Set value of 'DRIVER_HEARTBEAT_cmd'
     #[inline(always)]
-    pub fn set_driver_heartbeat_cmd(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_driver_heartbeat_cmd(
+        &mut self,
+        value: DriverHeartbeatDriverHeartbeatCmd,
+    ) -> Result<(), CanError> {
+        self.set_driver_heartbeat_cmd_raw(u8::from(value))
+    }
+    /// Set raw value of 'DRIVER_HEARTBEAT_cmd'
+    #[inline(always)]
+    pub fn set_driver_heartbeat_cmd_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: DriverHeartbeat::MESSAGE_ID,
@@ -251,10 +261,10 @@ impl IoDebug {
     pub const IO_DEBUG_TEST_SIGNED_MAX: i8 = 0_i8;
     pub const IO_DEBUG_TEST_FLOAT_MIN: f32 = 0_f32;
     pub const IO_DEBUG_TEST_FLOAT_MAX: f32 = 0_f32;
-    /// Construct new IO_DEBUG from values
+    /// Construct new 'IO_DEBUG' from values
     pub fn new(
         io_debug_test_unsigned: u8,
-        io_debug_test_enum: u8,
+        io_debug_test_enum: IoDebugIoDebugTestEnum,
         io_debug_test_signed: i8,
         io_debug_test_float: f32,
     ) -> Result<Self, CanError> {
@@ -269,7 +279,7 @@ impl IoDebug {
     pub fn raw(&self) -> &[u8; 4] {
         &self.raw
     }
-    /// IO_DEBUG_test_unsigned
+    /// Get value of 'IO_DEBUG_test_unsigned'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -279,7 +289,7 @@ impl IoDebug {
     pub fn io_debug_test_unsigned(&self) -> u8 {
         self.io_debug_test_unsigned_raw()
     }
-    /// Get raw value of IO_DEBUG_test_unsigned
+    /// Get raw value of 'IO_DEBUG_test_unsigned'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -293,7 +303,7 @@ impl IoDebug {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_unsigned
+    /// Set value of 'IO_DEBUG_test_unsigned'
     #[inline(always)]
     pub fn set_io_debug_test_unsigned(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -311,7 +321,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_enum
+    /// Get value of 'IO_DEBUG_test_enum'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -326,7 +336,7 @@ impl IoDebug {
             _ => IoDebugIoDebugTestEnum::_Other(self.io_debug_test_enum_raw()),
         }
     }
-    /// Get raw value of IO_DEBUG_test_enum
+    /// Get raw value of 'IO_DEBUG_test_enum'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -340,9 +350,17 @@ impl IoDebug {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_enum
+    /// Set value of 'IO_DEBUG_test_enum'
     #[inline(always)]
-    pub fn set_io_debug_test_enum(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_io_debug_test_enum(
+        &mut self,
+        value: IoDebugIoDebugTestEnum,
+    ) -> Result<(), CanError> {
+        self.set_io_debug_test_enum_raw(u8::from(value))
+    }
+    /// Set raw value of 'IO_DEBUG_test_enum'
+    #[inline(always)]
+    pub fn set_io_debug_test_enum_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: IoDebug::MESSAGE_ID,
@@ -358,7 +376,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_signed
+    /// Get value of 'IO_DEBUG_test_signed'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -368,7 +386,7 @@ impl IoDebug {
     pub fn io_debug_test_signed(&self) -> i8 {
         self.io_debug_test_signed_raw()
     }
-    /// Get raw value of IO_DEBUG_test_signed
+    /// Get raw value of 'IO_DEBUG_test_signed'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -383,7 +401,7 @@ impl IoDebug {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of IO_DEBUG_test_signed
+    /// Set value of 'IO_DEBUG_test_signed'
     #[inline(always)]
     pub fn set_io_debug_test_signed(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -402,7 +420,7 @@ impl IoDebug {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// IO_DEBUG_test_float
+    /// Get value of 'IO_DEBUG_test_float'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -412,7 +430,7 @@ impl IoDebug {
     pub fn io_debug_test_float(&self) -> f32 {
         self.io_debug_test_float_raw()
     }
-    /// Get raw value of IO_DEBUG_test_float
+    /// Get raw value of 'IO_DEBUG_test_float'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -427,7 +445,7 @@ impl IoDebug {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IO_DEBUG_test_float
+    /// Set value of 'IO_DEBUG_test_float'
     #[inline(always)]
     pub fn set_io_debug_test_float(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -533,7 +551,7 @@ impl MotorCmd {
     pub const MOTOR_CMD_STEER_MAX: i8 = 5_i8;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
     pub const MOTOR_CMD_DRIVE_MAX: u8 = 9_u8;
-    /// Construct new MOTOR_CMD from values
+    /// Construct new 'MOTOR_CMD' from values
     pub fn new(motor_cmd_steer: i8, motor_cmd_drive: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 1] };
         res.set_motor_cmd_steer(motor_cmd_steer)?;
@@ -544,7 +562,7 @@ impl MotorCmd {
     pub fn raw(&self) -> &[u8; 1] {
         &self.raw
     }
-    /// MOTOR_CMD_steer
+    /// Get value of 'MOTOR_CMD_steer'
     ///
     /// - Min: -5
     /// - Max: 5
@@ -554,7 +572,7 @@ impl MotorCmd {
     pub fn motor_cmd_steer(&self) -> i8 {
         self.motor_cmd_steer_raw()
     }
-    /// Get raw value of MOTOR_CMD_steer
+    /// Get raw value of 'MOTOR_CMD_steer'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -569,7 +587,7 @@ impl MotorCmd {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_sub(5)
     }
-    /// Set value of MOTOR_CMD_steer
+    /// Set value of 'MOTOR_CMD_steer'
     #[inline(always)]
     pub fn set_motor_cmd_steer(&mut self, value: i8) -> Result<(), CanError> {
         if value < -5_i8 || 5_i8 < value {
@@ -588,7 +606,7 @@ impl MotorCmd {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// MOTOR_CMD_drive
+    /// Get value of 'MOTOR_CMD_drive'
     ///
     /// - Min: 0
     /// - Max: 9
@@ -598,7 +616,7 @@ impl MotorCmd {
     pub fn motor_cmd_drive(&self) -> u8 {
         self.motor_cmd_drive_raw()
     }
-    /// Get raw value of MOTOR_CMD_drive
+    /// Get raw value of 'MOTOR_CMD_drive'
     ///
     /// - Start bit: 4
     /// - Signal size: 4 bits
@@ -612,7 +630,7 @@ impl MotorCmd {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MOTOR_CMD_drive
+    /// Set value of 'MOTOR_CMD_drive'
     #[inline(always)]
     pub fn set_motor_cmd_drive(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 9_u8 < value {
@@ -695,7 +713,7 @@ impl MotorStatus {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
-    /// Construct new MOTOR_STATUS from values
+    /// Construct new 'MOTOR_STATUS' from values
     pub fn new(
         motor_status_wheel_error: bool,
         motor_status_speed_kph: f32,
@@ -709,7 +727,7 @@ impl MotorStatus {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// MOTOR_STATUS_wheel_error
+    /// Get value of 'MOTOR_STATUS_wheel_error'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -719,7 +737,7 @@ impl MotorStatus {
     pub fn motor_status_wheel_error(&self) -> bool {
         self.motor_status_wheel_error_raw()
     }
-    /// Get raw value of MOTOR_STATUS_wheel_error
+    /// Get raw value of 'MOTOR_STATUS_wheel_error'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -732,14 +750,14 @@ impl MotorStatus {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of MOTOR_STATUS_wheel_error
+    /// Set value of 'MOTOR_STATUS_wheel_error'
     #[inline(always)]
     pub fn set_motor_status_wheel_error(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[0..1].store_le(value);
         Ok(())
     }
-    /// MOTOR_STATUS_speed_kph
+    /// Get value of 'MOTOR_STATUS_speed_kph'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -749,7 +767,7 @@ impl MotorStatus {
     pub fn motor_status_speed_kph(&self) -> f32 {
         self.motor_status_speed_kph_raw()
     }
-    /// Get raw value of MOTOR_STATUS_speed_kph
+    /// Get raw value of 'MOTOR_STATUS_speed_kph'
     ///
     /// - Start bit: 8
     /// - Signal size: 16 bits
@@ -764,7 +782,7 @@ impl MotorStatus {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of MOTOR_STATUS_speed_kph
+    /// Set value of 'MOTOR_STATUS_speed_kph'
     #[inline(always)]
     pub fn set_motor_status_speed_kph(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -861,7 +879,7 @@ impl SensorSonars {
     pub const SENSOR_SONARS_NO_FILT_RIGHT_MAX: f32 = 0_f32;
     pub const SENSOR_SONARS_NO_FILT_REAR_MIN: f32 = 0_f32;
     pub const SENSOR_SONARS_NO_FILT_REAR_MAX: f32 = 0_f32;
-    /// Construct new SENSOR_SONARS from values
+    /// Construct new 'SENSOR_SONARS' from values
     pub fn new(
         sensor_sonars_mux: u8,
         sensor_sonars_err_count: u16,
@@ -875,7 +893,7 @@ impl SensorSonars {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of SENSOR_SONARS_mux
+    /// Get raw value of 'SENSOR_SONARS_mux'
     ///
     /// - Start bit: 0
     /// - Signal size: 4 bits
@@ -915,7 +933,7 @@ impl SensorSonars {
             }
         }
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     fn set_sensor_sonars_mux(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -933,7 +951,7 @@ impl SensorSonars {
         self.raw.view_bits_mut::<Lsb0>()[0..4].store_le(value);
         Ok(())
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     pub fn set_m0(
         &mut self,
@@ -945,7 +963,7 @@ impl SensorSonars {
         self.set_sensor_sonars_mux(0)?;
         Ok(())
     }
-    /// Set value of SENSOR_SONARS_mux
+    /// Set value of 'SENSOR_SONARS_mux'
     #[inline(always)]
     pub fn set_m1(
         &mut self,
@@ -957,7 +975,7 @@ impl SensorSonars {
         self.set_sensor_sonars_mux(1)?;
         Ok(())
     }
-    /// SENSOR_SONARS_err_count
+    /// Get value of 'SENSOR_SONARS_err_count'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -967,7 +985,7 @@ impl SensorSonars {
     pub fn sensor_sonars_err_count(&self) -> u16 {
         self.sensor_sonars_err_count_raw()
     }
-    /// Get raw value of SENSOR_SONARS_err_count
+    /// Get raw value of 'SENSOR_SONARS_err_count'
     ///
     /// - Start bit: 4
     /// - Signal size: 12 bits
@@ -981,7 +999,7 @@ impl SensorSonars {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SENSOR_SONARS_err_count
+    /// Set value of 'SENSOR_SONARS_err_count'
     #[inline(always)]
     pub fn set_sensor_sonars_err_count(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -1078,7 +1096,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SENSOR_SONARS_left
+    /// Get value of 'SENSOR_SONARS_left'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1088,7 +1106,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_left(&self) -> f32 {
         self.sensor_sonars_left_raw()
     }
-    /// Get raw value of SENSOR_SONARS_left
+    /// Get raw value of 'SENSOR_SONARS_left'
     ///
     /// - Start bit: 16
     /// - Signal size: 12 bits
@@ -1103,7 +1121,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_left
+    /// Set value of 'SENSOR_SONARS_left'
     #[inline(always)]
     pub fn set_sensor_sonars_left(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1117,7 +1135,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[16..28].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_middle
+    /// Get value of 'SENSOR_SONARS_middle'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1127,7 +1145,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_middle(&self) -> f32 {
         self.sensor_sonars_middle_raw()
     }
-    /// Get raw value of SENSOR_SONARS_middle
+    /// Get raw value of 'SENSOR_SONARS_middle'
     ///
     /// - Start bit: 28
     /// - Signal size: 12 bits
@@ -1142,7 +1160,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_middle
+    /// Set value of 'SENSOR_SONARS_middle'
     #[inline(always)]
     pub fn set_sensor_sonars_middle(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1156,7 +1174,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[28..40].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_right
+    /// Get value of 'SENSOR_SONARS_right'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1166,7 +1184,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_right(&self) -> f32 {
         self.sensor_sonars_right_raw()
     }
-    /// Get raw value of SENSOR_SONARS_right
+    /// Get raw value of 'SENSOR_SONARS_right'
     ///
     /// - Start bit: 40
     /// - Signal size: 12 bits
@@ -1181,7 +1199,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_right
+    /// Set value of 'SENSOR_SONARS_right'
     #[inline(always)]
     pub fn set_sensor_sonars_right(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1195,7 +1213,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         self.raw.view_bits_mut::<Lsb0>()[40..52].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_rear
+    /// Get value of 'SENSOR_SONARS_rear'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1205,7 +1223,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
     pub fn sensor_sonars_rear(&self) -> f32 {
         self.sensor_sonars_rear_raw()
     }
-    /// Get raw value of SENSOR_SONARS_rear
+    /// Get raw value of 'SENSOR_SONARS_rear'
     ///
     /// - Start bit: 52
     /// - Signal size: 12 bits
@@ -1220,7 +1238,7 @@ impl SensorSonarsSensorSonarsMuxM0 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_rear
+    /// Set value of 'SENSOR_SONARS_rear'
     #[inline(always)]
     pub fn set_sensor_sonars_rear(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -1261,7 +1279,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// SENSOR_SONARS_no_filt_left
+    /// Get value of 'SENSOR_SONARS_no_filt_left'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1271,7 +1289,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_left(&self) -> f32 {
         self.sensor_sonars_no_filt_left_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_left
+    /// Get raw value of 'SENSOR_SONARS_no_filt_left'
     ///
     /// - Start bit: 16
     /// - Signal size: 12 bits
@@ -1286,7 +1304,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_left
+    /// Set value of 'SENSOR_SONARS_no_filt_left'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_left(
         &mut self,
@@ -1303,7 +1321,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[16..28].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_middle
+    /// Get value of 'SENSOR_SONARS_no_filt_middle'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1313,7 +1331,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_middle(&self) -> f32 {
         self.sensor_sonars_no_filt_middle_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_middle
+    /// Get raw value of 'SENSOR_SONARS_no_filt_middle'
     ///
     /// - Start bit: 28
     /// - Signal size: 12 bits
@@ -1328,7 +1346,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_middle
+    /// Set value of 'SENSOR_SONARS_no_filt_middle'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_middle(
         &mut self,
@@ -1345,7 +1363,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[28..40].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_right
+    /// Get value of 'SENSOR_SONARS_no_filt_right'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1355,7 +1373,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_right(&self) -> f32 {
         self.sensor_sonars_no_filt_right_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_right
+    /// Get raw value of 'SENSOR_SONARS_no_filt_right'
     ///
     /// - Start bit: 40
     /// - Signal size: 12 bits
@@ -1370,7 +1388,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_right
+    /// Set value of 'SENSOR_SONARS_no_filt_right'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_right(
         &mut self,
@@ -1387,7 +1405,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         self.raw.view_bits_mut::<Lsb0>()[40..52].store_le(value);
         Ok(())
     }
-    /// SENSOR_SONARS_no_filt_rear
+    /// Get value of 'SENSOR_SONARS_no_filt_rear'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -1397,7 +1415,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
     pub fn sensor_sonars_no_filt_rear(&self) -> f32 {
         self.sensor_sonars_no_filt_rear_raw()
     }
-    /// Get raw value of SENSOR_SONARS_no_filt_rear
+    /// Get raw value of 'SENSOR_SONARS_no_filt_rear'
     ///
     /// - Start bit: 52
     /// - Signal size: 12 bits
@@ -1412,7 +1430,7 @@ impl SensorSonarsSensorSonarsMuxM1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of SENSOR_SONARS_no_filt_rear
+    /// Set value of 'SENSOR_SONARS_no_filt_rear'
     #[inline(always)]
     pub fn set_sensor_sonars_no_filt_rear(
         &mut self,

--- a/tests-snapshots/dbc-cantools/test_extended_id_dump.snap.rs
+++ b/tests-snapshots/dbc-cantools/test_extended_id_dump.snap.rs
@@ -74,7 +74,7 @@ impl SomeFrame {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SOME_DIFFERENT_SIG_MIN: i8 = 0_i8;
     pub const SOME_DIFFERENT_SIG_MAX: i8 = 0_i8;
-    /// Construct new SomeFrame from values
+    /// Construct new 'SomeFrame' from values
     pub fn new(some_different_sig: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_some_different_sig(some_different_sig)?;
@@ -84,7 +84,7 @@ impl SomeFrame {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SomeDifferentSig
+    /// Get value of 'SomeDifferentSig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -94,7 +94,7 @@ impl SomeFrame {
     pub fn some_different_sig(&self) -> i8 {
         self.some_different_sig_raw()
     }
-    /// Get raw value of SomeDifferentSig
+    /// Get raw value of 'SomeDifferentSig'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -109,7 +109,7 @@ impl SomeFrame {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SomeDifferentSig
+    /// Set value of 'SomeDifferentSig'
     #[inline(always)]
     pub fn set_some_different_sig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -191,7 +191,7 @@ impl SomeExtFrame {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SOME_SIG_MIN: i8 = 0_i8;
     pub const SOME_SIG_MAX: i8 = 0_i8;
-    /// Construct new SomeExtFrame from values
+    /// Construct new 'SomeExtFrame' from values
     pub fn new(some_sig: i8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_some_sig(some_sig)?;
@@ -201,7 +201,7 @@ impl SomeExtFrame {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// SomeSig
+    /// Get value of 'SomeSig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -211,7 +211,7 @@ impl SomeExtFrame {
     pub fn some_sig(&self) -> i8 {
         self.some_sig_raw()
     }
-    /// Get raw value of SomeSig
+    /// Get raw value of 'SomeSig'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -226,7 +226,7 @@ impl SomeExtFrame {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of SomeSig
+    /// Set value of 'SomeSig'
     #[inline(always)]
     pub fn set_some_sig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/test_multiplex_dump.snap.rs
+++ b/tests-snapshots/dbc-cantools/test_multiplex_dump.snap.rs
@@ -75,7 +75,7 @@ impl MuxedFrame {
     pub const MULTIPLEXED_SIG_MAX: i8 = 0_i8;
     pub const MULTIPLEXOR_SIG_MIN: u8 = 0_u8;
     pub const MULTIPLEXOR_SIG_MAX: u8 = 0_u8;
-    /// Construct new MuxedFrame from values
+    /// Construct new 'MuxedFrame' from values
     pub fn new(unmultiplexed_sig: i8, multiplexor_sig: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_unmultiplexed_sig(unmultiplexed_sig)?;
@@ -86,7 +86,7 @@ impl MuxedFrame {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// UnmultiplexedSig
+    /// Get value of 'UnmultiplexedSig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -96,7 +96,7 @@ impl MuxedFrame {
     pub fn unmultiplexed_sig(&self) -> i8 {
         self.unmultiplexed_sig_raw()
     }
-    /// Get raw value of UnmultiplexedSig
+    /// Get raw value of 'UnmultiplexedSig'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -111,7 +111,7 @@ impl MuxedFrame {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of UnmultiplexedSig
+    /// Set value of 'UnmultiplexedSig'
     #[inline(always)]
     pub fn set_unmultiplexed_sig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
@@ -130,7 +130,7 @@ impl MuxedFrame {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Get raw value of MultiplexorSig
+    /// Get raw value of 'MultiplexorSig'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -163,7 +163,7 @@ impl MuxedFrame {
             }
         }
     }
-    /// Set value of MultiplexorSig
+    /// Set value of 'MultiplexorSig'
     #[inline(always)]
     fn set_multiplexor_sig(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -181,7 +181,7 @@ impl MuxedFrame {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Set value of MultiplexorSig
+    /// Set value of 'MultiplexorSig'
     #[inline(always)]
     pub fn set_m42(
         &mut self,
@@ -271,7 +271,7 @@ impl MuxedFrameMultiplexorSigM42 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// MultiplexedSig
+    /// Get value of 'MultiplexedSig'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -281,7 +281,7 @@ impl MuxedFrameMultiplexorSigM42 {
     pub fn multiplexed_sig(&self) -> i8 {
         self.multiplexed_sig_raw()
     }
-    /// Get raw value of MultiplexedSig
+    /// Get raw value of 'MultiplexedSig'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -296,7 +296,7 @@ impl MuxedFrameMultiplexorSigM42 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MultiplexedSig
+    /// Set value of 'MultiplexedSig'
     #[inline(always)]
     pub fn set_multiplexed_sig(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {

--- a/tests-snapshots/dbc-cantools/timing.snap.rs
+++ b/tests-snapshots/dbc-cantools/timing.snap.rs
@@ -74,7 +74,7 @@ impl Foo {
     pub const MESSAGE_CYCLE_TIME_MS: u32 = 200;
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;
-    /// Construct new Foo from values
+    /// Construct new 'Foo' from values
     pub fn new(foo: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_foo(foo)?;
@@ -84,7 +84,7 @@ impl Foo {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Foo
+    /// Get value of 'Foo'
     ///
     /// - Min: 229.53
     /// - Max: 270.47
@@ -94,7 +94,7 @@ impl Foo {
     pub fn foo(&self) -> f32 {
         self.foo_raw()
     }
-    /// Get raw value of Foo
+    /// Get raw value of 'Foo'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -109,7 +109,7 @@ impl Foo {
         let offset = 250_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Foo
+    /// Set value of 'Foo'
     #[inline(always)]
     pub fn set_foo(&mut self, value: f32) -> Result<(), CanError> {
         if value < 229.53_f32 || 270.47_f32 < value {
@@ -188,7 +188,7 @@ impl Bar {
     pub const MESSAGE_SIZE: usize = 8;
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;
-    /// Construct new Bar from values
+    /// Construct new 'Bar' from values
     pub fn new(foo: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_foo(foo)?;
@@ -198,7 +198,7 @@ impl Bar {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Foo
+    /// Get value of 'Foo'
     ///
     /// - Min: 229.53
     /// - Max: 270.47
@@ -208,7 +208,7 @@ impl Bar {
     pub fn foo(&self) -> f32 {
         self.foo_raw()
     }
-    /// Get raw value of Foo
+    /// Get raw value of 'Foo'
     ///
     /// - Start bit: 0
     /// - Signal size: 12 bits
@@ -223,7 +223,7 @@ impl Bar {
         let offset = 250_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Foo
+    /// Set value of 'Foo'
     #[inline(always)]
     pub fn set_foo(&mut self, value: f32) -> Result<(), CanError> {
         if value < 229.53_f32 || 270.47_f32 < value {

--- a/tests-snapshots/dbc-cantools/val_table.snap.rs
+++ b/tests-snapshots/dbc-cantools/val_table.snap.rs
@@ -112,11 +112,7 @@ impl Message1 {
     /// Set value of 'Signal1'
     #[inline(always)]
     pub fn set_signal1(&mut self, value: Message1Signal1) -> Result<(), CanError> {
-        self.set_signal1_raw(i8::from(value))
-    }
-    /// Set raw value of 'Signal1'
-    #[inline(always)]
-    pub fn set_signal1_raw(&mut self, value: i8) -> Result<(), CanError> {
+        let value = i8::from(value);
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Message1::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/val_table.snap.rs
+++ b/tests-snapshots/dbc-cantools/val_table.snap.rs
@@ -69,8 +69,8 @@ impl Message1 {
     pub const MESSAGE_SIZE: usize = 8;
     pub const SIGNAL1_MIN: i8 = 0_i8;
     pub const SIGNAL1_MAX: i8 = 0_i8;
-    /// Construct new Message1 from values
-    pub fn new(signal1: i8) -> Result<Self, CanError> {
+    /// Construct new 'Message1' from values
+    pub fn new(signal1: Message1Signal1) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_signal1(signal1)?;
         Ok(res)
@@ -79,7 +79,7 @@ impl Message1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Signal1
+    /// Get value of 'Signal1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -94,7 +94,7 @@ impl Message1 {
             _ => Message1Signal1::_Other(self.signal1_raw()),
         }
     }
-    /// Get raw value of Signal1
+    /// Get raw value of 'Signal1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -109,9 +109,14 @@ impl Message1 {
         let signal = signal as i8;
         i8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal1
+    /// Set value of 'Signal1'
     #[inline(always)]
-    pub fn set_signal1(&mut self, value: i8) -> Result<(), CanError> {
+    pub fn set_signal1(&mut self, value: Message1Signal1) -> Result<(), CanError> {
+        self.set_signal1_raw(i8::from(value))
+    }
+    /// Set raw value of 'Signal1'
+    #[inline(always)]
+    pub fn set_signal1_raw(&mut self, value: i8) -> Result<(), CanError> {
         if value < 0_i8 || 0_i8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: Message1::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/variable_dlc.snap.rs
+++ b/tests-snapshots/dbc-cantools/variable_dlc.snap.rs
@@ -81,7 +81,7 @@ impl TestMessage1 {
     pub const SIGNAL2_MAX: u8 = 0_u8;
     pub const SIGNAL3_MIN: u8 = 0_u8;
     pub const SIGNAL3_MAX: u8 = 0_u8;
-    /// Construct new TestMessage1 from values
+    /// Construct new 'TestMessage1' from values
     pub fn new(signal1: u8, signal2: u8, signal3: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_signal1(signal1)?;
@@ -93,7 +93,7 @@ impl TestMessage1 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Signal1
+    /// Get value of 'Signal1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -103,7 +103,7 @@ impl TestMessage1 {
     pub fn signal1(&self) -> u8 {
         self.signal1_raw()
     }
-    /// Get raw value of Signal1
+    /// Get raw value of 'Signal1'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -117,7 +117,7 @@ impl TestMessage1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal1
+    /// Set value of 'Signal1'
     #[inline(always)]
     pub fn set_signal1(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -135,7 +135,7 @@ impl TestMessage1 {
         self.raw.view_bits_mut::<Lsb0>()[0..8].store_le(value);
         Ok(())
     }
-    /// Signal2
+    /// Get value of 'Signal2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -145,7 +145,7 @@ impl TestMessage1 {
     pub fn signal2(&self) -> u8 {
         self.signal2_raw()
     }
-    /// Get raw value of Signal2
+    /// Get raw value of 'Signal2'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -159,7 +159,7 @@ impl TestMessage1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal2
+    /// Set value of 'Signal2'
     #[inline(always)]
     pub fn set_signal2(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -177,7 +177,7 @@ impl TestMessage1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Signal3
+    /// Get value of 'Signal3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -187,7 +187,7 @@ impl TestMessage1 {
     pub fn signal3(&self) -> u8 {
         self.signal3_raw()
     }
-    /// Get raw value of Signal3
+    /// Get raw value of 'Signal3'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -201,7 +201,7 @@ impl TestMessage1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal3
+    /// Set value of 'Signal3'
     #[inline(always)]
     pub fn set_signal3(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -291,7 +291,7 @@ impl TestMessage2 {
     pub const SIGNAL7_MAX: u16 = 0_u16;
     pub const SIGNAL8_MIN: u16 = 0_u16;
     pub const SIGNAL8_MAX: u16 = 0_u16;
-    /// Construct new TestMessage2 from values
+    /// Construct new 'TestMessage2' from values
     pub fn new(
         signal4: u16,
         signal5: u16,
@@ -311,7 +311,7 @@ impl TestMessage2 {
     pub fn raw(&self) -> &[u8; 10] {
         &self.raw
     }
-    /// Signal4
+    /// Get value of 'Signal4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -321,7 +321,7 @@ impl TestMessage2 {
     pub fn signal4(&self) -> u16 {
         self.signal4_raw()
     }
-    /// Get raw value of Signal4
+    /// Get raw value of 'Signal4'
     ///
     /// - Start bit: 0
     /// - Signal size: 15 bits
@@ -335,7 +335,7 @@ impl TestMessage2 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal4
+    /// Set value of 'Signal4'
     #[inline(always)]
     pub fn set_signal4(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -353,7 +353,7 @@ impl TestMessage2 {
         self.raw.view_bits_mut::<Lsb0>()[0..15].store_le(value);
         Ok(())
     }
-    /// Signal5
+    /// Get value of 'Signal5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -363,7 +363,7 @@ impl TestMessage2 {
     pub fn signal5(&self) -> u16 {
         self.signal5_raw()
     }
-    /// Get raw value of Signal5
+    /// Get raw value of 'Signal5'
     ///
     /// - Start bit: 15
     /// - Signal size: 15 bits
@@ -377,7 +377,7 @@ impl TestMessage2 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal5
+    /// Set value of 'Signal5'
     #[inline(always)]
     pub fn set_signal5(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -395,7 +395,7 @@ impl TestMessage2 {
         self.raw.view_bits_mut::<Lsb0>()[15..30].store_le(value);
         Ok(())
     }
-    /// Signal6
+    /// Get value of 'Signal6'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -405,7 +405,7 @@ impl TestMessage2 {
     pub fn signal6(&self) -> u16 {
         self.signal6_raw()
     }
-    /// Get raw value of Signal6
+    /// Get raw value of 'Signal6'
     ///
     /// - Start bit: 30
     /// - Signal size: 15 bits
@@ -419,7 +419,7 @@ impl TestMessage2 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal6
+    /// Set value of 'Signal6'
     #[inline(always)]
     pub fn set_signal6(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -437,7 +437,7 @@ impl TestMessage2 {
         self.raw.view_bits_mut::<Lsb0>()[30..45].store_le(value);
         Ok(())
     }
-    /// Signal7
+    /// Get value of 'Signal7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -447,7 +447,7 @@ impl TestMessage2 {
     pub fn signal7(&self) -> u16 {
         self.signal7_raw()
     }
-    /// Get raw value of Signal7
+    /// Get raw value of 'Signal7'
     ///
     /// - Start bit: 45
     /// - Signal size: 15 bits
@@ -461,7 +461,7 @@ impl TestMessage2 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal7
+    /// Set value of 'Signal7'
     #[inline(always)]
     pub fn set_signal7(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -479,7 +479,7 @@ impl TestMessage2 {
         self.raw.view_bits_mut::<Lsb0>()[45..60].store_le(value);
         Ok(())
     }
-    /// Signal8
+    /// Get value of 'Signal8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -489,7 +489,7 @@ impl TestMessage2 {
     pub fn signal8(&self) -> u16 {
         self.signal8_raw()
     }
-    /// Get raw value of Signal8
+    /// Get raw value of 'Signal8'
     ///
     /// - Start bit: 60
     /// - Signal size: 15 bits
@@ -503,7 +503,7 @@ impl TestMessage2 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Signal8
+    /// Set value of 'Signal8'
     #[inline(always)]
     pub fn set_signal8(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {

--- a/tests-snapshots/dbc-cantools/vehicle.snap.rs
+++ b/tests-snapshots/dbc-cantools/vehicle.snap.rs
@@ -28149,11 +28149,7 @@ impl RtSbInsStatus {
         &mut self,
         value: RtSbInsStatusInsStatus,
     ) -> Result<(), CanError> {
-        self.set_ins_status_raw(u8::from(value))
-    }
-    /// Set raw value of 'INS_Status'
-    #[inline(always)]
-    pub fn set_ins_status_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 255_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: RtSbInsStatus::MESSAGE_ID,
@@ -28485,11 +28481,7 @@ impl RtSbInsAttitude {
         &mut self,
         value: RtSbInsAttitudeValidityRoll,
     ) -> Result<(), CanError> {
-        self.set_validity_roll_raw(bool::from(value))
-    }
-    /// Set raw value of 'Validity_Roll'
-    #[inline(always)]
-    pub fn set_validity_roll_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
@@ -28528,11 +28520,7 @@ impl RtSbInsAttitude {
         &mut self,
         value: RtSbInsAttitudeValidityPitch,
     ) -> Result<(), CanError> {
-        self.set_validity_pitch_raw(bool::from(value))
-    }
-    /// Set raw value of 'Validity_Pitch'
-    #[inline(always)]
-    pub fn set_validity_pitch_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
@@ -28571,11 +28559,7 @@ impl RtSbInsAttitude {
         &mut self,
         value: RtSbInsAttitudeValidityYaw,
     ) -> Result<(), CanError> {
-        self.set_validity_yaw_raw(bool::from(value))
-    }
-    /// Set raw value of 'Validity_Yaw'
-    #[inline(always)]
-    pub fn set_validity_yaw_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[0..1].store_le(value);
         Ok(())
@@ -28825,11 +28809,7 @@ impl RtSbOutputStatus {
         &mut self,
         value: RtSbOutputStatusStatusTrigger,
     ) -> Result<(), CanError> {
-        self.set_status_trigger_raw(bool::from(value))
-    }
-    /// Set raw value of 'Status_Trigger'
-    #[inline(always)]
-    pub fn set_status_trigger_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[15..16].store_le(value);
         Ok(())
@@ -28874,14 +28854,7 @@ impl RtSbOutputStatus {
         &mut self,
         value: RtSbOutputStatusStatusSerialOutput2,
     ) -> Result<(), CanError> {
-        self.set_status_serial_output_2_raw(bool::from(value))
-    }
-    /// Set raw value of 'Status_Serial_Output_2'
-    #[inline(always)]
-    pub fn set_status_serial_output_2_raw(
-        &mut self,
-        value: bool,
-    ) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[14..15].store_le(value);
         Ok(())
@@ -28926,14 +28899,7 @@ impl RtSbOutputStatus {
         &mut self,
         value: RtSbOutputStatusStatusSerialOutput1,
     ) -> Result<(), CanError> {
-        self.set_status_serial_output_1_raw(bool::from(value))
-    }
-    /// Set raw value of 'Status_Serial_Output_1'
-    #[inline(always)]
-    pub fn set_status_serial_output_1_raw(
-        &mut self,
-        value: bool,
-    ) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[13..14].store_le(value);
         Ok(())
@@ -28976,11 +28942,7 @@ impl RtSbOutputStatus {
         &mut self,
         value: RtSbOutputStatusStatusPulseOutput,
     ) -> Result<(), CanError> {
-        self.set_status_pulse_output_raw(bool::from(value))
-    }
-    /// Set raw value of 'Status_Pulse_Output'
-    #[inline(always)]
-    pub fn set_status_pulse_output_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[12..13].store_le(value);
         Ok(())
@@ -29021,11 +28983,7 @@ impl RtSbOutputStatus {
         &mut self,
         value: RtSbOutputStatusStatusAnalogue4,
     ) -> Result<(), CanError> {
-        self.set_status_analogue_4_raw(bool::from(value))
-    }
-    /// Set raw value of 'Status_Analogue_4'
-    #[inline(always)]
-    pub fn set_status_analogue_4_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[11..12].store_le(value);
         Ok(())
@@ -29066,11 +29024,7 @@ impl RtSbOutputStatus {
         &mut self,
         value: RtSbOutputStatusStatusAnalogue3,
     ) -> Result<(), CanError> {
-        self.set_status_analogue_3_raw(bool::from(value))
-    }
-    /// Set raw value of 'Status_Analogue_3'
-    #[inline(always)]
-    pub fn set_status_analogue_3_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[10..11].store_le(value);
         Ok(())
@@ -29111,11 +29065,7 @@ impl RtSbOutputStatus {
         &mut self,
         value: RtSbOutputStatusStatusAnalogue2,
     ) -> Result<(), CanError> {
-        self.set_status_analogue_2_raw(bool::from(value))
-    }
-    /// Set raw value of 'Status_Analogue_2'
-    #[inline(always)]
-    pub fn set_status_analogue_2_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[9..10].store_le(value);
         Ok(())
@@ -29156,11 +29106,7 @@ impl RtSbOutputStatus {
         &mut self,
         value: RtSbOutputStatusStatusAnalogue1,
     ) -> Result<(), CanError> {
-        self.set_status_analogue_1_raw(bool::from(value))
-    }
-    /// Set raw value of 'Status_Analogue_1'
-    #[inline(always)]
-    pub fn set_status_analogue_1_raw(&mut self, value: bool) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[8..9].store_le(value);
         Ok(())
@@ -30352,14 +30298,7 @@ impl RtSbTriggerTimestamp {
         &mut self,
         value: RtSbTriggerTimestampTriggerTimestampType,
     ) -> Result<(), CanError> {
-        self.set_trigger_timestamp_type_raw(bool::from(value))
-    }
-    /// Set raw value of 'Trigger_Timestamp_Type'
-    #[inline(always)]
-    pub fn set_trigger_timestamp_type_raw(
-        &mut self,
-        value: bool,
-    ) -> Result<(), CanError> {
+        let value = bool::from(value);
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
@@ -32571,11 +32510,7 @@ impl RtSbGpsStatus {
         &mut self,
         value: RtSbGpsStatusRtkStatus,
     ) -> Result<(), CanError> {
-        self.set_rtk_status_raw(u8::from(value))
-    }
-    /// Set raw value of 'RTK_Status'
-    #[inline(always)]
-    pub fn set_rtk_status_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 255_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: RtSbGpsStatus::MESSAGE_ID,
@@ -32898,11 +32833,7 @@ impl RtSbGpsStatus {
         &mut self,
         value: RtSbGpsStatusGpsStatus,
     ) -> Result<(), CanError> {
-        self.set_gps_status_raw(u8::from(value))
-    }
-    /// Set raw value of 'GPS_Status'
-    #[inline(always)]
-    pub fn set_gps_status_raw(&mut self, value: u8) -> Result<(), CanError> {
+        let value = u8::from(value);
         if value < 0_u8 || 255_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: RtSbGpsStatus::MESSAGE_ID,

--- a/tests-snapshots/dbc-cantools/vehicle.snap.rs
+++ b/tests-snapshots/dbc-cantools/vehicle.snap.rs
@@ -1173,7 +1173,7 @@ impl RtSbInsVelBodyAxes {
     pub const INS_VEL_FORWARDS_2D_MAX: f32 = 838_f32;
     pub const ACCURACY_INS_VEL_BODY_MIN: u8 = 0_u8;
     pub const ACCURACY_INS_VEL_BODY_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Vel_Body_Axes from values
+    /// Construct new 'RT_SB_INS_Vel_Body_Axes' from values
     pub fn new(
         ins_vel_sideways_2d: f32,
         ins_vel_forwards_2d: f32,
@@ -1193,7 +1193,7 @@ impl RtSbInsVelBodyAxes {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Vel_Sideways_2D
+    /// Get value of 'INS_Vel_Sideways_2D'
     ///
     /// Sideways Velocity in the vehicle body axes, 2D (no vertical component) .  +ve for motion to the vehicle RHS.
     ///
@@ -1205,7 +1205,7 @@ impl RtSbInsVelBodyAxes {
     pub fn ins_vel_sideways_2d(&self) -> f32 {
         self.ins_vel_sideways_2d_raw()
     }
-    /// Get raw value of INS_Vel_Sideways_2D
+    /// Get raw value of 'INS_Vel_Sideways_2D'
     ///
     /// - Start bit: 40
     /// - Signal size: 24 bits
@@ -1220,7 +1220,7 @@ impl RtSbInsVelBodyAxes {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Vel_Sideways_2D
+    /// Set value of 'INS_Vel_Sideways_2D'
     #[inline(always)]
     pub fn set_ins_vel_sideways_2d(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -1235,7 +1235,7 @@ impl RtSbInsVelBodyAxes {
         self.raw.view_bits_mut::<Lsb0>()[40..64].store_le(value);
         Ok(())
     }
-    /// INS_Vel_Forwards_2D
+    /// Get value of 'INS_Vel_Forwards_2D'
     ///
     /// Forwards Velocity in the vehicle body axes, 2D (no vertical component) .
     ///
@@ -1247,7 +1247,7 @@ impl RtSbInsVelBodyAxes {
     pub fn ins_vel_forwards_2d(&self) -> f32 {
         self.ins_vel_forwards_2d_raw()
     }
-    /// Get raw value of INS_Vel_Forwards_2D
+    /// Get raw value of 'INS_Vel_Forwards_2D'
     ///
     /// - Start bit: 16
     /// - Signal size: 24 bits
@@ -1262,7 +1262,7 @@ impl RtSbInsVelBodyAxes {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Vel_Forwards_2D
+    /// Set value of 'INS_Vel_Forwards_2D'
     #[inline(always)]
     pub fn set_ins_vel_forwards_2d(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -1277,7 +1277,7 @@ impl RtSbInsVelBodyAxes {
         self.raw.view_bits_mut::<Lsb0>()[16..40].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Vel_Body
+    /// Get value of 'Accuracy_INS_Vel_Body'
     ///
     /// Accuracy of INS body axis velocities (forward velocity and sideways velocity)
     ///
@@ -1289,7 +1289,7 @@ impl RtSbInsVelBodyAxes {
     pub fn accuracy_ins_vel_body(&self) -> u8 {
         self.accuracy_ins_vel_body_raw()
     }
-    /// Get raw value of Accuracy_INS_Vel_Body
+    /// Get raw value of 'Accuracy_INS_Vel_Body'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -1303,7 +1303,7 @@ impl RtSbInsVelBodyAxes {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Vel_Body
+    /// Set value of 'Accuracy_INS_Vel_Body'
     #[inline(always)]
     pub fn set_accuracy_ins_vel_body(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -1321,7 +1321,7 @@ impl RtSbInsVelBodyAxes {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Vel_Sideways
+    /// Get value of 'Validity_INS_Vel_Sideways'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -1333,7 +1333,7 @@ impl RtSbInsVelBodyAxes {
     pub fn validity_ins_vel_sideways(&self) -> bool {
         self.validity_ins_vel_sideways_raw()
     }
-    /// Get raw value of Validity_INS_Vel_Sideways
+    /// Get raw value of 'Validity_INS_Vel_Sideways'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -1346,7 +1346,7 @@ impl RtSbInsVelBodyAxes {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Vel_Sideways
+    /// Set value of 'Validity_INS_Vel_Sideways'
     #[inline(always)]
     pub fn set_validity_ins_vel_sideways(
         &mut self,
@@ -1356,7 +1356,7 @@ impl RtSbInsVelBodyAxes {
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Vel_Forwards
+    /// Get value of 'Validity_INS_Vel_Forwards'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -1368,7 +1368,7 @@ impl RtSbInsVelBodyAxes {
     pub fn validity_ins_vel_forwards(&self) -> bool {
         self.validity_ins_vel_forwards_raw()
     }
-    /// Get raw value of Validity_INS_Vel_Forwards
+    /// Get raw value of 'Validity_INS_Vel_Forwards'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -1381,7 +1381,7 @@ impl RtSbInsVelBodyAxes {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Vel_Forwards
+    /// Set value of 'Validity_INS_Vel_Forwards'
     #[inline(always)]
     pub fn set_validity_ins_vel_forwards(
         &mut self,
@@ -1456,7 +1456,7 @@ impl RtDl1mk3Speed {
     pub const SPEED_MAX: f32 = 20000_f32;
     pub const ACCURACY_SPEED_MIN: u8 = 0_u8;
     pub const ACCURACY_SPEED_MAX: u8 = 255_u8;
-    /// Construct new RT_DL1MK3_Speed from values
+    /// Construct new 'RT_DL1MK3_Speed' from values
     pub fn new(
         speed: f32,
         accuracy_speed: u8,
@@ -1472,7 +1472,7 @@ impl RtDl1mk3Speed {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Speed
+    /// Get value of 'Speed'
     ///
     /// - Min: -20000
     /// - Max: 20000
@@ -1482,7 +1482,7 @@ impl RtDl1mk3Speed {
     pub fn speed(&self) -> f32 {
         self.speed_raw()
     }
-    /// Get raw value of Speed
+    /// Get raw value of 'Speed'
     ///
     /// - Start bit: 16
     /// - Signal size: 32 bits
@@ -1497,7 +1497,7 @@ impl RtDl1mk3Speed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Speed
+    /// Set value of 'Speed'
     #[inline(always)]
     pub fn set_speed(&mut self, value: f32) -> Result<(), CanError> {
         if value < -20000_f32 || 20000_f32 < value {
@@ -1512,7 +1512,7 @@ impl RtDl1mk3Speed {
         self.raw.view_bits_mut::<Lsb0>()[16..48].store_le(value);
         Ok(())
     }
-    /// Accuracy_Speed
+    /// Get value of 'Accuracy_Speed'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -1524,7 +1524,7 @@ impl RtDl1mk3Speed {
     pub fn accuracy_speed(&self) -> u8 {
         self.accuracy_speed_raw()
     }
-    /// Get raw value of Accuracy_Speed
+    /// Get raw value of 'Accuracy_Speed'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -1538,7 +1538,7 @@ impl RtDl1mk3Speed {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_Speed
+    /// Set value of 'Accuracy_Speed'
     #[inline(always)]
     pub fn set_accuracy_speed(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -1556,7 +1556,7 @@ impl RtDl1mk3Speed {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_Speed
+    /// Get value of 'Validity_Speed'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -1568,7 +1568,7 @@ impl RtDl1mk3Speed {
     pub fn validity_speed(&self) -> bool {
         self.validity_speed_raw()
     }
-    /// Get raw value of Validity_Speed
+    /// Get raw value of 'Validity_Speed'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -1581,7 +1581,7 @@ impl RtDl1mk3Speed {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Speed
+    /// Set value of 'Validity_Speed'
     #[inline(always)]
     pub fn set_validity_speed(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -1655,7 +1655,7 @@ impl RtDl1mk3GpsTime {
     pub const GPS_TIME_MAX: f32 = 604800_f32;
     pub const ACCURACY_GPS_TIME_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_TIME_MAX: u8 = 255_u8;
-    /// Construct new RT_DL1MK3_GPS_Time from values
+    /// Construct new 'RT_DL1MK3_GPS_Time' from values
     pub fn new(
         gps_week: u16,
         gps_time: f32,
@@ -1675,7 +1675,7 @@ impl RtDl1mk3GpsTime {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Week
+    /// Get value of 'GPS_Week'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -1685,7 +1685,7 @@ impl RtDl1mk3GpsTime {
     pub fn gps_week(&self) -> u16 {
         self.gps_week_raw()
     }
-    /// Get raw value of GPS_Week
+    /// Get raw value of 'GPS_Week'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -1699,7 +1699,7 @@ impl RtDl1mk3GpsTime {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GPS_Week
+    /// Set value of 'GPS_Week'
     #[inline(always)]
     pub fn set_gps_week(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -1717,7 +1717,7 @@ impl RtDl1mk3GpsTime {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// GPS_Time
+    /// Get value of 'GPS_Time'
     ///
     /// GPS time is the time in seconds since midnight GMT on Saturday night.
     ///
@@ -1729,7 +1729,7 @@ impl RtDl1mk3GpsTime {
     pub fn gps_time(&self) -> f32 {
         self.gps_time_raw()
     }
-    /// Get raw value of GPS_Time
+    /// Get raw value of 'GPS_Time'
     ///
     /// - Start bit: 16
     /// - Signal size: 32 bits
@@ -1744,7 +1744,7 @@ impl RtDl1mk3GpsTime {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Time
+    /// Set value of 'GPS_Time'
     #[inline(always)]
     pub fn set_gps_time(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 604800_f32 < value {
@@ -1758,7 +1758,7 @@ impl RtDl1mk3GpsTime {
         self.raw.view_bits_mut::<Lsb0>()[16..48].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Time
+    /// Get value of 'Accuracy_GPS_Time'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -1768,7 +1768,7 @@ impl RtDl1mk3GpsTime {
     pub fn accuracy_gps_time(&self) -> u8 {
         self.accuracy_gps_time_raw()
     }
-    /// Get raw value of Accuracy_GPS_Time
+    /// Get raw value of 'Accuracy_GPS_Time'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -1782,7 +1782,7 @@ impl RtDl1mk3GpsTime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Time
+    /// Set value of 'Accuracy_GPS_Time'
     #[inline(always)]
     pub fn set_accuracy_gps_time(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -1800,7 +1800,7 @@ impl RtDl1mk3GpsTime {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Week
+    /// Get value of 'Validity_GPS_Week'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -1812,7 +1812,7 @@ impl RtDl1mk3GpsTime {
     pub fn validity_gps_week(&self) -> bool {
         self.validity_gps_week_raw()
     }
-    /// Get raw value of Validity_GPS_Week
+    /// Get raw value of 'Validity_GPS_Week'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -1825,14 +1825,14 @@ impl RtDl1mk3GpsTime {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Week
+    /// Set value of 'Validity_GPS_Week'
     #[inline(always)]
     pub fn set_validity_gps_week(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Time
+    /// Get value of 'Validity_GPS_Time'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -1844,7 +1844,7 @@ impl RtDl1mk3GpsTime {
     pub fn validity_gps_time(&self) -> bool {
         self.validity_gps_time_raw()
     }
-    /// Get raw value of Validity_GPS_Time
+    /// Get raw value of 'Validity_GPS_Time'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -1857,7 +1857,7 @@ impl RtDl1mk3GpsTime {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Time
+    /// Set value of 'Validity_GPS_Time'
     #[inline(always)]
     pub fn set_validity_gps_time(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -1929,7 +1929,7 @@ impl RtDl1mk3GpsPosLlh2 {
     pub const GPS_POS_LLH_ALTITUDE_MAX: f32 = 100000_f32;
     pub const GPS_POS_LLH_LONGITUDE_MIN: f32 = -180_f32;
     pub const GPS_POS_LLH_LONGITUDE_MAX: f32 = 180_f32;
-    /// Construct new RT_DL1MK3_GPS_Pos_LLH_2 from values
+    /// Construct new 'RT_DL1MK3_GPS_Pos_LLH_2' from values
     pub fn new(
         gps_pos_llh_altitude: f32,
         gps_pos_llh_longitude: f32,
@@ -1943,7 +1943,7 @@ impl RtDl1mk3GpsPosLlh2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Pos_LLH_Altitude
+    /// Get value of 'GPS_Pos_LLH_Altitude'
     ///
     /// - Min: -1000
     /// - Max: 100000
@@ -1953,7 +1953,7 @@ impl RtDl1mk3GpsPosLlh2 {
     pub fn gps_pos_llh_altitude(&self) -> f32 {
         self.gps_pos_llh_altitude_raw()
     }
-    /// Get raw value of GPS_Pos_LLH_Altitude
+    /// Get raw value of 'GPS_Pos_LLH_Altitude'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -1968,7 +1968,7 @@ impl RtDl1mk3GpsPosLlh2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Pos_LLH_Altitude
+    /// Set value of 'GPS_Pos_LLH_Altitude'
     #[inline(always)]
     pub fn set_gps_pos_llh_altitude(&mut self, value: f32) -> Result<(), CanError> {
         if value < -1000_f32 || 100000_f32 < value {
@@ -1983,7 +1983,7 @@ impl RtDl1mk3GpsPosLlh2 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// GPS_Pos_LLH_Longitude
+    /// Get value of 'GPS_Pos_LLH_Longitude'
     ///
     /// - Min: -180
     /// - Max: 180
@@ -1993,7 +1993,7 @@ impl RtDl1mk3GpsPosLlh2 {
     pub fn gps_pos_llh_longitude(&self) -> f32 {
         self.gps_pos_llh_longitude_raw()
     }
-    /// Get raw value of GPS_Pos_LLH_Longitude
+    /// Get raw value of 'GPS_Pos_LLH_Longitude'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -2008,7 +2008,7 @@ impl RtDl1mk3GpsPosLlh2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Pos_LLH_Longitude
+    /// Set value of 'GPS_Pos_LLH_Longitude'
     #[inline(always)]
     pub fn set_gps_pos_llh_longitude(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -2092,7 +2092,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub const ACCURACY_GPS_POS_LLH_LONGITUDE_MAX: u8 = 255_u8;
     pub const ACCURACY_GPS_POS_LLH_LATITUDE_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_POS_LLH_LATITUDE_MAX: u8 = 255_u8;
-    /// Construct new RT_DL1MK3_GPS_Pos_LLH_1 from values
+    /// Construct new 'RT_DL1MK3_GPS_Pos_LLH_1' from values
     pub fn new(
         gps_pos_llh_latitude: f32,
         accuracy_gps_pos_llh_altitude: u8,
@@ -2116,7 +2116,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Pos_LLH_Latitude
+    /// Get value of 'GPS_Pos_LLH_Latitude'
     ///
     /// - Min: -90
     /// - Max: 90
@@ -2126,7 +2126,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub fn gps_pos_llh_latitude(&self) -> f32 {
         self.gps_pos_llh_latitude_raw()
     }
-    /// Get raw value of GPS_Pos_LLH_Latitude
+    /// Get raw value of 'GPS_Pos_LLH_Latitude'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -2141,7 +2141,7 @@ impl RtDl1mk3GpsPosLlh1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Pos_LLH_Latitude
+    /// Set value of 'GPS_Pos_LLH_Latitude'
     #[inline(always)]
     pub fn set_gps_pos_llh_latitude(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -2156,7 +2156,7 @@ impl RtDl1mk3GpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Pos_LLH_Altitude
+    /// Get value of 'Accuracy_GPS_Pos_LLH_Altitude'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -2168,7 +2168,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub fn accuracy_gps_pos_llh_altitude(&self) -> u8 {
         self.accuracy_gps_pos_llh_altitude_raw()
     }
-    /// Get raw value of Accuracy_GPS_Pos_LLH_Altitude
+    /// Get raw value of 'Accuracy_GPS_Pos_LLH_Altitude'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -2182,7 +2182,7 @@ impl RtDl1mk3GpsPosLlh1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Pos_LLH_Altitude
+    /// Set value of 'Accuracy_GPS_Pos_LLH_Altitude'
     #[inline(always)]
     pub fn set_accuracy_gps_pos_llh_altitude(
         &mut self,
@@ -2203,7 +2203,7 @@ impl RtDl1mk3GpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Pos_LLH_Longitude
+    /// Get value of 'Accuracy_GPS_Pos_LLH_Longitude'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -2215,7 +2215,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub fn accuracy_gps_pos_llh_longitude(&self) -> u8 {
         self.accuracy_gps_pos_llh_longitude_raw()
     }
-    /// Get raw value of Accuracy_GPS_Pos_LLH_Longitude
+    /// Get raw value of 'Accuracy_GPS_Pos_LLH_Longitude'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -2229,7 +2229,7 @@ impl RtDl1mk3GpsPosLlh1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Pos_LLH_Longitude
+    /// Set value of 'Accuracy_GPS_Pos_LLH_Longitude'
     #[inline(always)]
     pub fn set_accuracy_gps_pos_llh_longitude(
         &mut self,
@@ -2250,7 +2250,7 @@ impl RtDl1mk3GpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Pos_LLH_Latitude
+    /// Get value of 'Accuracy_GPS_Pos_LLH_Latitude'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -2262,7 +2262,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub fn accuracy_gps_pos_llh_latitude(&self) -> u8 {
         self.accuracy_gps_pos_llh_latitude_raw()
     }
-    /// Get raw value of Accuracy_GPS_Pos_LLH_Latitude
+    /// Get raw value of 'Accuracy_GPS_Pos_LLH_Latitude'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -2276,7 +2276,7 @@ impl RtDl1mk3GpsPosLlh1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Pos_LLH_Latitude
+    /// Set value of 'Accuracy_GPS_Pos_LLH_Latitude'
     #[inline(always)]
     pub fn set_accuracy_gps_pos_llh_latitude(
         &mut self,
@@ -2297,7 +2297,7 @@ impl RtDl1mk3GpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Pos_LLH_Altitude
+    /// Get value of 'Validity_GPS_Pos_LLH_Altitude'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -2309,7 +2309,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub fn validity_gps_pos_llh_altitude(&self) -> bool {
         self.validity_gps_pos_llh_altitude_raw()
     }
-    /// Get raw value of Validity_GPS_Pos_LLH_Altitude
+    /// Get raw value of 'Validity_GPS_Pos_LLH_Altitude'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -2322,7 +2322,7 @@ impl RtDl1mk3GpsPosLlh1 {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Pos_LLH_Altitude
+    /// Set value of 'Validity_GPS_Pos_LLH_Altitude'
     #[inline(always)]
     pub fn set_validity_gps_pos_llh_altitude(
         &mut self,
@@ -2332,7 +2332,7 @@ impl RtDl1mk3GpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Pos_LLH_Longitude
+    /// Get value of 'Validity_GPS_Pos_LLH_Longitude'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -2344,7 +2344,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub fn validity_gps_pos_llh_longitude(&self) -> bool {
         self.validity_gps_pos_llh_longitude_raw()
     }
-    /// Get raw value of Validity_GPS_Pos_LLH_Longitude
+    /// Get raw value of 'Validity_GPS_Pos_LLH_Longitude'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -2357,7 +2357,7 @@ impl RtDl1mk3GpsPosLlh1 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Pos_LLH_Longitude
+    /// Set value of 'Validity_GPS_Pos_LLH_Longitude'
     #[inline(always)]
     pub fn set_validity_gps_pos_llh_longitude(
         &mut self,
@@ -2367,7 +2367,7 @@ impl RtDl1mk3GpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Pos_LLH_Latitude
+    /// Get value of 'Validity_GPS_Pos_LLH_Latitude'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -2379,7 +2379,7 @@ impl RtDl1mk3GpsPosLlh1 {
     pub fn validity_gps_pos_llh_latitude(&self) -> bool {
         self.validity_gps_pos_llh_latitude_raw()
     }
-    /// Get raw value of Validity_GPS_Pos_LLH_Latitude
+    /// Get raw value of 'Validity_GPS_Pos_LLH_Latitude'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -2392,7 +2392,7 @@ impl RtDl1mk3GpsPosLlh1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Pos_LLH_Latitude
+    /// Set value of 'Validity_GPS_Pos_LLH_Latitude'
     #[inline(always)]
     pub fn set_validity_gps_pos_llh_latitude(
         &mut self,
@@ -2469,7 +2469,7 @@ impl RtDl1mk3GpsSpeed {
     pub const GPS_SPEED_2D_MAX: f32 = 1675_f32;
     pub const ACCURACY_GPS_SPEED_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_SPEED_MAX: u8 = 255_u8;
-    /// Construct new RT_DL1MK3_GPS_Speed from values
+    /// Construct new 'RT_DL1MK3_GPS_Speed' from values
     pub fn new(
         gps_speed_3d: f32,
         gps_speed_2d: f32,
@@ -2489,7 +2489,7 @@ impl RtDl1mk3GpsSpeed {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Speed_3D
+    /// Get value of 'GPS_Speed_3D'
     ///
     /// This is GPS scalar 3D speed - scalar speed with the local Z axis component included.
     ///
@@ -2501,7 +2501,7 @@ impl RtDl1mk3GpsSpeed {
     pub fn gps_speed_3d(&self) -> f32 {
         self.gps_speed_3d_raw()
     }
-    /// Get raw value of GPS_Speed_3D
+    /// Get raw value of 'GPS_Speed_3D'
     ///
     /// - Start bit: 40
     /// - Signal size: 24 bits
@@ -2516,7 +2516,7 @@ impl RtDl1mk3GpsSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Speed_3D
+    /// Set value of 'GPS_Speed_3D'
     #[inline(always)]
     pub fn set_gps_speed_3d(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 1675_f32 < value {
@@ -2530,7 +2530,7 @@ impl RtDl1mk3GpsSpeed {
         self.raw.view_bits_mut::<Lsb0>()[40..64].store_le(value);
         Ok(())
     }
-    /// GPS_Speed_2D
+    /// Get value of 'GPS_Speed_2D'
     ///
     /// This is GPS scalar 2D speed - scalar speed with no local Z axis component included.
     ///
@@ -2542,7 +2542,7 @@ impl RtDl1mk3GpsSpeed {
     pub fn gps_speed_2d(&self) -> f32 {
         self.gps_speed_2d_raw()
     }
-    /// Get raw value of GPS_Speed_2D
+    /// Get raw value of 'GPS_Speed_2D'
     ///
     /// - Start bit: 16
     /// - Signal size: 24 bits
@@ -2557,7 +2557,7 @@ impl RtDl1mk3GpsSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Speed_2D
+    /// Set value of 'GPS_Speed_2D'
     #[inline(always)]
     pub fn set_gps_speed_2d(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 1675_f32 < value {
@@ -2571,7 +2571,7 @@ impl RtDl1mk3GpsSpeed {
         self.raw.view_bits_mut::<Lsb0>()[16..40].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Speed
+    /// Get value of 'Accuracy_GPS_Speed'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -2583,7 +2583,7 @@ impl RtDl1mk3GpsSpeed {
     pub fn accuracy_gps_speed(&self) -> u8 {
         self.accuracy_gps_speed_raw()
     }
-    /// Get raw value of Accuracy_GPS_Speed
+    /// Get raw value of 'Accuracy_GPS_Speed'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -2597,7 +2597,7 @@ impl RtDl1mk3GpsSpeed {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Speed
+    /// Set value of 'Accuracy_GPS_Speed'
     #[inline(always)]
     pub fn set_accuracy_gps_speed(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -2615,7 +2615,7 @@ impl RtDl1mk3GpsSpeed {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Speed_3D
+    /// Get value of 'Validity_GPS_Speed_3D'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -2627,7 +2627,7 @@ impl RtDl1mk3GpsSpeed {
     pub fn validity_gps_speed_3d(&self) -> bool {
         self.validity_gps_speed_3d_raw()
     }
-    /// Get raw value of Validity_GPS_Speed_3D
+    /// Get raw value of 'Validity_GPS_Speed_3D'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -2640,14 +2640,14 @@ impl RtDl1mk3GpsSpeed {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Speed_3D
+    /// Set value of 'Validity_GPS_Speed_3D'
     #[inline(always)]
     pub fn set_validity_gps_speed_3d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Speed_2D
+    /// Get value of 'Validity_GPS_Speed_2D'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -2659,7 +2659,7 @@ impl RtDl1mk3GpsSpeed {
     pub fn validity_gps_speed_2d(&self) -> bool {
         self.validity_gps_speed_2d_raw()
     }
-    /// Get raw value of Validity_GPS_Speed_2D
+    /// Get raw value of 'Validity_GPS_Speed_2D'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -2672,7 +2672,7 @@ impl RtDl1mk3GpsSpeed {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Speed_2D
+    /// Set value of 'Validity_GPS_Speed_2D'
     #[inline(always)]
     pub fn set_validity_gps_speed_2d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -2742,7 +2742,7 @@ impl RtIrTempTemp7 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_7_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_7_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_7 from values
+    /// Construct new 'RT_IRTemp_Temp_7' from values
     pub fn new(ir_temperature_7: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_7(ir_temperature_7)?;
@@ -2752,7 +2752,7 @@ impl RtIrTempTemp7 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_7
+    /// Get value of 'IR_Temperature_7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2762,7 +2762,7 @@ impl RtIrTempTemp7 {
     pub fn ir_temperature_7(&self) -> f32 {
         self.ir_temperature_7_raw()
     }
-    /// Get raw value of IR_Temperature_7
+    /// Get raw value of 'IR_Temperature_7'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -2777,7 +2777,7 @@ impl RtIrTempTemp7 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_7
+    /// Set value of 'IR_Temperature_7'
     #[inline(always)]
     pub fn set_ir_temperature_7(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -2861,7 +2861,7 @@ impl RtIrTempTempRr2 {
     pub const IR_TEMPERATURE_30_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_29_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_29_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_RR_2 from values
+    /// Construct new 'RT_IRTemp_Temp_RR_2' from values
     pub fn new(
         ir_temperature_32: f32,
         ir_temperature_31: f32,
@@ -2879,7 +2879,7 @@ impl RtIrTempTempRr2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// IR_Temperature_32
+    /// Get value of 'IR_Temperature_32'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2889,7 +2889,7 @@ impl RtIrTempTempRr2 {
     pub fn ir_temperature_32(&self) -> f32 {
         self.ir_temperature_32_raw()
     }
-    /// Get raw value of IR_Temperature_32
+    /// Get raw value of 'IR_Temperature_32'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -2904,7 +2904,7 @@ impl RtIrTempTempRr2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_32
+    /// Set value of 'IR_Temperature_32'
     #[inline(always)]
     pub fn set_ir_temperature_32(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -2919,7 +2919,7 @@ impl RtIrTempTempRr2 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_31
+    /// Get value of 'IR_Temperature_31'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2929,7 +2929,7 @@ impl RtIrTempTempRr2 {
     pub fn ir_temperature_31(&self) -> f32 {
         self.ir_temperature_31_raw()
     }
-    /// Get raw value of IR_Temperature_31
+    /// Get raw value of 'IR_Temperature_31'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -2944,7 +2944,7 @@ impl RtIrTempTempRr2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_31
+    /// Set value of 'IR_Temperature_31'
     #[inline(always)]
     pub fn set_ir_temperature_31(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -2959,7 +2959,7 @@ impl RtIrTempTempRr2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_30
+    /// Get value of 'IR_Temperature_30'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -2969,7 +2969,7 @@ impl RtIrTempTempRr2 {
     pub fn ir_temperature_30(&self) -> f32 {
         self.ir_temperature_30_raw()
     }
-    /// Get raw value of IR_Temperature_30
+    /// Get raw value of 'IR_Temperature_30'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -2984,7 +2984,7 @@ impl RtIrTempTempRr2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_30
+    /// Set value of 'IR_Temperature_30'
     #[inline(always)]
     pub fn set_ir_temperature_30(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -2999,7 +2999,7 @@ impl RtIrTempTempRr2 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_29
+    /// Get value of 'IR_Temperature_29'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3009,7 +3009,7 @@ impl RtIrTempTempRr2 {
     pub fn ir_temperature_29(&self) -> f32 {
         self.ir_temperature_29_raw()
     }
-    /// Get raw value of IR_Temperature_29
+    /// Get raw value of 'IR_Temperature_29'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -3024,7 +3024,7 @@ impl RtIrTempTempRr2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_29
+    /// Set value of 'IR_Temperature_29'
     #[inline(always)]
     pub fn set_ir_temperature_29(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3108,7 +3108,7 @@ impl RtIrTempTempRl2 {
     pub const IR_TEMPERATURE_22_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_21_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_21_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_RL_2 from values
+    /// Construct new 'RT_IRTemp_Temp_RL_2' from values
     pub fn new(
         ir_temperature_24: f32,
         ir_temperature_23: f32,
@@ -3126,7 +3126,7 @@ impl RtIrTempTempRl2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// IR_Temperature_24
+    /// Get value of 'IR_Temperature_24'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3136,7 +3136,7 @@ impl RtIrTempTempRl2 {
     pub fn ir_temperature_24(&self) -> f32 {
         self.ir_temperature_24_raw()
     }
-    /// Get raw value of IR_Temperature_24
+    /// Get raw value of 'IR_Temperature_24'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -3151,7 +3151,7 @@ impl RtIrTempTempRl2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_24
+    /// Set value of 'IR_Temperature_24'
     #[inline(always)]
     pub fn set_ir_temperature_24(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3166,7 +3166,7 @@ impl RtIrTempTempRl2 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_23
+    /// Get value of 'IR_Temperature_23'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3176,7 +3176,7 @@ impl RtIrTempTempRl2 {
     pub fn ir_temperature_23(&self) -> f32 {
         self.ir_temperature_23_raw()
     }
-    /// Get raw value of IR_Temperature_23
+    /// Get raw value of 'IR_Temperature_23'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3191,7 +3191,7 @@ impl RtIrTempTempRl2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_23
+    /// Set value of 'IR_Temperature_23'
     #[inline(always)]
     pub fn set_ir_temperature_23(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3206,7 +3206,7 @@ impl RtIrTempTempRl2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_22
+    /// Get value of 'IR_Temperature_22'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3216,7 +3216,7 @@ impl RtIrTempTempRl2 {
     pub fn ir_temperature_22(&self) -> f32 {
         self.ir_temperature_22_raw()
     }
-    /// Get raw value of IR_Temperature_22
+    /// Get raw value of 'IR_Temperature_22'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3231,7 +3231,7 @@ impl RtIrTempTempRl2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_22
+    /// Set value of 'IR_Temperature_22'
     #[inline(always)]
     pub fn set_ir_temperature_22(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3246,7 +3246,7 @@ impl RtIrTempTempRl2 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_21
+    /// Get value of 'IR_Temperature_21'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3256,7 +3256,7 @@ impl RtIrTempTempRl2 {
     pub fn ir_temperature_21(&self) -> f32 {
         self.ir_temperature_21_raw()
     }
-    /// Get raw value of IR_Temperature_21
+    /// Get raw value of 'IR_Temperature_21'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -3271,7 +3271,7 @@ impl RtIrTempTempRl2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_21
+    /// Set value of 'IR_Temperature_21'
     #[inline(always)]
     pub fn set_ir_temperature_21(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3355,7 +3355,7 @@ impl RtIrTempTempFr2 {
     pub const IR_TEMPERATURE_14_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_13_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_13_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_FR_2 from values
+    /// Construct new 'RT_IRTemp_Temp_FR_2' from values
     pub fn new(
         ir_temperature_16: f32,
         ir_temperature_15: f32,
@@ -3373,7 +3373,7 @@ impl RtIrTempTempFr2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// IR_Temperature_16
+    /// Get value of 'IR_Temperature_16'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3383,7 +3383,7 @@ impl RtIrTempTempFr2 {
     pub fn ir_temperature_16(&self) -> f32 {
         self.ir_temperature_16_raw()
     }
-    /// Get raw value of IR_Temperature_16
+    /// Get raw value of 'IR_Temperature_16'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -3398,7 +3398,7 @@ impl RtIrTempTempFr2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_16
+    /// Set value of 'IR_Temperature_16'
     #[inline(always)]
     pub fn set_ir_temperature_16(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3413,7 +3413,7 @@ impl RtIrTempTempFr2 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_15
+    /// Get value of 'IR_Temperature_15'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3423,7 +3423,7 @@ impl RtIrTempTempFr2 {
     pub fn ir_temperature_15(&self) -> f32 {
         self.ir_temperature_15_raw()
     }
-    /// Get raw value of IR_Temperature_15
+    /// Get raw value of 'IR_Temperature_15'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3438,7 +3438,7 @@ impl RtIrTempTempFr2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_15
+    /// Set value of 'IR_Temperature_15'
     #[inline(always)]
     pub fn set_ir_temperature_15(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3453,7 +3453,7 @@ impl RtIrTempTempFr2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_14
+    /// Get value of 'IR_Temperature_14'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3463,7 +3463,7 @@ impl RtIrTempTempFr2 {
     pub fn ir_temperature_14(&self) -> f32 {
         self.ir_temperature_14_raw()
     }
-    /// Get raw value of IR_Temperature_14
+    /// Get raw value of 'IR_Temperature_14'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3478,7 +3478,7 @@ impl RtIrTempTempFr2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_14
+    /// Set value of 'IR_Temperature_14'
     #[inline(always)]
     pub fn set_ir_temperature_14(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3493,7 +3493,7 @@ impl RtIrTempTempFr2 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_13
+    /// Get value of 'IR_Temperature_13'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3503,7 +3503,7 @@ impl RtIrTempTempFr2 {
     pub fn ir_temperature_13(&self) -> f32 {
         self.ir_temperature_13_raw()
     }
-    /// Get raw value of IR_Temperature_13
+    /// Get raw value of 'IR_Temperature_13'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -3518,7 +3518,7 @@ impl RtIrTempTempFr2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_13
+    /// Set value of 'IR_Temperature_13'
     #[inline(always)]
     pub fn set_ir_temperature_13(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3602,7 +3602,7 @@ impl RtIrTempTempFl2 {
     pub const IR_TEMPERATURE_6_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_5_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_5_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_FL_2 from values
+    /// Construct new 'RT_IRTemp_Temp_FL_2' from values
     pub fn new(
         ir_temperature_8: f32,
         ir_temperature_7: f32,
@@ -3620,7 +3620,7 @@ impl RtIrTempTempFl2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// IR_Temperature_8
+    /// Get value of 'IR_Temperature_8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3630,7 +3630,7 @@ impl RtIrTempTempFl2 {
     pub fn ir_temperature_8(&self) -> f32 {
         self.ir_temperature_8_raw()
     }
-    /// Get raw value of IR_Temperature_8
+    /// Get raw value of 'IR_Temperature_8'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -3645,7 +3645,7 @@ impl RtIrTempTempFl2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_8
+    /// Set value of 'IR_Temperature_8'
     #[inline(always)]
     pub fn set_ir_temperature_8(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3660,7 +3660,7 @@ impl RtIrTempTempFl2 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_7
+    /// Get value of 'IR_Temperature_7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3670,7 +3670,7 @@ impl RtIrTempTempFl2 {
     pub fn ir_temperature_7(&self) -> f32 {
         self.ir_temperature_7_raw()
     }
-    /// Get raw value of IR_Temperature_7
+    /// Get raw value of 'IR_Temperature_7'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3685,7 +3685,7 @@ impl RtIrTempTempFl2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_7
+    /// Set value of 'IR_Temperature_7'
     #[inline(always)]
     pub fn set_ir_temperature_7(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3700,7 +3700,7 @@ impl RtIrTempTempFl2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_6
+    /// Get value of 'IR_Temperature_6'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3710,7 +3710,7 @@ impl RtIrTempTempFl2 {
     pub fn ir_temperature_6(&self) -> f32 {
         self.ir_temperature_6_raw()
     }
-    /// Get raw value of IR_Temperature_6
+    /// Get raw value of 'IR_Temperature_6'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3725,7 +3725,7 @@ impl RtIrTempTempFl2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_6
+    /// Set value of 'IR_Temperature_6'
     #[inline(always)]
     pub fn set_ir_temperature_6(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3740,7 +3740,7 @@ impl RtIrTempTempFl2 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_5
+    /// Get value of 'IR_Temperature_5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3750,7 +3750,7 @@ impl RtIrTempTempFl2 {
     pub fn ir_temperature_5(&self) -> f32 {
         self.ir_temperature_5_raw()
     }
-    /// Get raw value of IR_Temperature_5
+    /// Get raw value of 'IR_Temperature_5'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -3765,7 +3765,7 @@ impl RtIrTempTempFl2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_5
+    /// Set value of 'IR_Temperature_5'
     #[inline(always)]
     pub fn set_ir_temperature_5(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3849,7 +3849,7 @@ impl RtIrTempTempRr1 {
     pub const IR_TEMPERATURE_26_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_25_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_25_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_RR_1 from values
+    /// Construct new 'RT_IRTemp_Temp_RR_1' from values
     pub fn new(
         ir_temperature_28: f32,
         ir_temperature_27: f32,
@@ -3867,7 +3867,7 @@ impl RtIrTempTempRr1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// IR_Temperature_28
+    /// Get value of 'IR_Temperature_28'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3877,7 +3877,7 @@ impl RtIrTempTempRr1 {
     pub fn ir_temperature_28(&self) -> f32 {
         self.ir_temperature_28_raw()
     }
-    /// Get raw value of IR_Temperature_28
+    /// Get raw value of 'IR_Temperature_28'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -3892,7 +3892,7 @@ impl RtIrTempTempRr1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_28
+    /// Set value of 'IR_Temperature_28'
     #[inline(always)]
     pub fn set_ir_temperature_28(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3907,7 +3907,7 @@ impl RtIrTempTempRr1 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_27
+    /// Get value of 'IR_Temperature_27'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3917,7 +3917,7 @@ impl RtIrTempTempRr1 {
     pub fn ir_temperature_27(&self) -> f32 {
         self.ir_temperature_27_raw()
     }
-    /// Get raw value of IR_Temperature_27
+    /// Get raw value of 'IR_Temperature_27'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -3932,7 +3932,7 @@ impl RtIrTempTempRr1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_27
+    /// Set value of 'IR_Temperature_27'
     #[inline(always)]
     pub fn set_ir_temperature_27(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3947,7 +3947,7 @@ impl RtIrTempTempRr1 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_26
+    /// Get value of 'IR_Temperature_26'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3957,7 +3957,7 @@ impl RtIrTempTempRr1 {
     pub fn ir_temperature_26(&self) -> f32 {
         self.ir_temperature_26_raw()
     }
-    /// Get raw value of IR_Temperature_26
+    /// Get raw value of 'IR_Temperature_26'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -3972,7 +3972,7 @@ impl RtIrTempTempRr1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_26
+    /// Set value of 'IR_Temperature_26'
     #[inline(always)]
     pub fn set_ir_temperature_26(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -3987,7 +3987,7 @@ impl RtIrTempTempRr1 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_25
+    /// Get value of 'IR_Temperature_25'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -3997,7 +3997,7 @@ impl RtIrTempTempRr1 {
     pub fn ir_temperature_25(&self) -> f32 {
         self.ir_temperature_25_raw()
     }
-    /// Get raw value of IR_Temperature_25
+    /// Get raw value of 'IR_Temperature_25'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -4012,7 +4012,7 @@ impl RtIrTempTempRr1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_25
+    /// Set value of 'IR_Temperature_25'
     #[inline(always)]
     pub fn set_ir_temperature_25(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4096,7 +4096,7 @@ impl RtIrTempTempRl1 {
     pub const IR_TEMPERATURE_18_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_17_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_17_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_RL_1 from values
+    /// Construct new 'RT_IRTemp_Temp_RL_1' from values
     pub fn new(
         ir_temperature_20: f32,
         ir_temperature_19: f32,
@@ -4114,7 +4114,7 @@ impl RtIrTempTempRl1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// IR_Temperature_20
+    /// Get value of 'IR_Temperature_20'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4124,7 +4124,7 @@ impl RtIrTempTempRl1 {
     pub fn ir_temperature_20(&self) -> f32 {
         self.ir_temperature_20_raw()
     }
-    /// Get raw value of IR_Temperature_20
+    /// Get raw value of 'IR_Temperature_20'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -4139,7 +4139,7 @@ impl RtIrTempTempRl1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_20
+    /// Set value of 'IR_Temperature_20'
     #[inline(always)]
     pub fn set_ir_temperature_20(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4154,7 +4154,7 @@ impl RtIrTempTempRl1 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_19
+    /// Get value of 'IR_Temperature_19'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4164,7 +4164,7 @@ impl RtIrTempTempRl1 {
     pub fn ir_temperature_19(&self) -> f32 {
         self.ir_temperature_19_raw()
     }
-    /// Get raw value of IR_Temperature_19
+    /// Get raw value of 'IR_Temperature_19'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4179,7 +4179,7 @@ impl RtIrTempTempRl1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_19
+    /// Set value of 'IR_Temperature_19'
     #[inline(always)]
     pub fn set_ir_temperature_19(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4194,7 +4194,7 @@ impl RtIrTempTempRl1 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_18
+    /// Get value of 'IR_Temperature_18'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4204,7 +4204,7 @@ impl RtIrTempTempRl1 {
     pub fn ir_temperature_18(&self) -> f32 {
         self.ir_temperature_18_raw()
     }
-    /// Get raw value of IR_Temperature_18
+    /// Get raw value of 'IR_Temperature_18'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4219,7 +4219,7 @@ impl RtIrTempTempRl1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_18
+    /// Set value of 'IR_Temperature_18'
     #[inline(always)]
     pub fn set_ir_temperature_18(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4234,7 +4234,7 @@ impl RtIrTempTempRl1 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_17
+    /// Get value of 'IR_Temperature_17'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4244,7 +4244,7 @@ impl RtIrTempTempRl1 {
     pub fn ir_temperature_17(&self) -> f32 {
         self.ir_temperature_17_raw()
     }
-    /// Get raw value of IR_Temperature_17
+    /// Get raw value of 'IR_Temperature_17'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -4259,7 +4259,7 @@ impl RtIrTempTempRl1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_17
+    /// Set value of 'IR_Temperature_17'
     #[inline(always)]
     pub fn set_ir_temperature_17(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4343,7 +4343,7 @@ impl RtIrTempTempFr1 {
     pub const IR_TEMPERATURE_10_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_9_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_9_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_FR_1 from values
+    /// Construct new 'RT_IRTemp_Temp_FR_1' from values
     pub fn new(
         ir_temperature_12: f32,
         ir_temperature_11: f32,
@@ -4361,7 +4361,7 @@ impl RtIrTempTempFr1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// IR_Temperature_12
+    /// Get value of 'IR_Temperature_12'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4371,7 +4371,7 @@ impl RtIrTempTempFr1 {
     pub fn ir_temperature_12(&self) -> f32 {
         self.ir_temperature_12_raw()
     }
-    /// Get raw value of IR_Temperature_12
+    /// Get raw value of 'IR_Temperature_12'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -4386,7 +4386,7 @@ impl RtIrTempTempFr1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_12
+    /// Set value of 'IR_Temperature_12'
     #[inline(always)]
     pub fn set_ir_temperature_12(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4401,7 +4401,7 @@ impl RtIrTempTempFr1 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_11
+    /// Get value of 'IR_Temperature_11'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4411,7 +4411,7 @@ impl RtIrTempTempFr1 {
     pub fn ir_temperature_11(&self) -> f32 {
         self.ir_temperature_11_raw()
     }
-    /// Get raw value of IR_Temperature_11
+    /// Get raw value of 'IR_Temperature_11'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4426,7 +4426,7 @@ impl RtIrTempTempFr1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_11
+    /// Set value of 'IR_Temperature_11'
     #[inline(always)]
     pub fn set_ir_temperature_11(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4441,7 +4441,7 @@ impl RtIrTempTempFr1 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_10
+    /// Get value of 'IR_Temperature_10'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4451,7 +4451,7 @@ impl RtIrTempTempFr1 {
     pub fn ir_temperature_10(&self) -> f32 {
         self.ir_temperature_10_raw()
     }
-    /// Get raw value of IR_Temperature_10
+    /// Get raw value of 'IR_Temperature_10'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4466,7 +4466,7 @@ impl RtIrTempTempFr1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_10
+    /// Set value of 'IR_Temperature_10'
     #[inline(always)]
     pub fn set_ir_temperature_10(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4481,7 +4481,7 @@ impl RtIrTempTempFr1 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_9
+    /// Get value of 'IR_Temperature_9'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4491,7 +4491,7 @@ impl RtIrTempTempFr1 {
     pub fn ir_temperature_9(&self) -> f32 {
         self.ir_temperature_9_raw()
     }
-    /// Get raw value of IR_Temperature_9
+    /// Get raw value of 'IR_Temperature_9'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -4506,7 +4506,7 @@ impl RtIrTempTempFr1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_9
+    /// Set value of 'IR_Temperature_9'
     #[inline(always)]
     pub fn set_ir_temperature_9(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4590,7 +4590,7 @@ impl RtIrTempTempFl1 {
     pub const IR_TEMPERATURE_2_MAX: f32 = 0_f32;
     pub const IR_TEMPERATURE_1_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_1_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_FL_1 from values
+    /// Construct new 'RT_IRTemp_Temp_FL_1' from values
     pub fn new(
         ir_temperature_4: f32,
         ir_temperature_3: f32,
@@ -4608,7 +4608,7 @@ impl RtIrTempTempFl1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// IR_Temperature_4
+    /// Get value of 'IR_Temperature_4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4618,7 +4618,7 @@ impl RtIrTempTempFl1 {
     pub fn ir_temperature_4(&self) -> f32 {
         self.ir_temperature_4_raw()
     }
-    /// Get raw value of IR_Temperature_4
+    /// Get raw value of 'IR_Temperature_4'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -4633,7 +4633,7 @@ impl RtIrTempTempFl1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_4
+    /// Set value of 'IR_Temperature_4'
     #[inline(always)]
     pub fn set_ir_temperature_4(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4648,7 +4648,7 @@ impl RtIrTempTempFl1 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_3
+    /// Get value of 'IR_Temperature_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4658,7 +4658,7 @@ impl RtIrTempTempFl1 {
     pub fn ir_temperature_3(&self) -> f32 {
         self.ir_temperature_3_raw()
     }
-    /// Get raw value of IR_Temperature_3
+    /// Get raw value of 'IR_Temperature_3'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -4673,7 +4673,7 @@ impl RtIrTempTempFl1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_3
+    /// Set value of 'IR_Temperature_3'
     #[inline(always)]
     pub fn set_ir_temperature_3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4688,7 +4688,7 @@ impl RtIrTempTempFl1 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_2
+    /// Get value of 'IR_Temperature_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4698,7 +4698,7 @@ impl RtIrTempTempFl1 {
     pub fn ir_temperature_2(&self) -> f32 {
         self.ir_temperature_2_raw()
     }
-    /// Get raw value of IR_Temperature_2
+    /// Get raw value of 'IR_Temperature_2'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -4713,7 +4713,7 @@ impl RtIrTempTempFl1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_2
+    /// Set value of 'IR_Temperature_2'
     #[inline(always)]
     pub fn set_ir_temperature_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4728,7 +4728,7 @@ impl RtIrTempTempFl1 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// IR_Temperature_1
+    /// Get value of 'IR_Temperature_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4738,7 +4738,7 @@ impl RtIrTempTempFl1 {
     pub fn ir_temperature_1(&self) -> f32 {
         self.ir_temperature_1_raw()
     }
-    /// Get raw value of IR_Temperature_1
+    /// Get raw value of 'IR_Temperature_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -4753,7 +4753,7 @@ impl RtIrTempTempFl1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_1
+    /// Set value of 'IR_Temperature_1'
     #[inline(always)]
     pub fn set_ir_temperature_1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4831,7 +4831,7 @@ impl RtIrTempTemp32 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_32_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_32_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_32 from values
+    /// Construct new 'RT_IRTemp_Temp_32' from values
     pub fn new(ir_temperature_32: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_32(ir_temperature_32)?;
@@ -4841,7 +4841,7 @@ impl RtIrTempTemp32 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_32
+    /// Get value of 'IR_Temperature_32'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4851,7 +4851,7 @@ impl RtIrTempTemp32 {
     pub fn ir_temperature_32(&self) -> f32 {
         self.ir_temperature_32_raw()
     }
-    /// Get raw value of IR_Temperature_32
+    /// Get raw value of 'IR_Temperature_32'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -4866,7 +4866,7 @@ impl RtIrTempTemp32 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_32
+    /// Set value of 'IR_Temperature_32'
     #[inline(always)]
     pub fn set_ir_temperature_32(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -4944,7 +4944,7 @@ impl RtIrTempTemp31 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_31_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_31_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_31 from values
+    /// Construct new 'RT_IRTemp_Temp_31' from values
     pub fn new(ir_temperature_31: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_31(ir_temperature_31)?;
@@ -4954,7 +4954,7 @@ impl RtIrTempTemp31 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_31
+    /// Get value of 'IR_Temperature_31'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -4964,7 +4964,7 @@ impl RtIrTempTemp31 {
     pub fn ir_temperature_31(&self) -> f32 {
         self.ir_temperature_31_raw()
     }
-    /// Get raw value of IR_Temperature_31
+    /// Get raw value of 'IR_Temperature_31'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -4979,7 +4979,7 @@ impl RtIrTempTemp31 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_31
+    /// Set value of 'IR_Temperature_31'
     #[inline(always)]
     pub fn set_ir_temperature_31(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -5057,7 +5057,7 @@ impl RtIrTempTemp30 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_30_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_30_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_30 from values
+    /// Construct new 'RT_IRTemp_Temp_30' from values
     pub fn new(ir_temperature_30: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_30(ir_temperature_30)?;
@@ -5067,7 +5067,7 @@ impl RtIrTempTemp30 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_30
+    /// Get value of 'IR_Temperature_30'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -5077,7 +5077,7 @@ impl RtIrTempTemp30 {
     pub fn ir_temperature_30(&self) -> f32 {
         self.ir_temperature_30_raw()
     }
-    /// Get raw value of IR_Temperature_30
+    /// Get raw value of 'IR_Temperature_30'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -5092,7 +5092,7 @@ impl RtIrTempTemp30 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_30
+    /// Set value of 'IR_Temperature_30'
     #[inline(always)]
     pub fn set_ir_temperature_30(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -5170,7 +5170,7 @@ impl RtIrTempTemp29 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_29_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_29_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_29 from values
+    /// Construct new 'RT_IRTemp_Temp_29' from values
     pub fn new(ir_temperature_29: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_29(ir_temperature_29)?;
@@ -5180,7 +5180,7 @@ impl RtIrTempTemp29 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_29
+    /// Get value of 'IR_Temperature_29'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -5190,7 +5190,7 @@ impl RtIrTempTemp29 {
     pub fn ir_temperature_29(&self) -> f32 {
         self.ir_temperature_29_raw()
     }
-    /// Get raw value of IR_Temperature_29
+    /// Get raw value of 'IR_Temperature_29'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -5205,7 +5205,7 @@ impl RtIrTempTemp29 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_29
+    /// Set value of 'IR_Temperature_29'
     #[inline(always)]
     pub fn set_ir_temperature_29(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -5283,7 +5283,7 @@ impl RtIrTempTemp28 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_28_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_28_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_28 from values
+    /// Construct new 'RT_IRTemp_Temp_28' from values
     pub fn new(ir_temperature_28: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_28(ir_temperature_28)?;
@@ -5293,7 +5293,7 @@ impl RtIrTempTemp28 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_28
+    /// Get value of 'IR_Temperature_28'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -5303,7 +5303,7 @@ impl RtIrTempTemp28 {
     pub fn ir_temperature_28(&self) -> f32 {
         self.ir_temperature_28_raw()
     }
-    /// Get raw value of IR_Temperature_28
+    /// Get raw value of 'IR_Temperature_28'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -5318,7 +5318,7 @@ impl RtIrTempTemp28 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_28
+    /// Set value of 'IR_Temperature_28'
     #[inline(always)]
     pub fn set_ir_temperature_28(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -5396,7 +5396,7 @@ impl RtIrTempTemp27 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_27_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_27_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_27 from values
+    /// Construct new 'RT_IRTemp_Temp_27' from values
     pub fn new(ir_temperature_27: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_27(ir_temperature_27)?;
@@ -5406,7 +5406,7 @@ impl RtIrTempTemp27 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_27
+    /// Get value of 'IR_Temperature_27'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -5416,7 +5416,7 @@ impl RtIrTempTemp27 {
     pub fn ir_temperature_27(&self) -> f32 {
         self.ir_temperature_27_raw()
     }
-    /// Get raw value of IR_Temperature_27
+    /// Get raw value of 'IR_Temperature_27'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -5431,7 +5431,7 @@ impl RtIrTempTemp27 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_27
+    /// Set value of 'IR_Temperature_27'
     #[inline(always)]
     pub fn set_ir_temperature_27(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -5509,7 +5509,7 @@ impl RtIrTempTemp26 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_26_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_26_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_26 from values
+    /// Construct new 'RT_IRTemp_Temp_26' from values
     pub fn new(ir_temperature_26: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_26(ir_temperature_26)?;
@@ -5519,7 +5519,7 @@ impl RtIrTempTemp26 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_26
+    /// Get value of 'IR_Temperature_26'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -5529,7 +5529,7 @@ impl RtIrTempTemp26 {
     pub fn ir_temperature_26(&self) -> f32 {
         self.ir_temperature_26_raw()
     }
-    /// Get raw value of IR_Temperature_26
+    /// Get raw value of 'IR_Temperature_26'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -5544,7 +5544,7 @@ impl RtIrTempTemp26 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_26
+    /// Set value of 'IR_Temperature_26'
     #[inline(always)]
     pub fn set_ir_temperature_26(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -5622,7 +5622,7 @@ impl RtIrTempTemp25 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_25_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_25_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_25 from values
+    /// Construct new 'RT_IRTemp_Temp_25' from values
     pub fn new(ir_temperature_25: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_25(ir_temperature_25)?;
@@ -5632,7 +5632,7 @@ impl RtIrTempTemp25 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_25
+    /// Get value of 'IR_Temperature_25'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -5642,7 +5642,7 @@ impl RtIrTempTemp25 {
     pub fn ir_temperature_25(&self) -> f32 {
         self.ir_temperature_25_raw()
     }
-    /// Get raw value of IR_Temperature_25
+    /// Get raw value of 'IR_Temperature_25'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -5657,7 +5657,7 @@ impl RtIrTempTemp25 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_25
+    /// Set value of 'IR_Temperature_25'
     #[inline(always)]
     pub fn set_ir_temperature_25(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -5735,7 +5735,7 @@ impl RtIrTempTemp24 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_24_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_24_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_24 from values
+    /// Construct new 'RT_IRTemp_Temp_24' from values
     pub fn new(ir_temperature_24: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_24(ir_temperature_24)?;
@@ -5745,7 +5745,7 @@ impl RtIrTempTemp24 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_24
+    /// Get value of 'IR_Temperature_24'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -5755,7 +5755,7 @@ impl RtIrTempTemp24 {
     pub fn ir_temperature_24(&self) -> f32 {
         self.ir_temperature_24_raw()
     }
-    /// Get raw value of IR_Temperature_24
+    /// Get raw value of 'IR_Temperature_24'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -5770,7 +5770,7 @@ impl RtIrTempTemp24 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_24
+    /// Set value of 'IR_Temperature_24'
     #[inline(always)]
     pub fn set_ir_temperature_24(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -5848,7 +5848,7 @@ impl RtIrTempTemp22 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_22_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_22_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_22 from values
+    /// Construct new 'RT_IRTemp_Temp_22' from values
     pub fn new(ir_temperature_22: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_22(ir_temperature_22)?;
@@ -5858,7 +5858,7 @@ impl RtIrTempTemp22 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_22
+    /// Get value of 'IR_Temperature_22'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -5868,7 +5868,7 @@ impl RtIrTempTemp22 {
     pub fn ir_temperature_22(&self) -> f32 {
         self.ir_temperature_22_raw()
     }
-    /// Get raw value of IR_Temperature_22
+    /// Get raw value of 'IR_Temperature_22'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -5883,7 +5883,7 @@ impl RtIrTempTemp22 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_22
+    /// Set value of 'IR_Temperature_22'
     #[inline(always)]
     pub fn set_ir_temperature_22(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -5961,7 +5961,7 @@ impl RtIrTempTemp23 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_23_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_23_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_23 from values
+    /// Construct new 'RT_IRTemp_Temp_23' from values
     pub fn new(ir_temperature_23: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_23(ir_temperature_23)?;
@@ -5971,7 +5971,7 @@ impl RtIrTempTemp23 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_23
+    /// Get value of 'IR_Temperature_23'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -5981,7 +5981,7 @@ impl RtIrTempTemp23 {
     pub fn ir_temperature_23(&self) -> f32 {
         self.ir_temperature_23_raw()
     }
-    /// Get raw value of IR_Temperature_23
+    /// Get raw value of 'IR_Temperature_23'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -5996,7 +5996,7 @@ impl RtIrTempTemp23 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_23
+    /// Set value of 'IR_Temperature_23'
     #[inline(always)]
     pub fn set_ir_temperature_23(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -6074,7 +6074,7 @@ impl RtIrTempTemp21 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_21_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_21_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_21 from values
+    /// Construct new 'RT_IRTemp_Temp_21' from values
     pub fn new(ir_temperature_21: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_21(ir_temperature_21)?;
@@ -6084,7 +6084,7 @@ impl RtIrTempTemp21 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_21
+    /// Get value of 'IR_Temperature_21'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -6094,7 +6094,7 @@ impl RtIrTempTemp21 {
     pub fn ir_temperature_21(&self) -> f32 {
         self.ir_temperature_21_raw()
     }
-    /// Get raw value of IR_Temperature_21
+    /// Get raw value of 'IR_Temperature_21'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -6109,7 +6109,7 @@ impl RtIrTempTemp21 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_21
+    /// Set value of 'IR_Temperature_21'
     #[inline(always)]
     pub fn set_ir_temperature_21(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -6187,7 +6187,7 @@ impl RtIrTempTemp20 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_20_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_20_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_20 from values
+    /// Construct new 'RT_IRTemp_Temp_20' from values
     pub fn new(ir_temperature_20: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_20(ir_temperature_20)?;
@@ -6197,7 +6197,7 @@ impl RtIrTempTemp20 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_20
+    /// Get value of 'IR_Temperature_20'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -6207,7 +6207,7 @@ impl RtIrTempTemp20 {
     pub fn ir_temperature_20(&self) -> f32 {
         self.ir_temperature_20_raw()
     }
-    /// Get raw value of IR_Temperature_20
+    /// Get raw value of 'IR_Temperature_20'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -6222,7 +6222,7 @@ impl RtIrTempTemp20 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_20
+    /// Set value of 'IR_Temperature_20'
     #[inline(always)]
     pub fn set_ir_temperature_20(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -6300,7 +6300,7 @@ impl RtIrTempTemp19 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_19_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_19_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_19 from values
+    /// Construct new 'RT_IRTemp_Temp_19' from values
     pub fn new(ir_temperature_19: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_19(ir_temperature_19)?;
@@ -6310,7 +6310,7 @@ impl RtIrTempTemp19 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_19
+    /// Get value of 'IR_Temperature_19'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -6320,7 +6320,7 @@ impl RtIrTempTemp19 {
     pub fn ir_temperature_19(&self) -> f32 {
         self.ir_temperature_19_raw()
     }
-    /// Get raw value of IR_Temperature_19
+    /// Get raw value of 'IR_Temperature_19'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -6335,7 +6335,7 @@ impl RtIrTempTemp19 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_19
+    /// Set value of 'IR_Temperature_19'
     #[inline(always)]
     pub fn set_ir_temperature_19(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -6413,7 +6413,7 @@ impl RtIrTempTemp18 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_18_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_18_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_18 from values
+    /// Construct new 'RT_IRTemp_Temp_18' from values
     pub fn new(ir_temperature_18: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_18(ir_temperature_18)?;
@@ -6423,7 +6423,7 @@ impl RtIrTempTemp18 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_18
+    /// Get value of 'IR_Temperature_18'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -6433,7 +6433,7 @@ impl RtIrTempTemp18 {
     pub fn ir_temperature_18(&self) -> f32 {
         self.ir_temperature_18_raw()
     }
-    /// Get raw value of IR_Temperature_18
+    /// Get raw value of 'IR_Temperature_18'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -6448,7 +6448,7 @@ impl RtIrTempTemp18 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_18
+    /// Set value of 'IR_Temperature_18'
     #[inline(always)]
     pub fn set_ir_temperature_18(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -6526,7 +6526,7 @@ impl RtIrTempTemp16 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_16_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_16_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_16 from values
+    /// Construct new 'RT_IRTemp_Temp_16' from values
     pub fn new(ir_temperature_16: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_16(ir_temperature_16)?;
@@ -6536,7 +6536,7 @@ impl RtIrTempTemp16 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_16
+    /// Get value of 'IR_Temperature_16'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -6546,7 +6546,7 @@ impl RtIrTempTemp16 {
     pub fn ir_temperature_16(&self) -> f32 {
         self.ir_temperature_16_raw()
     }
-    /// Get raw value of IR_Temperature_16
+    /// Get raw value of 'IR_Temperature_16'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -6561,7 +6561,7 @@ impl RtIrTempTemp16 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_16
+    /// Set value of 'IR_Temperature_16'
     #[inline(always)]
     pub fn set_ir_temperature_16(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -6639,7 +6639,7 @@ impl RtIrTempTemp15 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_15_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_15_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_15 from values
+    /// Construct new 'RT_IRTemp_Temp_15' from values
     pub fn new(ir_temperature_15: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_15(ir_temperature_15)?;
@@ -6649,7 +6649,7 @@ impl RtIrTempTemp15 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_15
+    /// Get value of 'IR_Temperature_15'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -6659,7 +6659,7 @@ impl RtIrTempTemp15 {
     pub fn ir_temperature_15(&self) -> f32 {
         self.ir_temperature_15_raw()
     }
-    /// Get raw value of IR_Temperature_15
+    /// Get raw value of 'IR_Temperature_15'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -6674,7 +6674,7 @@ impl RtIrTempTemp15 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_15
+    /// Set value of 'IR_Temperature_15'
     #[inline(always)]
     pub fn set_ir_temperature_15(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -6752,7 +6752,7 @@ impl RtIrTempTemp14 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_14_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_14_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_14 from values
+    /// Construct new 'RT_IRTemp_Temp_14' from values
     pub fn new(ir_temperature_14: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_14(ir_temperature_14)?;
@@ -6762,7 +6762,7 @@ impl RtIrTempTemp14 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_14
+    /// Get value of 'IR_Temperature_14'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -6772,7 +6772,7 @@ impl RtIrTempTemp14 {
     pub fn ir_temperature_14(&self) -> f32 {
         self.ir_temperature_14_raw()
     }
-    /// Get raw value of IR_Temperature_14
+    /// Get raw value of 'IR_Temperature_14'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -6787,7 +6787,7 @@ impl RtIrTempTemp14 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_14
+    /// Set value of 'IR_Temperature_14'
     #[inline(always)]
     pub fn set_ir_temperature_14(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -6865,7 +6865,7 @@ impl RtIrTempTemp13 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_13_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_13_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_13 from values
+    /// Construct new 'RT_IRTemp_Temp_13' from values
     pub fn new(ir_temperature_13: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_13(ir_temperature_13)?;
@@ -6875,7 +6875,7 @@ impl RtIrTempTemp13 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_13
+    /// Get value of 'IR_Temperature_13'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -6885,7 +6885,7 @@ impl RtIrTempTemp13 {
     pub fn ir_temperature_13(&self) -> f32 {
         self.ir_temperature_13_raw()
     }
-    /// Get raw value of IR_Temperature_13
+    /// Get raw value of 'IR_Temperature_13'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -6900,7 +6900,7 @@ impl RtIrTempTemp13 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_13
+    /// Set value of 'IR_Temperature_13'
     #[inline(always)]
     pub fn set_ir_temperature_13(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -6978,7 +6978,7 @@ impl RtIrTempTemp12 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_12_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_12_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_12 from values
+    /// Construct new 'RT_IRTemp_Temp_12' from values
     pub fn new(ir_temperature_12: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_12(ir_temperature_12)?;
@@ -6988,7 +6988,7 @@ impl RtIrTempTemp12 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_12
+    /// Get value of 'IR_Temperature_12'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -6998,7 +6998,7 @@ impl RtIrTempTemp12 {
     pub fn ir_temperature_12(&self) -> f32 {
         self.ir_temperature_12_raw()
     }
-    /// Get raw value of IR_Temperature_12
+    /// Get raw value of 'IR_Temperature_12'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -7013,7 +7013,7 @@ impl RtIrTempTemp12 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_12
+    /// Set value of 'IR_Temperature_12'
     #[inline(always)]
     pub fn set_ir_temperature_12(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -7091,7 +7091,7 @@ impl RtIrTempTemp11 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_11_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_11_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_11 from values
+    /// Construct new 'RT_IRTemp_Temp_11' from values
     pub fn new(ir_temperature_11: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_11(ir_temperature_11)?;
@@ -7101,7 +7101,7 @@ impl RtIrTempTemp11 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_11
+    /// Get value of 'IR_Temperature_11'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -7111,7 +7111,7 @@ impl RtIrTempTemp11 {
     pub fn ir_temperature_11(&self) -> f32 {
         self.ir_temperature_11_raw()
     }
-    /// Get raw value of IR_Temperature_11
+    /// Get raw value of 'IR_Temperature_11'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -7126,7 +7126,7 @@ impl RtIrTempTemp11 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_11
+    /// Set value of 'IR_Temperature_11'
     #[inline(always)]
     pub fn set_ir_temperature_11(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -7204,7 +7204,7 @@ impl RtIrTempTemp10 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_10_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_10_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_10 from values
+    /// Construct new 'RT_IRTemp_Temp_10' from values
     pub fn new(ir_temperature_10: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_10(ir_temperature_10)?;
@@ -7214,7 +7214,7 @@ impl RtIrTempTemp10 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_10
+    /// Get value of 'IR_Temperature_10'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -7224,7 +7224,7 @@ impl RtIrTempTemp10 {
     pub fn ir_temperature_10(&self) -> f32 {
         self.ir_temperature_10_raw()
     }
-    /// Get raw value of IR_Temperature_10
+    /// Get raw value of 'IR_Temperature_10'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -7239,7 +7239,7 @@ impl RtIrTempTemp10 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_10
+    /// Set value of 'IR_Temperature_10'
     #[inline(always)]
     pub fn set_ir_temperature_10(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -7317,7 +7317,7 @@ impl RtIrTempTemp8 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_8_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_8_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_8 from values
+    /// Construct new 'RT_IRTemp_Temp_8' from values
     pub fn new(ir_temperature_8: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_8(ir_temperature_8)?;
@@ -7327,7 +7327,7 @@ impl RtIrTempTemp8 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_8
+    /// Get value of 'IR_Temperature_8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -7337,7 +7337,7 @@ impl RtIrTempTemp8 {
     pub fn ir_temperature_8(&self) -> f32 {
         self.ir_temperature_8_raw()
     }
-    /// Get raw value of IR_Temperature_8
+    /// Get raw value of 'IR_Temperature_8'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -7352,7 +7352,7 @@ impl RtIrTempTemp8 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_8
+    /// Set value of 'IR_Temperature_8'
     #[inline(always)]
     pub fn set_ir_temperature_8(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -7430,7 +7430,7 @@ impl RtIrTempTemp9 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_9_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_9_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_9 from values
+    /// Construct new 'RT_IRTemp_Temp_9' from values
     pub fn new(ir_temperature_9: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_9(ir_temperature_9)?;
@@ -7440,7 +7440,7 @@ impl RtIrTempTemp9 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_9
+    /// Get value of 'IR_Temperature_9'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -7450,7 +7450,7 @@ impl RtIrTempTemp9 {
     pub fn ir_temperature_9(&self) -> f32 {
         self.ir_temperature_9_raw()
     }
-    /// Get raw value of IR_Temperature_9
+    /// Get raw value of 'IR_Temperature_9'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -7465,7 +7465,7 @@ impl RtIrTempTemp9 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_9
+    /// Set value of 'IR_Temperature_9'
     #[inline(always)]
     pub fn set_ir_temperature_9(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -7543,7 +7543,7 @@ impl RtIrTempTemp17 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_17_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_17_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_17 from values
+    /// Construct new 'RT_IRTemp_Temp_17' from values
     pub fn new(ir_temperature_17: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_17(ir_temperature_17)?;
@@ -7553,7 +7553,7 @@ impl RtIrTempTemp17 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_17
+    /// Get value of 'IR_Temperature_17'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -7563,7 +7563,7 @@ impl RtIrTempTemp17 {
     pub fn ir_temperature_17(&self) -> f32 {
         self.ir_temperature_17_raw()
     }
-    /// Get raw value of IR_Temperature_17
+    /// Get raw value of 'IR_Temperature_17'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -7578,7 +7578,7 @@ impl RtIrTempTemp17 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_17
+    /// Set value of 'IR_Temperature_17'
     #[inline(always)]
     pub fn set_ir_temperature_17(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -7656,7 +7656,7 @@ impl RtIrTempTemp6 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_6_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_6_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_6 from values
+    /// Construct new 'RT_IRTemp_Temp_6' from values
     pub fn new(ir_temperature_6: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_6(ir_temperature_6)?;
@@ -7666,7 +7666,7 @@ impl RtIrTempTemp6 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_6
+    /// Get value of 'IR_Temperature_6'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -7676,7 +7676,7 @@ impl RtIrTempTemp6 {
     pub fn ir_temperature_6(&self) -> f32 {
         self.ir_temperature_6_raw()
     }
-    /// Get raw value of IR_Temperature_6
+    /// Get raw value of 'IR_Temperature_6'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -7691,7 +7691,7 @@ impl RtIrTempTemp6 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_6
+    /// Set value of 'IR_Temperature_6'
     #[inline(always)]
     pub fn set_ir_temperature_6(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -7769,7 +7769,7 @@ impl RtIrTempTemp5 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_5_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_5_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_5 from values
+    /// Construct new 'RT_IRTemp_Temp_5' from values
     pub fn new(ir_temperature_5: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_5(ir_temperature_5)?;
@@ -7779,7 +7779,7 @@ impl RtIrTempTemp5 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_5
+    /// Get value of 'IR_Temperature_5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -7789,7 +7789,7 @@ impl RtIrTempTemp5 {
     pub fn ir_temperature_5(&self) -> f32 {
         self.ir_temperature_5_raw()
     }
-    /// Get raw value of IR_Temperature_5
+    /// Get raw value of 'IR_Temperature_5'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -7804,7 +7804,7 @@ impl RtIrTempTemp5 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_5
+    /// Set value of 'IR_Temperature_5'
     #[inline(always)]
     pub fn set_ir_temperature_5(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -7882,7 +7882,7 @@ impl RtIrTempTemp4 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_4_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_4_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_4 from values
+    /// Construct new 'RT_IRTemp_Temp_4' from values
     pub fn new(ir_temperature_4: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_4(ir_temperature_4)?;
@@ -7892,7 +7892,7 @@ impl RtIrTempTemp4 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_4
+    /// Get value of 'IR_Temperature_4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -7902,7 +7902,7 @@ impl RtIrTempTemp4 {
     pub fn ir_temperature_4(&self) -> f32 {
         self.ir_temperature_4_raw()
     }
-    /// Get raw value of IR_Temperature_4
+    /// Get raw value of 'IR_Temperature_4'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -7917,7 +7917,7 @@ impl RtIrTempTemp4 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_4
+    /// Set value of 'IR_Temperature_4'
     #[inline(always)]
     pub fn set_ir_temperature_4(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -7995,7 +7995,7 @@ impl RtIrTempTemp3 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_3_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_3_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_3 from values
+    /// Construct new 'RT_IRTemp_Temp_3' from values
     pub fn new(ir_temperature_3: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_3(ir_temperature_3)?;
@@ -8005,7 +8005,7 @@ impl RtIrTempTemp3 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_3
+    /// Get value of 'IR_Temperature_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -8015,7 +8015,7 @@ impl RtIrTempTemp3 {
     pub fn ir_temperature_3(&self) -> f32 {
         self.ir_temperature_3_raw()
     }
-    /// Get raw value of IR_Temperature_3
+    /// Get raw value of 'IR_Temperature_3'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -8030,7 +8030,7 @@ impl RtIrTempTemp3 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_3
+    /// Set value of 'IR_Temperature_3'
     #[inline(always)]
     pub fn set_ir_temperature_3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -8108,7 +8108,7 @@ impl RtIrTempTemp2 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_2_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_2_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_2 from values
+    /// Construct new 'RT_IRTemp_Temp_2' from values
     pub fn new(ir_temperature_2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_2(ir_temperature_2)?;
@@ -8118,7 +8118,7 @@ impl RtIrTempTemp2 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_2
+    /// Get value of 'IR_Temperature_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -8128,7 +8128,7 @@ impl RtIrTempTemp2 {
     pub fn ir_temperature_2(&self) -> f32 {
         self.ir_temperature_2_raw()
     }
-    /// Get raw value of IR_Temperature_2
+    /// Get raw value of 'IR_Temperature_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -8143,7 +8143,7 @@ impl RtIrTempTemp2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_2
+    /// Set value of 'IR_Temperature_2'
     #[inline(always)]
     pub fn set_ir_temperature_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -8221,7 +8221,7 @@ impl RtIrTempTemp1 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const IR_TEMPERATURE_1_MIN: f32 = 0_f32;
     pub const IR_TEMPERATURE_1_MAX: f32 = 0_f32;
-    /// Construct new RT_IRTemp_Temp_1 from values
+    /// Construct new 'RT_IRTemp_Temp_1' from values
     pub fn new(ir_temperature_1: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_ir_temperature_1(ir_temperature_1)?;
@@ -8231,7 +8231,7 @@ impl RtIrTempTemp1 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// IR_Temperature_1
+    /// Get value of 'IR_Temperature_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -8241,7 +8241,7 @@ impl RtIrTempTemp1 {
     pub fn ir_temperature_1(&self) -> f32 {
         self.ir_temperature_1_raw()
     }
-    /// Get raw value of IR_Temperature_1
+    /// Get raw value of 'IR_Temperature_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -8256,7 +8256,7 @@ impl RtIrTempTemp1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of IR_Temperature_1
+    /// Set value of 'IR_Temperature_1'
     #[inline(always)]
     pub fn set_ir_temperature_1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -8334,7 +8334,7 @@ impl RtSbTrigFinalCondition {
     pub const MESSAGE_SIZE: usize = 8;
     pub const FINAL_SPEED_MIN: f32 = 0_f32;
     pub const FINAL_SPEED_MAX: f32 = 1675_f32;
-    /// Construct new RT_SB_Trig_Final_Condition from values
+    /// Construct new 'RT_SB_Trig_Final_Condition' from values
     pub fn new(final_speed: f32, validity_final_speed: bool) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_final_speed(final_speed)?;
@@ -8345,7 +8345,7 @@ impl RtSbTrigFinalCondition {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Final_Speed
+    /// Get value of 'Final_Speed'
     ///
     /// Speed at end of triggered test
     ///
@@ -8357,7 +8357,7 @@ impl RtSbTrigFinalCondition {
     pub fn final_speed(&self) -> f32 {
         self.final_speed_raw()
     }
-    /// Get raw value of Final_Speed
+    /// Get raw value of 'Final_Speed'
     ///
     /// - Start bit: 8
     /// - Signal size: 24 bits
@@ -8372,7 +8372,7 @@ impl RtSbTrigFinalCondition {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Final_Speed
+    /// Set value of 'Final_Speed'
     #[inline(always)]
     pub fn set_final_speed(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 1675_f32 < value {
@@ -8386,7 +8386,7 @@ impl RtSbTrigFinalCondition {
         self.raw.view_bits_mut::<Lsb0>()[8..32].store_le(value);
         Ok(())
     }
-    /// Validity_Final_Speed
+    /// Get value of 'Validity_Final_Speed'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -8398,7 +8398,7 @@ impl RtSbTrigFinalCondition {
     pub fn validity_final_speed(&self) -> bool {
         self.validity_final_speed_raw()
     }
-    /// Get raw value of Validity_Final_Speed
+    /// Get raw value of 'Validity_Final_Speed'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -8411,7 +8411,7 @@ impl RtSbTrigFinalCondition {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Final_Speed
+    /// Set value of 'Validity_Final_Speed'
     #[inline(always)]
     pub fn set_validity_final_speed(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -8487,7 +8487,7 @@ impl RtSbTrigInitialCondition {
     pub const INITIAL_HEADING_MAX: f32 = 180_f32;
     pub const INITIAL_SPEED_MIN: f32 = 0_f32;
     pub const INITIAL_SPEED_MAX: f32 = 1675_f32;
-    /// Construct new RT_SB_Trig_Initial_Condition from values
+    /// Construct new 'RT_SB_Trig_Initial_Condition' from values
     pub fn new(
         mfdd_end_threshold: u8,
         mfdd_start_threshold: u8,
@@ -8509,7 +8509,7 @@ impl RtSbTrigInitialCondition {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// MFDD_End_Threshold
+    /// Get value of 'MFDD_End_Threshold'
     ///
     /// - Min: 0
     /// - Max: 100
@@ -8519,7 +8519,7 @@ impl RtSbTrigInitialCondition {
     pub fn mfdd_end_threshold(&self) -> u8 {
         self.mfdd_end_threshold_raw()
     }
-    /// Get raw value of MFDD_End_Threshold
+    /// Get raw value of 'MFDD_End_Threshold'
     ///
     /// - Start bit: 56
     /// - Signal size: 8 bits
@@ -8533,7 +8533,7 @@ impl RtSbTrigInitialCondition {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MFDD_End_Threshold
+    /// Set value of 'MFDD_End_Threshold'
     #[inline(always)]
     pub fn set_mfdd_end_threshold(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 100_u8 < value {
@@ -8551,7 +8551,7 @@ impl RtSbTrigInitialCondition {
         self.raw.view_bits_mut::<Lsb0>()[56..64].store_le(value);
         Ok(())
     }
-    /// MFDD_Start_Threshold
+    /// Get value of 'MFDD_Start_Threshold'
     ///
     /// - Min: 0
     /// - Max: 100
@@ -8561,7 +8561,7 @@ impl RtSbTrigInitialCondition {
     pub fn mfdd_start_threshold(&self) -> u8 {
         self.mfdd_start_threshold_raw()
     }
-    /// Get raw value of MFDD_Start_Threshold
+    /// Get raw value of 'MFDD_Start_Threshold'
     ///
     /// - Start bit: 48
     /// - Signal size: 8 bits
@@ -8575,7 +8575,7 @@ impl RtSbTrigInitialCondition {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of MFDD_Start_Threshold
+    /// Set value of 'MFDD_Start_Threshold'
     #[inline(always)]
     pub fn set_mfdd_start_threshold(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 100_u8 < value {
@@ -8593,7 +8593,7 @@ impl RtSbTrigInitialCondition {
         self.raw.view_bits_mut::<Lsb0>()[48..56].store_le(value);
         Ok(())
     }
-    /// Initial_Heading
+    /// Get value of 'Initial_Heading'
     ///
     /// Heading (track) at start of triggered test
     ///
@@ -8605,7 +8605,7 @@ impl RtSbTrigInitialCondition {
     pub fn initial_heading(&self) -> f32 {
         self.initial_heading_raw()
     }
-    /// Get raw value of Initial_Heading
+    /// Get raw value of 'Initial_Heading'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -8620,7 +8620,7 @@ impl RtSbTrigInitialCondition {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Initial_Heading
+    /// Set value of 'Initial_Heading'
     #[inline(always)]
     pub fn set_initial_heading(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -8635,7 +8635,7 @@ impl RtSbTrigInitialCondition {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Initial_Speed
+    /// Get value of 'Initial_Speed'
     ///
     /// Speed at start of triggered test
     ///
@@ -8647,7 +8647,7 @@ impl RtSbTrigInitialCondition {
     pub fn initial_speed(&self) -> f32 {
         self.initial_speed_raw()
     }
-    /// Get raw value of Initial_Speed
+    /// Get raw value of 'Initial_Speed'
     ///
     /// - Start bit: 8
     /// - Signal size: 24 bits
@@ -8662,7 +8662,7 @@ impl RtSbTrigInitialCondition {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Initial_Speed
+    /// Set value of 'Initial_Speed'
     #[inline(always)]
     pub fn set_initial_speed(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 1675_f32 < value {
@@ -8676,7 +8676,7 @@ impl RtSbTrigInitialCondition {
         self.raw.view_bits_mut::<Lsb0>()[8..32].store_le(value);
         Ok(())
     }
-    /// Validity_Initial_Heading
+    /// Get value of 'Validity_Initial_Heading'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -8688,7 +8688,7 @@ impl RtSbTrigInitialCondition {
     pub fn validity_initial_heading(&self) -> bool {
         self.validity_initial_heading_raw()
     }
-    /// Get raw value of Validity_Initial_Heading
+    /// Get raw value of 'Validity_Initial_Heading'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -8701,14 +8701,14 @@ impl RtSbTrigInitialCondition {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Initial_Heading
+    /// Set value of 'Validity_Initial_Heading'
     #[inline(always)]
     pub fn set_validity_initial_heading(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_Initial_Speed
+    /// Get value of 'Validity_Initial_Speed'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -8720,7 +8720,7 @@ impl RtSbTrigInitialCondition {
     pub fn validity_initial_speed(&self) -> bool {
         self.validity_initial_speed_raw()
     }
-    /// Get raw value of Validity_Initial_Speed
+    /// Get raw value of 'Validity_Initial_Speed'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -8733,7 +8733,7 @@ impl RtSbTrigInitialCondition {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Initial_Speed
+    /// Set value of 'Validity_Initial_Speed'
     #[inline(always)]
     pub fn set_validity_initial_speed(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -8805,7 +8805,7 @@ impl RtSbTrigDirectDist {
     pub const PATH_DISTANCE_2D_MAX: f32 = 4294967_f32;
     pub const DIRECT_DISTANCE_MIN: f32 = 0_f32;
     pub const DIRECT_DISTANCE_MAX: f32 = 4294967_f32;
-    /// Construct new RT_SB_Trig_Direct_Dist from values
+    /// Construct new 'RT_SB_Trig_Direct_Dist' from values
     pub fn new(path_distance_2d: f32, direct_distance: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_path_distance_2d(path_distance_2d)?;
@@ -8816,7 +8816,7 @@ impl RtSbTrigDirectDist {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Path_Distance_2D
+    /// Get value of 'Path_Distance_2D'
     ///
     /// 2D path distance (horizontal components only)
     ///
@@ -8828,7 +8828,7 @@ impl RtSbTrigDirectDist {
     pub fn path_distance_2d(&self) -> f32 {
         self.path_distance_2d_raw()
     }
-    /// Get raw value of Path_Distance_2D
+    /// Get raw value of 'Path_Distance_2D'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -8843,7 +8843,7 @@ impl RtSbTrigDirectDist {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Path_Distance_2D
+    /// Set value of 'Path_Distance_2D'
     #[inline(always)]
     pub fn set_path_distance_2d(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 4294967_f32 < value {
@@ -8857,7 +8857,7 @@ impl RtSbTrigDirectDist {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Direct_Distance
+    /// Get value of 'Direct_Distance'
     ///
     /// Direct distance from start of test to current position
     ///
@@ -8869,7 +8869,7 @@ impl RtSbTrigDirectDist {
     pub fn direct_distance(&self) -> f32 {
         self.direct_distance_raw()
     }
-    /// Get raw value of Direct_Distance
+    /// Get raw value of 'Direct_Distance'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -8884,7 +8884,7 @@ impl RtSbTrigDirectDist {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Direct_Distance
+    /// Set value of 'Direct_Distance'
     #[inline(always)]
     pub fn set_direct_distance(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 4294967_f32 < value {
@@ -8963,7 +8963,7 @@ impl RtSbTrigForwardDist {
     pub const DEVIATION_DISTANCE_MAX: f32 = 2147483.647_f32;
     pub const FORWARD_DISTANCE_MIN: f32 = -2147483.648_f32;
     pub const FORWARD_DISTANCE_MAX: f32 = 2147483.647_f32;
-    /// Construct new RT_SB_Trig_Forward_Dist from values
+    /// Construct new 'RT_SB_Trig_Forward_Dist' from values
     pub fn new(
         deviation_distance: f32,
         forward_distance: f32,
@@ -8977,7 +8977,7 @@ impl RtSbTrigForwardDist {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Deviation_Distance
+    /// Get value of 'Deviation_Distance'
     ///
     /// Current deviation distance from a line projected along the initial heading at start of test, +ve for deviation to the right.
     ///
@@ -8989,7 +8989,7 @@ impl RtSbTrigForwardDist {
     pub fn deviation_distance(&self) -> f32 {
         self.deviation_distance_raw()
     }
-    /// Get raw value of Deviation_Distance
+    /// Get raw value of 'Deviation_Distance'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -9004,7 +9004,7 @@ impl RtSbTrigForwardDist {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Deviation_Distance
+    /// Set value of 'Deviation_Distance'
     #[inline(always)]
     pub fn set_deviation_distance(&mut self, value: f32) -> Result<(), CanError> {
         if value < -2147483.648_f32 || 2147483.647_f32 < value {
@@ -9019,7 +9019,7 @@ impl RtSbTrigForwardDist {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Forward_Distance
+    /// Get value of 'Forward_Distance'
     ///
     /// Current forward distance from start of test in direction of initial heading at start of test
     ///
@@ -9031,7 +9031,7 @@ impl RtSbTrigForwardDist {
     pub fn forward_distance(&self) -> f32 {
         self.forward_distance_raw()
     }
-    /// Get raw value of Forward_Distance
+    /// Get raw value of 'Forward_Distance'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -9046,7 +9046,7 @@ impl RtSbTrigForwardDist {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Forward_Distance
+    /// Set value of 'Forward_Distance'
     #[inline(always)]
     pub fn set_forward_distance(&mut self, value: f32) -> Result<(), CanError> {
         if value < -2147483.648_f32 || 2147483.647_f32 < value {
@@ -9124,7 +9124,7 @@ impl RtSbTrigPathDist {
     pub const MESSAGE_SIZE: usize = 8;
     pub const PATH_DISTANCE_3D_MIN: f32 = 0_f32;
     pub const PATH_DISTANCE_3D_MAX: f32 = 4294967_f32;
-    /// Construct new RT_SB_Trig_Path_Dist from values
+    /// Construct new 'RT_SB_Trig_Path_Dist' from values
     pub fn new(path_distance_3d: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_path_distance_3d(path_distance_3d)?;
@@ -9134,7 +9134,7 @@ impl RtSbTrigPathDist {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Path_Distance_3D
+    /// Get value of 'Path_Distance_3D'
     ///
     /// 3D path distance
     ///
@@ -9146,7 +9146,7 @@ impl RtSbTrigPathDist {
     pub fn path_distance_3d(&self) -> f32 {
         self.path_distance_3d_raw()
     }
-    /// Get raw value of Path_Distance_3D
+    /// Get raw value of 'Path_Distance_3D'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -9161,7 +9161,7 @@ impl RtSbTrigPathDist {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Path_Distance_3D
+    /// Set value of 'Path_Distance_3D'
     #[inline(always)]
     pub fn set_path_distance_3d(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 4294967_f32 < value {
@@ -9242,7 +9242,7 @@ impl RtSbTrigAccel {
     pub const AVERAGE_ACCEL_MAX: f32 = 65_f32;
     pub const MFDD_MIN: f32 = -65_f32;
     pub const MFDD_MAX: f32 = 65_f32;
-    /// Construct new RT_SB_Trig_Accel from values
+    /// Construct new 'RT_SB_Trig_Accel' from values
     pub fn new(
         triggered_time: f32,
         average_accel: f32,
@@ -9264,7 +9264,7 @@ impl RtSbTrigAccel {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Triggered_Time
+    /// Get value of 'Triggered_Time'
     ///
     /// Cumulative time from start of triggered test to current time.
     ///
@@ -9276,7 +9276,7 @@ impl RtSbTrigAccel {
     pub fn triggered_time(&self) -> f32 {
         self.triggered_time_raw()
     }
-    /// Get raw value of Triggered_Time
+    /// Get raw value of 'Triggered_Time'
     ///
     /// - Start bit: 40
     /// - Signal size: 24 bits
@@ -9291,7 +9291,7 @@ impl RtSbTrigAccel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Triggered_Time
+    /// Set value of 'Triggered_Time'
     #[inline(always)]
     pub fn set_triggered_time(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 167772_f32 < value {
@@ -9305,7 +9305,7 @@ impl RtSbTrigAccel {
         self.raw.view_bits_mut::<Lsb0>()[40..64].store_le(value);
         Ok(())
     }
-    /// Average_Accel
+    /// Get value of 'Average_Accel'
     ///
     /// Average acceleration from start of triggered test to current time.
     ///
@@ -9317,7 +9317,7 @@ impl RtSbTrigAccel {
     pub fn average_accel(&self) -> f32 {
         self.average_accel_raw()
     }
-    /// Get raw value of Average_Accel
+    /// Get raw value of 'Average_Accel'
     ///
     /// - Start bit: 24
     /// - Signal size: 16 bits
@@ -9332,7 +9332,7 @@ impl RtSbTrigAccel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Average_Accel
+    /// Set value of 'Average_Accel'
     #[inline(always)]
     pub fn set_average_accel(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -9347,7 +9347,7 @@ impl RtSbTrigAccel {
         self.raw.view_bits_mut::<Lsb0>()[24..40].store_le(value);
         Ok(())
     }
-    /// MFDD
+    /// Get value of 'MFDD'
     ///
     /// Mean fully-developed decelleration of triggered test.  Thresholds used are as set in the logger configuration.
     ///
@@ -9359,7 +9359,7 @@ impl RtSbTrigAccel {
     pub fn mfdd(&self) -> f32 {
         self.mfdd_raw()
     }
-    /// Get raw value of MFDD
+    /// Get raw value of 'MFDD'
     ///
     /// - Start bit: 8
     /// - Signal size: 16 bits
@@ -9374,7 +9374,7 @@ impl RtSbTrigAccel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of MFDD
+    /// Set value of 'MFDD'
     #[inline(always)]
     pub fn set_mfdd(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -9389,7 +9389,7 @@ impl RtSbTrigAccel {
         self.raw.view_bits_mut::<Lsb0>()[8..24].store_le(value);
         Ok(())
     }
-    /// Validity_Triggered_Time
+    /// Get value of 'Validity_Triggered_Time'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -9401,7 +9401,7 @@ impl RtSbTrigAccel {
     pub fn validity_triggered_time(&self) -> bool {
         self.validity_triggered_time_raw()
     }
-    /// Get raw value of Validity_Triggered_Time
+    /// Get raw value of 'Validity_Triggered_Time'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -9414,14 +9414,14 @@ impl RtSbTrigAccel {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Triggered_Time
+    /// Set value of 'Validity_Triggered_Time'
     #[inline(always)]
     pub fn set_validity_triggered_time(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_Average_Accel
+    /// Get value of 'Validity_Average_Accel'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -9433,7 +9433,7 @@ impl RtSbTrigAccel {
     pub fn validity_average_accel(&self) -> bool {
         self.validity_average_accel_raw()
     }
-    /// Get raw value of Validity_Average_Accel
+    /// Get raw value of 'Validity_Average_Accel'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -9446,14 +9446,14 @@ impl RtSbTrigAccel {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Average_Accel
+    /// Set value of 'Validity_Average_Accel'
     #[inline(always)]
     pub fn set_validity_average_accel(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_MFDD
+    /// Get value of 'Validity_MFDD'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -9465,7 +9465,7 @@ impl RtSbTrigAccel {
     pub fn validity_mfdd(&self) -> bool {
         self.validity_mfdd_raw()
     }
-    /// Get raw value of Validity_MFDD
+    /// Get raw value of 'Validity_MFDD'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -9478,7 +9478,7 @@ impl RtSbTrigAccel {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_MFDD
+    /// Set value of 'Validity_MFDD'
     #[inline(always)]
     pub fn set_validity_mfdd(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -9548,7 +9548,7 @@ impl RtDl1mk3MeasureTime12 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_12_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_12_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_12 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_12' from values
     pub fn new(measured_time_12: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_12(measured_time_12)?;
@@ -9558,7 +9558,7 @@ impl RtDl1mk3MeasureTime12 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_12
+    /// Get value of 'Measured_Time_12'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -9568,7 +9568,7 @@ impl RtDl1mk3MeasureTime12 {
     pub fn measured_time_12(&self) -> u32 {
         self.measured_time_12_raw()
     }
-    /// Get raw value of Measured_Time_12
+    /// Get raw value of 'Measured_Time_12'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -9582,7 +9582,7 @@ impl RtDl1mk3MeasureTime12 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_12
+    /// Set value of 'Measured_Time_12'
     #[inline(always)]
     pub fn set_measured_time_12(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -9663,7 +9663,7 @@ impl RtDl1mk3MeasureTime11 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_11_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_11_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_11 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_11' from values
     pub fn new(measured_time_11: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_11(measured_time_11)?;
@@ -9673,7 +9673,7 @@ impl RtDl1mk3MeasureTime11 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_11
+    /// Get value of 'Measured_Time_11'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -9683,7 +9683,7 @@ impl RtDl1mk3MeasureTime11 {
     pub fn measured_time_11(&self) -> u32 {
         self.measured_time_11_raw()
     }
-    /// Get raw value of Measured_Time_11
+    /// Get raw value of 'Measured_Time_11'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -9697,7 +9697,7 @@ impl RtDl1mk3MeasureTime11 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_11
+    /// Set value of 'Measured_Time_11'
     #[inline(always)]
     pub fn set_measured_time_11(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -9778,7 +9778,7 @@ impl RtDl1mk3MeasureTime10 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_10_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_10_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_10 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_10' from values
     pub fn new(measured_time_10: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_10(measured_time_10)?;
@@ -9788,7 +9788,7 @@ impl RtDl1mk3MeasureTime10 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_10
+    /// Get value of 'Measured_Time_10'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -9798,7 +9798,7 @@ impl RtDl1mk3MeasureTime10 {
     pub fn measured_time_10(&self) -> u32 {
         self.measured_time_10_raw()
     }
-    /// Get raw value of Measured_Time_10
+    /// Get raw value of 'Measured_Time_10'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -9812,7 +9812,7 @@ impl RtDl1mk3MeasureTime10 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_10
+    /// Set value of 'Measured_Time_10'
     #[inline(always)]
     pub fn set_measured_time_10(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -9893,7 +9893,7 @@ impl RtDl1mk3MeasureTime9 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_9_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_9_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_9 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_9' from values
     pub fn new(measured_time_9: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_9(measured_time_9)?;
@@ -9903,7 +9903,7 @@ impl RtDl1mk3MeasureTime9 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_9
+    /// Get value of 'Measured_Time_9'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -9913,7 +9913,7 @@ impl RtDl1mk3MeasureTime9 {
     pub fn measured_time_9(&self) -> u32 {
         self.measured_time_9_raw()
     }
-    /// Get raw value of Measured_Time_9
+    /// Get raw value of 'Measured_Time_9'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -9927,7 +9927,7 @@ impl RtDl1mk3MeasureTime9 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_9
+    /// Set value of 'Measured_Time_9'
     #[inline(always)]
     pub fn set_measured_time_9(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -10008,7 +10008,7 @@ impl RtDl1mk3MeasureTime8 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_8_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_8_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_8 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_8' from values
     pub fn new(measured_time_8: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_8(measured_time_8)?;
@@ -10018,7 +10018,7 @@ impl RtDl1mk3MeasureTime8 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_8
+    /// Get value of 'Measured_Time_8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -10028,7 +10028,7 @@ impl RtDl1mk3MeasureTime8 {
     pub fn measured_time_8(&self) -> u32 {
         self.measured_time_8_raw()
     }
-    /// Get raw value of Measured_Time_8
+    /// Get raw value of 'Measured_Time_8'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -10042,7 +10042,7 @@ impl RtDl1mk3MeasureTime8 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_8
+    /// Set value of 'Measured_Time_8'
     #[inline(always)]
     pub fn set_measured_time_8(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -10123,7 +10123,7 @@ impl RtDl1mk3MeasureTime7 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_7_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_7_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_7 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_7' from values
     pub fn new(measured_time_7: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_7(measured_time_7)?;
@@ -10133,7 +10133,7 @@ impl RtDl1mk3MeasureTime7 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_7
+    /// Get value of 'Measured_Time_7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -10143,7 +10143,7 @@ impl RtDl1mk3MeasureTime7 {
     pub fn measured_time_7(&self) -> u32 {
         self.measured_time_7_raw()
     }
-    /// Get raw value of Measured_Time_7
+    /// Get raw value of 'Measured_Time_7'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -10157,7 +10157,7 @@ impl RtDl1mk3MeasureTime7 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_7
+    /// Set value of 'Measured_Time_7'
     #[inline(always)]
     pub fn set_measured_time_7(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -10238,7 +10238,7 @@ impl RtDl1mk3MeasureTime6 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_6_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_6_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_6 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_6' from values
     pub fn new(measured_time_6: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_6(measured_time_6)?;
@@ -10248,7 +10248,7 @@ impl RtDl1mk3MeasureTime6 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_6
+    /// Get value of 'Measured_Time_6'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -10258,7 +10258,7 @@ impl RtDl1mk3MeasureTime6 {
     pub fn measured_time_6(&self) -> u32 {
         self.measured_time_6_raw()
     }
-    /// Get raw value of Measured_Time_6
+    /// Get raw value of 'Measured_Time_6'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -10272,7 +10272,7 @@ impl RtDl1mk3MeasureTime6 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_6
+    /// Set value of 'Measured_Time_6'
     #[inline(always)]
     pub fn set_measured_time_6(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -10353,7 +10353,7 @@ impl RtDl1mk3MeasureTime5 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_5_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_5_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_5 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_5' from values
     pub fn new(measured_time_5: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_5(measured_time_5)?;
@@ -10363,7 +10363,7 @@ impl RtDl1mk3MeasureTime5 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_5
+    /// Get value of 'Measured_Time_5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -10373,7 +10373,7 @@ impl RtDl1mk3MeasureTime5 {
     pub fn measured_time_5(&self) -> u32 {
         self.measured_time_5_raw()
     }
-    /// Get raw value of Measured_Time_5
+    /// Get raw value of 'Measured_Time_5'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -10387,7 +10387,7 @@ impl RtDl1mk3MeasureTime5 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_5
+    /// Set value of 'Measured_Time_5'
     #[inline(always)]
     pub fn set_measured_time_5(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -10468,7 +10468,7 @@ impl RtDl1mk3MeasureTime4 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_4_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_4_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_4 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_4' from values
     pub fn new(measured_time_4: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_4(measured_time_4)?;
@@ -10478,7 +10478,7 @@ impl RtDl1mk3MeasureTime4 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_4
+    /// Get value of 'Measured_Time_4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -10488,7 +10488,7 @@ impl RtDl1mk3MeasureTime4 {
     pub fn measured_time_4(&self) -> u32 {
         self.measured_time_4_raw()
     }
-    /// Get raw value of Measured_Time_4
+    /// Get raw value of 'Measured_Time_4'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -10502,7 +10502,7 @@ impl RtDl1mk3MeasureTime4 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_4
+    /// Set value of 'Measured_Time_4'
     #[inline(always)]
     pub fn set_measured_time_4(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -10583,7 +10583,7 @@ impl RtDl1mk3MeasureTime3 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_3_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_3_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_3 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_3' from values
     pub fn new(measured_time_3: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_3(measured_time_3)?;
@@ -10593,7 +10593,7 @@ impl RtDl1mk3MeasureTime3 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_3
+    /// Get value of 'Measured_Time_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -10603,7 +10603,7 @@ impl RtDl1mk3MeasureTime3 {
     pub fn measured_time_3(&self) -> u32 {
         self.measured_time_3_raw()
     }
-    /// Get raw value of Measured_Time_3
+    /// Get raw value of 'Measured_Time_3'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -10617,7 +10617,7 @@ impl RtDl1mk3MeasureTime3 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_3
+    /// Set value of 'Measured_Time_3'
     #[inline(always)]
     pub fn set_measured_time_3(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -10698,7 +10698,7 @@ impl RtDl1mk3MeasureTime2 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_2_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_2_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_2 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_2' from values
     pub fn new(measured_time_2: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_2(measured_time_2)?;
@@ -10708,7 +10708,7 @@ impl RtDl1mk3MeasureTime2 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_2
+    /// Get value of 'Measured_Time_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -10718,7 +10718,7 @@ impl RtDl1mk3MeasureTime2 {
     pub fn measured_time_2(&self) -> u32 {
         self.measured_time_2_raw()
     }
-    /// Get raw value of Measured_Time_2
+    /// Get raw value of 'Measured_Time_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -10732,7 +10732,7 @@ impl RtDl1mk3MeasureTime2 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_2
+    /// Set value of 'Measured_Time_2'
     #[inline(always)]
     pub fn set_measured_time_2(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -10813,7 +10813,7 @@ impl RtDl1mk3MeasureTime1 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const MEASURED_TIME_1_MIN: u32 = 0_u32;
     pub const MEASURED_TIME_1_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Measure_Time_1 from values
+    /// Construct new 'RT_DL1MK3_Measure_Time_1' from values
     pub fn new(measured_time_1: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_measured_time_1(measured_time_1)?;
@@ -10823,7 +10823,7 @@ impl RtDl1mk3MeasureTime1 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Measured_Time_1
+    /// Get value of 'Measured_Time_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -10833,7 +10833,7 @@ impl RtDl1mk3MeasureTime1 {
     pub fn measured_time_1(&self) -> u32 {
         self.measured_time_1_raw()
     }
-    /// Get raw value of Measured_Time_1
+    /// Get raw value of 'Measured_Time_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -10847,7 +10847,7 @@ impl RtDl1mk3MeasureTime1 {
         let factor = 1;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Measured_Time_1
+    /// Set value of 'Measured_Time_1'
     #[inline(always)]
     pub fn set_measured_time_1(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -10928,7 +10928,7 @@ impl RtDl1mk3Rpm {
     pub const MESSAGE_SIZE: usize = 2;
     pub const RPM_MIN: u16 = 0_u16;
     pub const RPM_MAX: u16 = 0_u16;
-    /// Construct new RT_DL1MK3_RPM from values
+    /// Construct new 'RT_DL1MK3_RPM' from values
     pub fn new(rpm: u16) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_rpm(rpm)?;
@@ -10938,7 +10938,7 @@ impl RtDl1mk3Rpm {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// RPM
+    /// Get value of 'RPM'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -10948,7 +10948,7 @@ impl RtDl1mk3Rpm {
     pub fn rpm(&self) -> u16 {
         self.rpm_raw()
     }
-    /// Get raw value of RPM
+    /// Get raw value of 'RPM'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -10962,7 +10962,7 @@ impl RtDl1mk3Rpm {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of RPM
+    /// Set value of 'RPM'
     #[inline(always)]
     pub fn set_rpm(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 0_u16 < value {
@@ -11043,7 +11043,7 @@ impl RtDl1mk3Freq4 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const FREQUENCY_4_MIN: f32 = 0_f32;
     pub const FREQUENCY_4_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Freq_4 from values
+    /// Construct new 'RT_DL1MK3_Freq_4' from values
     pub fn new(frequency_4: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_frequency_4(frequency_4)?;
@@ -11053,7 +11053,7 @@ impl RtDl1mk3Freq4 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Frequency_4
+    /// Get value of 'Frequency_4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -11063,7 +11063,7 @@ impl RtDl1mk3Freq4 {
     pub fn frequency_4(&self) -> f32 {
         self.frequency_4_raw()
     }
-    /// Get raw value of Frequency_4
+    /// Get raw value of 'Frequency_4'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -11078,7 +11078,7 @@ impl RtDl1mk3Freq4 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Frequency_4
+    /// Set value of 'Frequency_4'
     #[inline(always)]
     pub fn set_frequency_4(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -11155,7 +11155,7 @@ impl RtDl1mk3Freq3 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const FREQUENCY_3_MIN: f32 = 0_f32;
     pub const FREQUENCY_3_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Freq_3 from values
+    /// Construct new 'RT_DL1MK3_Freq_3' from values
     pub fn new(frequency_3: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_frequency_3(frequency_3)?;
@@ -11165,7 +11165,7 @@ impl RtDl1mk3Freq3 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Frequency_3
+    /// Get value of 'Frequency_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -11175,7 +11175,7 @@ impl RtDl1mk3Freq3 {
     pub fn frequency_3(&self) -> f32 {
         self.frequency_3_raw()
     }
-    /// Get raw value of Frequency_3
+    /// Get raw value of 'Frequency_3'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -11190,7 +11190,7 @@ impl RtDl1mk3Freq3 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Frequency_3
+    /// Set value of 'Frequency_3'
     #[inline(always)]
     pub fn set_frequency_3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -11267,7 +11267,7 @@ impl RtDl1mk3Freq2 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const FREQUENCY_2_MIN: f32 = 0_f32;
     pub const FREQUENCY_2_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Freq_2 from values
+    /// Construct new 'RT_DL1MK3_Freq_2' from values
     pub fn new(frequency_2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_frequency_2(frequency_2)?;
@@ -11277,7 +11277,7 @@ impl RtDl1mk3Freq2 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Frequency_2
+    /// Get value of 'Frequency_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -11287,7 +11287,7 @@ impl RtDl1mk3Freq2 {
     pub fn frequency_2(&self) -> f32 {
         self.frequency_2_raw()
     }
-    /// Get raw value of Frequency_2
+    /// Get raw value of 'Frequency_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -11302,7 +11302,7 @@ impl RtDl1mk3Freq2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Frequency_2
+    /// Set value of 'Frequency_2'
     #[inline(always)]
     pub fn set_frequency_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -11379,7 +11379,7 @@ impl RtDl1mk3Misc3 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const MISC_3_MIN: f32 = 0_f32;
     pub const MISC_3_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Misc_3 from values
+    /// Construct new 'RT_DL1MK3_Misc_3' from values
     pub fn new(misc_3: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_misc_3(misc_3)?;
@@ -11389,7 +11389,7 @@ impl RtDl1mk3Misc3 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Misc_3
+    /// Get value of 'Misc_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -11399,7 +11399,7 @@ impl RtDl1mk3Misc3 {
     pub fn misc_3(&self) -> f32 {
         self.misc_3_raw()
     }
-    /// Get raw value of Misc_3
+    /// Get raw value of 'Misc_3'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -11414,7 +11414,7 @@ impl RtDl1mk3Misc3 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Misc_3
+    /// Set value of 'Misc_3'
     #[inline(always)]
     pub fn set_misc_3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -11491,7 +11491,7 @@ impl RtDl1mk3Misc2 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const MISC_2_MIN: f32 = 0_f32;
     pub const MISC_2_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Misc_2 from values
+    /// Construct new 'RT_DL1MK3_Misc_2' from values
     pub fn new(misc_2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_misc_2(misc_2)?;
@@ -11501,7 +11501,7 @@ impl RtDl1mk3Misc2 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Misc_2
+    /// Get value of 'Misc_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -11511,7 +11511,7 @@ impl RtDl1mk3Misc2 {
     pub fn misc_2(&self) -> f32 {
         self.misc_2_raw()
     }
-    /// Get raw value of Misc_2
+    /// Get raw value of 'Misc_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -11526,7 +11526,7 @@ impl RtDl1mk3Misc2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Misc_2
+    /// Set value of 'Misc_2'
     #[inline(always)]
     pub fn set_misc_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -11603,7 +11603,7 @@ impl RtDl1mk3Misc1 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const MISC_1_MIN: f32 = 0_f32;
     pub const MISC_1_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Misc_1 from values
+    /// Construct new 'RT_DL1MK3_Misc_1' from values
     pub fn new(misc_1: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_misc_1(misc_1)?;
@@ -11613,7 +11613,7 @@ impl RtDl1mk3Misc1 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Misc_1
+    /// Get value of 'Misc_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -11623,7 +11623,7 @@ impl RtDl1mk3Misc1 {
     pub fn misc_1(&self) -> f32 {
         self.misc_1_raw()
     }
-    /// Get raw value of Misc_1
+    /// Get raw value of 'Misc_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -11638,7 +11638,7 @@ impl RtDl1mk3Misc1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Misc_1
+    /// Set value of 'Misc_1'
     #[inline(always)]
     pub fn set_misc_1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -11715,7 +11715,7 @@ impl RtDl1mk3Aux31 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_31_MIN: f32 = 0_f32;
     pub const AUX_31_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_31 from values
+    /// Construct new 'RT_DL1MK3_Aux_31' from values
     pub fn new(aux_31: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_31(aux_31)?;
@@ -11725,7 +11725,7 @@ impl RtDl1mk3Aux31 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_31
+    /// Get value of 'AUX_31'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -11735,7 +11735,7 @@ impl RtDl1mk3Aux31 {
     pub fn aux_31(&self) -> f32 {
         self.aux_31_raw()
     }
-    /// Get raw value of AUX_31
+    /// Get raw value of 'AUX_31'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -11750,7 +11750,7 @@ impl RtDl1mk3Aux31 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_31
+    /// Set value of 'AUX_31'
     #[inline(always)]
     pub fn set_aux_31(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -11827,7 +11827,7 @@ impl RtDl1mk3Aux30 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_30_MIN: f32 = 0_f32;
     pub const AUX_30_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_30 from values
+    /// Construct new 'RT_DL1MK3_Aux_30' from values
     pub fn new(aux_30: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_30(aux_30)?;
@@ -11837,7 +11837,7 @@ impl RtDl1mk3Aux30 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_30
+    /// Get value of 'AUX_30'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -11847,7 +11847,7 @@ impl RtDl1mk3Aux30 {
     pub fn aux_30(&self) -> f32 {
         self.aux_30_raw()
     }
-    /// Get raw value of AUX_30
+    /// Get raw value of 'AUX_30'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -11862,7 +11862,7 @@ impl RtDl1mk3Aux30 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_30
+    /// Set value of 'AUX_30'
     #[inline(always)]
     pub fn set_aux_30(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -11939,7 +11939,7 @@ impl RtDl1mk3Aux29 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_29_MIN: f32 = 0_f32;
     pub const AUX_29_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_29 from values
+    /// Construct new 'RT_DL1MK3_Aux_29' from values
     pub fn new(aux_29: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_29(aux_29)?;
@@ -11949,7 +11949,7 @@ impl RtDl1mk3Aux29 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_29
+    /// Get value of 'AUX_29'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -11959,7 +11959,7 @@ impl RtDl1mk3Aux29 {
     pub fn aux_29(&self) -> f32 {
         self.aux_29_raw()
     }
-    /// Get raw value of AUX_29
+    /// Get raw value of 'AUX_29'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -11974,7 +11974,7 @@ impl RtDl1mk3Aux29 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_29
+    /// Set value of 'AUX_29'
     #[inline(always)]
     pub fn set_aux_29(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -12051,7 +12051,7 @@ impl RtDl1mk3Aux28 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_28_MIN: f32 = 0_f32;
     pub const AUX_28_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_28 from values
+    /// Construct new 'RT_DL1MK3_Aux_28' from values
     pub fn new(aux_28: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_28(aux_28)?;
@@ -12061,7 +12061,7 @@ impl RtDl1mk3Aux28 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_28
+    /// Get value of 'AUX_28'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -12071,7 +12071,7 @@ impl RtDl1mk3Aux28 {
     pub fn aux_28(&self) -> f32 {
         self.aux_28_raw()
     }
-    /// Get raw value of AUX_28
+    /// Get raw value of 'AUX_28'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -12086,7 +12086,7 @@ impl RtDl1mk3Aux28 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_28
+    /// Set value of 'AUX_28'
     #[inline(always)]
     pub fn set_aux_28(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -12163,7 +12163,7 @@ impl RtDl1mk3Aux27 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_27_MIN: f32 = 0_f32;
     pub const AUX_27_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_27 from values
+    /// Construct new 'RT_DL1MK3_Aux_27' from values
     pub fn new(aux_27: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_27(aux_27)?;
@@ -12173,7 +12173,7 @@ impl RtDl1mk3Aux27 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_27
+    /// Get value of 'AUX_27'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -12183,7 +12183,7 @@ impl RtDl1mk3Aux27 {
     pub fn aux_27(&self) -> f32 {
         self.aux_27_raw()
     }
-    /// Get raw value of AUX_27
+    /// Get raw value of 'AUX_27'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -12198,7 +12198,7 @@ impl RtDl1mk3Aux27 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_27
+    /// Set value of 'AUX_27'
     #[inline(always)]
     pub fn set_aux_27(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -12275,7 +12275,7 @@ impl RtDl1mk3Aux26 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_26_MIN: f32 = 0_f32;
     pub const AUX_26_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_26 from values
+    /// Construct new 'RT_DL1MK3_Aux_26' from values
     pub fn new(aux_26: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_26(aux_26)?;
@@ -12285,7 +12285,7 @@ impl RtDl1mk3Aux26 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_26
+    /// Get value of 'AUX_26'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -12295,7 +12295,7 @@ impl RtDl1mk3Aux26 {
     pub fn aux_26(&self) -> f32 {
         self.aux_26_raw()
     }
-    /// Get raw value of AUX_26
+    /// Get raw value of 'AUX_26'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -12310,7 +12310,7 @@ impl RtDl1mk3Aux26 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_26
+    /// Set value of 'AUX_26'
     #[inline(always)]
     pub fn set_aux_26(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -12387,7 +12387,7 @@ impl RtDl1mk3Aux25 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_25_MIN: f32 = 0_f32;
     pub const AUX_25_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_25 from values
+    /// Construct new 'RT_DL1MK3_Aux_25' from values
     pub fn new(aux_25: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_25(aux_25)?;
@@ -12397,7 +12397,7 @@ impl RtDl1mk3Aux25 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_25
+    /// Get value of 'AUX_25'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -12407,7 +12407,7 @@ impl RtDl1mk3Aux25 {
     pub fn aux_25(&self) -> f32 {
         self.aux_25_raw()
     }
-    /// Get raw value of AUX_25
+    /// Get raw value of 'AUX_25'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -12422,7 +12422,7 @@ impl RtDl1mk3Aux25 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_25
+    /// Set value of 'AUX_25'
     #[inline(always)]
     pub fn set_aux_25(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -12499,7 +12499,7 @@ impl RtDl1mk3Aux24 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_24_MIN: f32 = 0_f32;
     pub const AUX_24_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_24 from values
+    /// Construct new 'RT_DL1MK3_Aux_24' from values
     pub fn new(aux_24: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_24(aux_24)?;
@@ -12509,7 +12509,7 @@ impl RtDl1mk3Aux24 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_24
+    /// Get value of 'AUX_24'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -12519,7 +12519,7 @@ impl RtDl1mk3Aux24 {
     pub fn aux_24(&self) -> f32 {
         self.aux_24_raw()
     }
-    /// Get raw value of AUX_24
+    /// Get raw value of 'AUX_24'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -12534,7 +12534,7 @@ impl RtDl1mk3Aux24 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_24
+    /// Set value of 'AUX_24'
     #[inline(always)]
     pub fn set_aux_24(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -12611,7 +12611,7 @@ impl RtDl1mk3Aux23 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_23_MIN: f32 = 0_f32;
     pub const AUX_23_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_23 from values
+    /// Construct new 'RT_DL1MK3_Aux_23' from values
     pub fn new(aux_23: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_23(aux_23)?;
@@ -12621,7 +12621,7 @@ impl RtDl1mk3Aux23 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_23
+    /// Get value of 'AUX_23'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -12631,7 +12631,7 @@ impl RtDl1mk3Aux23 {
     pub fn aux_23(&self) -> f32 {
         self.aux_23_raw()
     }
-    /// Get raw value of AUX_23
+    /// Get raw value of 'AUX_23'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -12646,7 +12646,7 @@ impl RtDl1mk3Aux23 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_23
+    /// Set value of 'AUX_23'
     #[inline(always)]
     pub fn set_aux_23(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -12723,7 +12723,7 @@ impl RtDl1mk3Aux22 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_22_MIN: u32 = 0_u32;
     pub const AUX_22_MAX: u32 = 0_u32;
-    /// Construct new RT_DL1MK3_Aux_22 from values
+    /// Construct new 'RT_DL1MK3_Aux_22' from values
     pub fn new(aux_22: u32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_22(aux_22)?;
@@ -12733,7 +12733,7 @@ impl RtDl1mk3Aux22 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_22
+    /// Get value of 'AUX_22'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -12743,7 +12743,7 @@ impl RtDl1mk3Aux22 {
     pub fn aux_22(&self) -> u32 {
         self.aux_22_raw()
     }
-    /// Get raw value of AUX_22
+    /// Get raw value of 'AUX_22'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -12757,7 +12757,7 @@ impl RtDl1mk3Aux22 {
         let factor = 10;
         u32::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of AUX_22
+    /// Set value of 'AUX_22'
     #[inline(always)]
     pub fn set_aux_22(&mut self, value: u32) -> Result<(), CanError> {
         if value < 0_u32 || 0_u32 < value {
@@ -12838,7 +12838,7 @@ impl RtDl1mk3Aux21 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_21_MIN: f32 = 0_f32;
     pub const AUX_21_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_21 from values
+    /// Construct new 'RT_DL1MK3_Aux_21' from values
     pub fn new(aux_21: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_21(aux_21)?;
@@ -12848,7 +12848,7 @@ impl RtDl1mk3Aux21 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_21
+    /// Get value of 'AUX_21'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -12858,7 +12858,7 @@ impl RtDl1mk3Aux21 {
     pub fn aux_21(&self) -> f32 {
         self.aux_21_raw()
     }
-    /// Get raw value of AUX_21
+    /// Get raw value of 'AUX_21'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -12873,7 +12873,7 @@ impl RtDl1mk3Aux21 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_21
+    /// Set value of 'AUX_21'
     #[inline(always)]
     pub fn set_aux_21(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -12950,7 +12950,7 @@ impl RtDl1mk3Aux20 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_20_MIN: f32 = 0_f32;
     pub const AUX_20_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_20 from values
+    /// Construct new 'RT_DL1MK3_Aux_20' from values
     pub fn new(aux_20: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_20(aux_20)?;
@@ -12960,7 +12960,7 @@ impl RtDl1mk3Aux20 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_20
+    /// Get value of 'AUX_20'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -12970,7 +12970,7 @@ impl RtDl1mk3Aux20 {
     pub fn aux_20(&self) -> f32 {
         self.aux_20_raw()
     }
-    /// Get raw value of AUX_20
+    /// Get raw value of 'AUX_20'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -12985,7 +12985,7 @@ impl RtDl1mk3Aux20 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_20
+    /// Set value of 'AUX_20'
     #[inline(always)]
     pub fn set_aux_20(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -13062,7 +13062,7 @@ impl RtDl1mk3Aux19 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_19_MIN: f32 = 0_f32;
     pub const AUX_19_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_19 from values
+    /// Construct new 'RT_DL1MK3_Aux_19' from values
     pub fn new(aux_19: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_19(aux_19)?;
@@ -13072,7 +13072,7 @@ impl RtDl1mk3Aux19 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_19
+    /// Get value of 'AUX_19'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -13082,7 +13082,7 @@ impl RtDl1mk3Aux19 {
     pub fn aux_19(&self) -> f32 {
         self.aux_19_raw()
     }
-    /// Get raw value of AUX_19
+    /// Get raw value of 'AUX_19'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -13097,7 +13097,7 @@ impl RtDl1mk3Aux19 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_19
+    /// Set value of 'AUX_19'
     #[inline(always)]
     pub fn set_aux_19(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -13174,7 +13174,7 @@ impl RtDl1mk3Aux18 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_18_MIN: f32 = 0_f32;
     pub const AUX_18_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_18 from values
+    /// Construct new 'RT_DL1MK3_Aux_18' from values
     pub fn new(aux_18: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_18(aux_18)?;
@@ -13184,7 +13184,7 @@ impl RtDl1mk3Aux18 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_18
+    /// Get value of 'AUX_18'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -13194,7 +13194,7 @@ impl RtDl1mk3Aux18 {
     pub fn aux_18(&self) -> f32 {
         self.aux_18_raw()
     }
-    /// Get raw value of AUX_18
+    /// Get raw value of 'AUX_18'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -13209,7 +13209,7 @@ impl RtDl1mk3Aux18 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_18
+    /// Set value of 'AUX_18'
     #[inline(always)]
     pub fn set_aux_18(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -13286,7 +13286,7 @@ impl RtDl1mk3Aux17 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_17_MIN: f32 = 0_f32;
     pub const AUX_17_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_17 from values
+    /// Construct new 'RT_DL1MK3_Aux_17' from values
     pub fn new(aux_17: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_17(aux_17)?;
@@ -13296,7 +13296,7 @@ impl RtDl1mk3Aux17 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_17
+    /// Get value of 'AUX_17'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -13306,7 +13306,7 @@ impl RtDl1mk3Aux17 {
     pub fn aux_17(&self) -> f32 {
         self.aux_17_raw()
     }
-    /// Get raw value of AUX_17
+    /// Get raw value of 'AUX_17'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -13321,7 +13321,7 @@ impl RtDl1mk3Aux17 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_17
+    /// Set value of 'AUX_17'
     #[inline(always)]
     pub fn set_aux_17(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -13398,7 +13398,7 @@ impl RtDl1mk3Aux16 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_16_MIN: f32 = 0_f32;
     pub const AUX_16_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_16 from values
+    /// Construct new 'RT_DL1MK3_Aux_16' from values
     pub fn new(aux_16: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_16(aux_16)?;
@@ -13408,7 +13408,7 @@ impl RtDl1mk3Aux16 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_16
+    /// Get value of 'AUX_16'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -13418,7 +13418,7 @@ impl RtDl1mk3Aux16 {
     pub fn aux_16(&self) -> f32 {
         self.aux_16_raw()
     }
-    /// Get raw value of AUX_16
+    /// Get raw value of 'AUX_16'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -13433,7 +13433,7 @@ impl RtDl1mk3Aux16 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_16
+    /// Set value of 'AUX_16'
     #[inline(always)]
     pub fn set_aux_16(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -13510,7 +13510,7 @@ impl RtDl1mk3Aux15 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_15_MIN: f32 = 0_f32;
     pub const AUX_15_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_15 from values
+    /// Construct new 'RT_DL1MK3_Aux_15' from values
     pub fn new(aux_15: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_15(aux_15)?;
@@ -13520,7 +13520,7 @@ impl RtDl1mk3Aux15 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_15
+    /// Get value of 'AUX_15'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -13530,7 +13530,7 @@ impl RtDl1mk3Aux15 {
     pub fn aux_15(&self) -> f32 {
         self.aux_15_raw()
     }
-    /// Get raw value of AUX_15
+    /// Get raw value of 'AUX_15'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -13545,7 +13545,7 @@ impl RtDl1mk3Aux15 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_15
+    /// Set value of 'AUX_15'
     #[inline(always)]
     pub fn set_aux_15(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -13622,7 +13622,7 @@ impl RtDl1mk3Aux14 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_14_MIN: f32 = 0_f32;
     pub const AUX_14_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_14 from values
+    /// Construct new 'RT_DL1MK3_Aux_14' from values
     pub fn new(aux_14: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_14(aux_14)?;
@@ -13632,7 +13632,7 @@ impl RtDl1mk3Aux14 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_14
+    /// Get value of 'AUX_14'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -13642,7 +13642,7 @@ impl RtDl1mk3Aux14 {
     pub fn aux_14(&self) -> f32 {
         self.aux_14_raw()
     }
-    /// Get raw value of AUX_14
+    /// Get raw value of 'AUX_14'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -13657,7 +13657,7 @@ impl RtDl1mk3Aux14 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_14
+    /// Set value of 'AUX_14'
     #[inline(always)]
     pub fn set_aux_14(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -13734,7 +13734,7 @@ impl RtDl1mk3Aux13 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_13_MIN: f32 = 0_f32;
     pub const AUX_13_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_13 from values
+    /// Construct new 'RT_DL1MK3_Aux_13' from values
     pub fn new(aux_13: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_13(aux_13)?;
@@ -13744,7 +13744,7 @@ impl RtDl1mk3Aux13 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_13
+    /// Get value of 'AUX_13'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -13754,7 +13754,7 @@ impl RtDl1mk3Aux13 {
     pub fn aux_13(&self) -> f32 {
         self.aux_13_raw()
     }
-    /// Get raw value of AUX_13
+    /// Get raw value of 'AUX_13'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -13769,7 +13769,7 @@ impl RtDl1mk3Aux13 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_13
+    /// Set value of 'AUX_13'
     #[inline(always)]
     pub fn set_aux_13(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -13846,7 +13846,7 @@ impl RtDl1mk3Aux12 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_12_MIN: f32 = 0_f32;
     pub const AUX_12_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_12 from values
+    /// Construct new 'RT_DL1MK3_Aux_12' from values
     pub fn new(aux_12: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_12(aux_12)?;
@@ -13856,7 +13856,7 @@ impl RtDl1mk3Aux12 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_12
+    /// Get value of 'AUX_12'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -13866,7 +13866,7 @@ impl RtDl1mk3Aux12 {
     pub fn aux_12(&self) -> f32 {
         self.aux_12_raw()
     }
-    /// Get raw value of AUX_12
+    /// Get raw value of 'AUX_12'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -13881,7 +13881,7 @@ impl RtDl1mk3Aux12 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_12
+    /// Set value of 'AUX_12'
     #[inline(always)]
     pub fn set_aux_12(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -13958,7 +13958,7 @@ impl RtDl1mk3Aux11 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_11_MIN: f32 = 0_f32;
     pub const AUX_11_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_11 from values
+    /// Construct new 'RT_DL1MK3_Aux_11' from values
     pub fn new(aux_11: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_11(aux_11)?;
@@ -13968,7 +13968,7 @@ impl RtDl1mk3Aux11 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_11
+    /// Get value of 'AUX_11'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -13978,7 +13978,7 @@ impl RtDl1mk3Aux11 {
     pub fn aux_11(&self) -> f32 {
         self.aux_11_raw()
     }
-    /// Get raw value of AUX_11
+    /// Get raw value of 'AUX_11'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -13993,7 +13993,7 @@ impl RtDl1mk3Aux11 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_11
+    /// Set value of 'AUX_11'
     #[inline(always)]
     pub fn set_aux_11(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -14070,7 +14070,7 @@ impl RtDl1mk3Aux9 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_9_MIN: f32 = 0_f32;
     pub const AUX_9_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_9 from values
+    /// Construct new 'RT_DL1MK3_Aux_9' from values
     pub fn new(aux_9: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_9(aux_9)?;
@@ -14080,7 +14080,7 @@ impl RtDl1mk3Aux9 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_9
+    /// Get value of 'AUX_9'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -14090,7 +14090,7 @@ impl RtDl1mk3Aux9 {
     pub fn aux_9(&self) -> f32 {
         self.aux_9_raw()
     }
-    /// Get raw value of AUX_9
+    /// Get raw value of 'AUX_9'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -14105,7 +14105,7 @@ impl RtDl1mk3Aux9 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_9
+    /// Set value of 'AUX_9'
     #[inline(always)]
     pub fn set_aux_9(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -14182,7 +14182,7 @@ impl RtDl1mk3Aux10 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_10_MIN: f32 = 0_f32;
     pub const AUX_10_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_10 from values
+    /// Construct new 'RT_DL1MK3_Aux_10' from values
     pub fn new(aux_10: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_10(aux_10)?;
@@ -14192,7 +14192,7 @@ impl RtDl1mk3Aux10 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_10
+    /// Get value of 'AUX_10'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -14202,7 +14202,7 @@ impl RtDl1mk3Aux10 {
     pub fn aux_10(&self) -> f32 {
         self.aux_10_raw()
     }
-    /// Get raw value of AUX_10
+    /// Get raw value of 'AUX_10'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -14217,7 +14217,7 @@ impl RtDl1mk3Aux10 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_10
+    /// Set value of 'AUX_10'
     #[inline(always)]
     pub fn set_aux_10(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -14294,7 +14294,7 @@ impl RtDl1mk3Aux8 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_8_MIN: f32 = 0_f32;
     pub const AUX_8_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_8 from values
+    /// Construct new 'RT_DL1MK3_Aux_8' from values
     pub fn new(aux_8: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_8(aux_8)?;
@@ -14304,7 +14304,7 @@ impl RtDl1mk3Aux8 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_8
+    /// Get value of 'AUX_8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -14314,7 +14314,7 @@ impl RtDl1mk3Aux8 {
     pub fn aux_8(&self) -> f32 {
         self.aux_8_raw()
     }
-    /// Get raw value of AUX_8
+    /// Get raw value of 'AUX_8'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -14329,7 +14329,7 @@ impl RtDl1mk3Aux8 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_8
+    /// Set value of 'AUX_8'
     #[inline(always)]
     pub fn set_aux_8(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -14406,7 +14406,7 @@ impl RtDl1mk3Aux7 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_7_MIN: f32 = 0_f32;
     pub const AUX_7_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_7 from values
+    /// Construct new 'RT_DL1MK3_Aux_7' from values
     pub fn new(aux_7: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_7(aux_7)?;
@@ -14416,7 +14416,7 @@ impl RtDl1mk3Aux7 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_7
+    /// Get value of 'AUX_7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -14426,7 +14426,7 @@ impl RtDl1mk3Aux7 {
     pub fn aux_7(&self) -> f32 {
         self.aux_7_raw()
     }
-    /// Get raw value of AUX_7
+    /// Get raw value of 'AUX_7'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -14441,7 +14441,7 @@ impl RtDl1mk3Aux7 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_7
+    /// Set value of 'AUX_7'
     #[inline(always)]
     pub fn set_aux_7(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -14518,7 +14518,7 @@ impl RtDl1mk3Aux6 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_6_MIN: f32 = 0_f32;
     pub const AUX_6_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_6 from values
+    /// Construct new 'RT_DL1MK3_Aux_6' from values
     pub fn new(aux_6: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_6(aux_6)?;
@@ -14528,7 +14528,7 @@ impl RtDl1mk3Aux6 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_6
+    /// Get value of 'AUX_6'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -14538,7 +14538,7 @@ impl RtDl1mk3Aux6 {
     pub fn aux_6(&self) -> f32 {
         self.aux_6_raw()
     }
-    /// Get raw value of AUX_6
+    /// Get raw value of 'AUX_6'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -14553,7 +14553,7 @@ impl RtDl1mk3Aux6 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_6
+    /// Set value of 'AUX_6'
     #[inline(always)]
     pub fn set_aux_6(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -14630,7 +14630,7 @@ impl RtDl1mk3Aux5 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_5_MIN: f32 = 0_f32;
     pub const AUX_5_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_5 from values
+    /// Construct new 'RT_DL1MK3_Aux_5' from values
     pub fn new(aux_5: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_5(aux_5)?;
@@ -14640,7 +14640,7 @@ impl RtDl1mk3Aux5 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_5
+    /// Get value of 'AUX_5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -14650,7 +14650,7 @@ impl RtDl1mk3Aux5 {
     pub fn aux_5(&self) -> f32 {
         self.aux_5_raw()
     }
-    /// Get raw value of AUX_5
+    /// Get raw value of 'AUX_5'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -14665,7 +14665,7 @@ impl RtDl1mk3Aux5 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_5
+    /// Set value of 'AUX_5'
     #[inline(always)]
     pub fn set_aux_5(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -14742,7 +14742,7 @@ impl RtDl1mk3Aux4 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_4_MIN: f32 = 0_f32;
     pub const AUX_4_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_4 from values
+    /// Construct new 'RT_DL1MK3_Aux_4' from values
     pub fn new(aux_4: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_4(aux_4)?;
@@ -14752,7 +14752,7 @@ impl RtDl1mk3Aux4 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_4
+    /// Get value of 'AUX_4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -14762,7 +14762,7 @@ impl RtDl1mk3Aux4 {
     pub fn aux_4(&self) -> f32 {
         self.aux_4_raw()
     }
-    /// Get raw value of AUX_4
+    /// Get raw value of 'AUX_4'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -14777,7 +14777,7 @@ impl RtDl1mk3Aux4 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_4
+    /// Set value of 'AUX_4'
     #[inline(always)]
     pub fn set_aux_4(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -14854,7 +14854,7 @@ impl RtDl1mk3Aux3 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_3_MIN: f32 = 0_f32;
     pub const AUX_3_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_3 from values
+    /// Construct new 'RT_DL1MK3_Aux_3' from values
     pub fn new(aux_3: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_3(aux_3)?;
@@ -14864,7 +14864,7 @@ impl RtDl1mk3Aux3 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_3
+    /// Get value of 'AUX_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -14874,7 +14874,7 @@ impl RtDl1mk3Aux3 {
     pub fn aux_3(&self) -> f32 {
         self.aux_3_raw()
     }
-    /// Get raw value of AUX_3
+    /// Get raw value of 'AUX_3'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -14889,7 +14889,7 @@ impl RtDl1mk3Aux3 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_3
+    /// Set value of 'AUX_3'
     #[inline(always)]
     pub fn set_aux_3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -14966,7 +14966,7 @@ impl RtDl1mk3Aux2 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_2_MIN: f32 = 0_f32;
     pub const AUX_2_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_2 from values
+    /// Construct new 'RT_DL1MK3_Aux_2' from values
     pub fn new(aux_2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_2(aux_2)?;
@@ -14976,7 +14976,7 @@ impl RtDl1mk3Aux2 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_2
+    /// Get value of 'AUX_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -14986,7 +14986,7 @@ impl RtDl1mk3Aux2 {
     pub fn aux_2(&self) -> f32 {
         self.aux_2_raw()
     }
-    /// Get raw value of AUX_2
+    /// Get raw value of 'AUX_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -15001,7 +15001,7 @@ impl RtDl1mk3Aux2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_2
+    /// Set value of 'AUX_2'
     #[inline(always)]
     pub fn set_aux_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -15078,7 +15078,7 @@ impl RtDl1mk3Aux1 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const AUX_1_MIN: f32 = 0_f32;
     pub const AUX_1_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Aux_1 from values
+    /// Construct new 'RT_DL1MK3_Aux_1' from values
     pub fn new(aux_1: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_aux_1(aux_1)?;
@@ -15088,7 +15088,7 @@ impl RtDl1mk3Aux1 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// AUX_1
+    /// Get value of 'AUX_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -15098,7 +15098,7 @@ impl RtDl1mk3Aux1 {
     pub fn aux_1(&self) -> f32 {
         self.aux_1_raw()
     }
-    /// Get raw value of AUX_1
+    /// Get raw value of 'AUX_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -15113,7 +15113,7 @@ impl RtDl1mk3Aux1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of AUX_1
+    /// Set value of 'AUX_1'
     #[inline(always)]
     pub fn set_aux_1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -15190,7 +15190,7 @@ impl RtDl1mk3Pressure5 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_5_MIN: f32 = 0_f32;
     pub const PRESSURE_5_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Pressure_5 from values
+    /// Construct new 'RT_DL1MK3_Pressure_5' from values
     pub fn new(pressure_5: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_pressure_5(pressure_5)?;
@@ -15200,7 +15200,7 @@ impl RtDl1mk3Pressure5 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Pressure_5
+    /// Get value of 'Pressure_5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -15210,7 +15210,7 @@ impl RtDl1mk3Pressure5 {
     pub fn pressure_5(&self) -> f32 {
         self.pressure_5_raw()
     }
-    /// Get raw value of Pressure_5
+    /// Get raw value of 'Pressure_5'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -15225,7 +15225,7 @@ impl RtDl1mk3Pressure5 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Pressure_5
+    /// Set value of 'Pressure_5'
     #[inline(always)]
     pub fn set_pressure_5(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -15302,7 +15302,7 @@ impl RtDl1mk3Pressure4 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_4_MIN: f32 = 0_f32;
     pub const PRESSURE_4_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Pressure_4 from values
+    /// Construct new 'RT_DL1MK3_Pressure_4' from values
     pub fn new(pressure_4: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_pressure_4(pressure_4)?;
@@ -15312,7 +15312,7 @@ impl RtDl1mk3Pressure4 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Pressure_4
+    /// Get value of 'Pressure_4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -15322,7 +15322,7 @@ impl RtDl1mk3Pressure4 {
     pub fn pressure_4(&self) -> f32 {
         self.pressure_4_raw()
     }
-    /// Get raw value of Pressure_4
+    /// Get raw value of 'Pressure_4'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -15337,7 +15337,7 @@ impl RtDl1mk3Pressure4 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Pressure_4
+    /// Set value of 'Pressure_4'
     #[inline(always)]
     pub fn set_pressure_4(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -15414,7 +15414,7 @@ impl RtDl1mk3Pressure3 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_3_MIN: f32 = 0_f32;
     pub const PRESSURE_3_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Pressure_3 from values
+    /// Construct new 'RT_DL1MK3_Pressure_3' from values
     pub fn new(pressure_3: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_pressure_3(pressure_3)?;
@@ -15424,7 +15424,7 @@ impl RtDl1mk3Pressure3 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Pressure_3
+    /// Get value of 'Pressure_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -15434,7 +15434,7 @@ impl RtDl1mk3Pressure3 {
     pub fn pressure_3(&self) -> f32 {
         self.pressure_3_raw()
     }
-    /// Get raw value of Pressure_3
+    /// Get raw value of 'Pressure_3'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -15449,7 +15449,7 @@ impl RtDl1mk3Pressure3 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Pressure_3
+    /// Set value of 'Pressure_3'
     #[inline(always)]
     pub fn set_pressure_3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -15526,7 +15526,7 @@ impl RtDl1mk3Pressure2 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_2_MIN: f32 = 0_f32;
     pub const PRESSURE_2_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Pressure_2 from values
+    /// Construct new 'RT_DL1MK3_Pressure_2' from values
     pub fn new(pressure_2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_pressure_2(pressure_2)?;
@@ -15536,7 +15536,7 @@ impl RtDl1mk3Pressure2 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Pressure_2
+    /// Get value of 'Pressure_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -15546,7 +15546,7 @@ impl RtDl1mk3Pressure2 {
     pub fn pressure_2(&self) -> f32 {
         self.pressure_2_raw()
     }
-    /// Get raw value of Pressure_2
+    /// Get raw value of 'Pressure_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -15561,7 +15561,7 @@ impl RtDl1mk3Pressure2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Pressure_2
+    /// Set value of 'Pressure_2'
     #[inline(always)]
     pub fn set_pressure_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -15638,7 +15638,7 @@ impl RtDl1mk3Pressure1 {
     pub const MESSAGE_SIZE: usize = 3;
     pub const PRESSURE_1_MIN: f32 = 0_f32;
     pub const PRESSURE_1_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Pressure_1 from values
+    /// Construct new 'RT_DL1MK3_Pressure_1' from values
     pub fn new(pressure_1: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 3] };
         res.set_pressure_1(pressure_1)?;
@@ -15648,7 +15648,7 @@ impl RtDl1mk3Pressure1 {
     pub fn raw(&self) -> &[u8; 3] {
         &self.raw
     }
-    /// Pressure_1
+    /// Get value of 'Pressure_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -15658,7 +15658,7 @@ impl RtDl1mk3Pressure1 {
     pub fn pressure_1(&self) -> f32 {
         self.pressure_1_raw()
     }
-    /// Get raw value of Pressure_1
+    /// Get raw value of 'Pressure_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -15673,7 +15673,7 @@ impl RtDl1mk3Pressure1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Pressure_1
+    /// Set value of 'Pressure_1'
     #[inline(always)]
     pub fn set_pressure_1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -15750,7 +15750,7 @@ impl RtDl1mk3Angle3 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANGLE_3_MIN: f32 = 0_f32;
     pub const ANGLE_3_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Angle_3 from values
+    /// Construct new 'RT_DL1MK3_Angle_3' from values
     pub fn new(angle_3: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_angle_3(angle_3)?;
@@ -15760,7 +15760,7 @@ impl RtDl1mk3Angle3 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Angle_3
+    /// Get value of 'Angle_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -15770,7 +15770,7 @@ impl RtDl1mk3Angle3 {
     pub fn angle_3(&self) -> f32 {
         self.angle_3_raw()
     }
-    /// Get raw value of Angle_3
+    /// Get raw value of 'Angle_3'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -15785,7 +15785,7 @@ impl RtDl1mk3Angle3 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Angle_3
+    /// Set value of 'Angle_3'
     #[inline(always)]
     pub fn set_angle_3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -15863,7 +15863,7 @@ impl RtDl1mk3Angle2 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANGLE_2_MIN: f32 = 0_f32;
     pub const ANGLE_2_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Angle_2 from values
+    /// Construct new 'RT_DL1MK3_Angle_2' from values
     pub fn new(angle_2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_angle_2(angle_2)?;
@@ -15873,7 +15873,7 @@ impl RtDl1mk3Angle2 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Angle_2
+    /// Get value of 'Angle_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -15883,7 +15883,7 @@ impl RtDl1mk3Angle2 {
     pub fn angle_2(&self) -> f32 {
         self.angle_2_raw()
     }
-    /// Get raw value of Angle_2
+    /// Get raw value of 'Angle_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -15898,7 +15898,7 @@ impl RtDl1mk3Angle2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Angle_2
+    /// Set value of 'Angle_2'
     #[inline(always)]
     pub fn set_angle_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -15976,7 +15976,7 @@ impl RtDl1mk3Angle1 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANGLE_1_MIN: f32 = 0_f32;
     pub const ANGLE_1_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Angle_1 from values
+    /// Construct new 'RT_DL1MK3_Angle_1' from values
     pub fn new(angle_1: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_angle_1(angle_1)?;
@@ -15986,7 +15986,7 @@ impl RtDl1mk3Angle1 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Angle_1
+    /// Get value of 'Angle_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -15996,7 +15996,7 @@ impl RtDl1mk3Angle1 {
     pub fn angle_1(&self) -> f32 {
         self.angle_1_raw()
     }
-    /// Get raw value of Angle_1
+    /// Get raw value of 'Angle_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -16011,7 +16011,7 @@ impl RtDl1mk3Angle1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Angle_1
+    /// Set value of 'Angle_1'
     #[inline(always)]
     pub fn set_angle_1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -16089,7 +16089,7 @@ impl RtDl1mk3Temp25 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_25_MIN: f32 = 0_f32;
     pub const TEMPERATURE_25_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_25 from values
+    /// Construct new 'RT_DL1MK3_Temp_25' from values
     pub fn new(temperature_25: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_25(temperature_25)?;
@@ -16099,7 +16099,7 @@ impl RtDl1mk3Temp25 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_25
+    /// Get value of 'Temperature_25'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -16109,7 +16109,7 @@ impl RtDl1mk3Temp25 {
     pub fn temperature_25(&self) -> f32 {
         self.temperature_25_raw()
     }
-    /// Get raw value of Temperature_25
+    /// Get raw value of 'Temperature_25'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -16124,7 +16124,7 @@ impl RtDl1mk3Temp25 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_25
+    /// Set value of 'Temperature_25'
     #[inline(always)]
     pub fn set_temperature_25(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -16202,7 +16202,7 @@ impl RtDl1mk3Temp24 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_24_MIN: f32 = 0_f32;
     pub const TEMPERATURE_24_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_24 from values
+    /// Construct new 'RT_DL1MK3_Temp_24' from values
     pub fn new(temperature_24: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_24(temperature_24)?;
@@ -16212,7 +16212,7 @@ impl RtDl1mk3Temp24 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_24
+    /// Get value of 'Temperature_24'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -16222,7 +16222,7 @@ impl RtDl1mk3Temp24 {
     pub fn temperature_24(&self) -> f32 {
         self.temperature_24_raw()
     }
-    /// Get raw value of Temperature_24
+    /// Get raw value of 'Temperature_24'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -16237,7 +16237,7 @@ impl RtDl1mk3Temp24 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_24
+    /// Set value of 'Temperature_24'
     #[inline(always)]
     pub fn set_temperature_24(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -16315,7 +16315,7 @@ impl RtDl1mk3Temp23 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_23_MIN: f32 = 0_f32;
     pub const TEMPERATURE_23_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_23 from values
+    /// Construct new 'RT_DL1MK3_Temp_23' from values
     pub fn new(temperature_23: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_23(temperature_23)?;
@@ -16325,7 +16325,7 @@ impl RtDl1mk3Temp23 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_23
+    /// Get value of 'Temperature_23'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -16335,7 +16335,7 @@ impl RtDl1mk3Temp23 {
     pub fn temperature_23(&self) -> f32 {
         self.temperature_23_raw()
     }
-    /// Get raw value of Temperature_23
+    /// Get raw value of 'Temperature_23'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -16350,7 +16350,7 @@ impl RtDl1mk3Temp23 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_23
+    /// Set value of 'Temperature_23'
     #[inline(always)]
     pub fn set_temperature_23(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -16428,7 +16428,7 @@ impl RtDl1mk3Temp22 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_22_MIN: f32 = 0_f32;
     pub const TEMPERATURE_22_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_22 from values
+    /// Construct new 'RT_DL1MK3_Temp_22' from values
     pub fn new(temperature_22: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_22(temperature_22)?;
@@ -16438,7 +16438,7 @@ impl RtDl1mk3Temp22 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_22
+    /// Get value of 'Temperature_22'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -16448,7 +16448,7 @@ impl RtDl1mk3Temp22 {
     pub fn temperature_22(&self) -> f32 {
         self.temperature_22_raw()
     }
-    /// Get raw value of Temperature_22
+    /// Get raw value of 'Temperature_22'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -16463,7 +16463,7 @@ impl RtDl1mk3Temp22 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_22
+    /// Set value of 'Temperature_22'
     #[inline(always)]
     pub fn set_temperature_22(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -16541,7 +16541,7 @@ impl RtDl1mk3Temp21 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_21_MIN: f32 = 0_f32;
     pub const TEMPERATURE_21_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_21 from values
+    /// Construct new 'RT_DL1MK3_Temp_21' from values
     pub fn new(temperature_21: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_21(temperature_21)?;
@@ -16551,7 +16551,7 @@ impl RtDl1mk3Temp21 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_21
+    /// Get value of 'Temperature_21'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -16561,7 +16561,7 @@ impl RtDl1mk3Temp21 {
     pub fn temperature_21(&self) -> f32 {
         self.temperature_21_raw()
     }
-    /// Get raw value of Temperature_21
+    /// Get raw value of 'Temperature_21'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -16576,7 +16576,7 @@ impl RtDl1mk3Temp21 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_21
+    /// Set value of 'Temperature_21'
     #[inline(always)]
     pub fn set_temperature_21(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -16654,7 +16654,7 @@ impl RtDl1mk3Temp20 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_20_MIN: f32 = 0_f32;
     pub const TEMPERATURE_20_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_20 from values
+    /// Construct new 'RT_DL1MK3_Temp_20' from values
     pub fn new(temperature_20: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_20(temperature_20)?;
@@ -16664,7 +16664,7 @@ impl RtDl1mk3Temp20 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_20
+    /// Get value of 'Temperature_20'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -16674,7 +16674,7 @@ impl RtDl1mk3Temp20 {
     pub fn temperature_20(&self) -> f32 {
         self.temperature_20_raw()
     }
-    /// Get raw value of Temperature_20
+    /// Get raw value of 'Temperature_20'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -16689,7 +16689,7 @@ impl RtDl1mk3Temp20 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_20
+    /// Set value of 'Temperature_20'
     #[inline(always)]
     pub fn set_temperature_20(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -16767,7 +16767,7 @@ impl RtDl1mk3Temp19 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_19_MIN: f32 = 0_f32;
     pub const TEMPERATURE_19_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_19 from values
+    /// Construct new 'RT_DL1MK3_Temp_19' from values
     pub fn new(temperature_19: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_19(temperature_19)?;
@@ -16777,7 +16777,7 @@ impl RtDl1mk3Temp19 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_19
+    /// Get value of 'Temperature_19'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -16787,7 +16787,7 @@ impl RtDl1mk3Temp19 {
     pub fn temperature_19(&self) -> f32 {
         self.temperature_19_raw()
     }
-    /// Get raw value of Temperature_19
+    /// Get raw value of 'Temperature_19'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -16802,7 +16802,7 @@ impl RtDl1mk3Temp19 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_19
+    /// Set value of 'Temperature_19'
     #[inline(always)]
     pub fn set_temperature_19(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -16880,7 +16880,7 @@ impl RtDl1mk3Temp18 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_18_MIN: f32 = 0_f32;
     pub const TEMPERATURE_18_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_18 from values
+    /// Construct new 'RT_DL1MK3_Temp_18' from values
     pub fn new(temperature_18: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_18(temperature_18)?;
@@ -16890,7 +16890,7 @@ impl RtDl1mk3Temp18 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_18
+    /// Get value of 'Temperature_18'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -16900,7 +16900,7 @@ impl RtDl1mk3Temp18 {
     pub fn temperature_18(&self) -> f32 {
         self.temperature_18_raw()
     }
-    /// Get raw value of Temperature_18
+    /// Get raw value of 'Temperature_18'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -16915,7 +16915,7 @@ impl RtDl1mk3Temp18 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_18
+    /// Set value of 'Temperature_18'
     #[inline(always)]
     pub fn set_temperature_18(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -16993,7 +16993,7 @@ impl RtDl1mk3Temp17 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_17_MIN: f32 = 0_f32;
     pub const TEMPERATURE_17_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_17 from values
+    /// Construct new 'RT_DL1MK3_Temp_17' from values
     pub fn new(temperature_17: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_17(temperature_17)?;
@@ -17003,7 +17003,7 @@ impl RtDl1mk3Temp17 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_17
+    /// Get value of 'Temperature_17'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -17013,7 +17013,7 @@ impl RtDl1mk3Temp17 {
     pub fn temperature_17(&self) -> f32 {
         self.temperature_17_raw()
     }
-    /// Get raw value of Temperature_17
+    /// Get raw value of 'Temperature_17'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -17028,7 +17028,7 @@ impl RtDl1mk3Temp17 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_17
+    /// Set value of 'Temperature_17'
     #[inline(always)]
     pub fn set_temperature_17(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -17106,7 +17106,7 @@ impl RtDl1mk3Temp16 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_16_MIN: f32 = 0_f32;
     pub const TEMPERATURE_16_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_16 from values
+    /// Construct new 'RT_DL1MK3_Temp_16' from values
     pub fn new(temperature_16: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_16(temperature_16)?;
@@ -17116,7 +17116,7 @@ impl RtDl1mk3Temp16 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_16
+    /// Get value of 'Temperature_16'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -17126,7 +17126,7 @@ impl RtDl1mk3Temp16 {
     pub fn temperature_16(&self) -> f32 {
         self.temperature_16_raw()
     }
-    /// Get raw value of Temperature_16
+    /// Get raw value of 'Temperature_16'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -17141,7 +17141,7 @@ impl RtDl1mk3Temp16 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_16
+    /// Set value of 'Temperature_16'
     #[inline(always)]
     pub fn set_temperature_16(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -17219,7 +17219,7 @@ impl RtDl1mk3Temp15 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_15_MIN: f32 = 0_f32;
     pub const TEMPERATURE_15_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_15 from values
+    /// Construct new 'RT_DL1MK3_Temp_15' from values
     pub fn new(temperature_15: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_15(temperature_15)?;
@@ -17229,7 +17229,7 @@ impl RtDl1mk3Temp15 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_15
+    /// Get value of 'Temperature_15'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -17239,7 +17239,7 @@ impl RtDl1mk3Temp15 {
     pub fn temperature_15(&self) -> f32 {
         self.temperature_15_raw()
     }
-    /// Get raw value of Temperature_15
+    /// Get raw value of 'Temperature_15'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -17254,7 +17254,7 @@ impl RtDl1mk3Temp15 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_15
+    /// Set value of 'Temperature_15'
     #[inline(always)]
     pub fn set_temperature_15(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -17332,7 +17332,7 @@ impl RtDl1mk3Temp14 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_14_MIN: f32 = 0_f32;
     pub const TEMPERATURE_14_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_14 from values
+    /// Construct new 'RT_DL1MK3_Temp_14' from values
     pub fn new(temperature_14: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_14(temperature_14)?;
@@ -17342,7 +17342,7 @@ impl RtDl1mk3Temp14 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_14
+    /// Get value of 'Temperature_14'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -17352,7 +17352,7 @@ impl RtDl1mk3Temp14 {
     pub fn temperature_14(&self) -> f32 {
         self.temperature_14_raw()
     }
-    /// Get raw value of Temperature_14
+    /// Get raw value of 'Temperature_14'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -17367,7 +17367,7 @@ impl RtDl1mk3Temp14 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_14
+    /// Set value of 'Temperature_14'
     #[inline(always)]
     pub fn set_temperature_14(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -17445,7 +17445,7 @@ impl RtDl1mk3Temp13 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_13_MIN: f32 = 0_f32;
     pub const TEMPERATURE_13_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_13 from values
+    /// Construct new 'RT_DL1MK3_Temp_13' from values
     pub fn new(temperature_13: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_13(temperature_13)?;
@@ -17455,7 +17455,7 @@ impl RtDl1mk3Temp13 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_13
+    /// Get value of 'Temperature_13'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -17465,7 +17465,7 @@ impl RtDl1mk3Temp13 {
     pub fn temperature_13(&self) -> f32 {
         self.temperature_13_raw()
     }
-    /// Get raw value of Temperature_13
+    /// Get raw value of 'Temperature_13'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -17480,7 +17480,7 @@ impl RtDl1mk3Temp13 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_13
+    /// Set value of 'Temperature_13'
     #[inline(always)]
     pub fn set_temperature_13(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -17558,7 +17558,7 @@ impl RtDl1mk3Temp12 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_12_MIN: f32 = 0_f32;
     pub const TEMPERATURE_12_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_12 from values
+    /// Construct new 'RT_DL1MK3_Temp_12' from values
     pub fn new(temperature_12: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_12(temperature_12)?;
@@ -17568,7 +17568,7 @@ impl RtDl1mk3Temp12 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_12
+    /// Get value of 'Temperature_12'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -17578,7 +17578,7 @@ impl RtDl1mk3Temp12 {
     pub fn temperature_12(&self) -> f32 {
         self.temperature_12_raw()
     }
-    /// Get raw value of Temperature_12
+    /// Get raw value of 'Temperature_12'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -17593,7 +17593,7 @@ impl RtDl1mk3Temp12 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_12
+    /// Set value of 'Temperature_12'
     #[inline(always)]
     pub fn set_temperature_12(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -17671,7 +17671,7 @@ impl RtDl1mk3Temp11 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_11_MIN: f32 = 0_f32;
     pub const TEMPERATURE_11_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_11 from values
+    /// Construct new 'RT_DL1MK3_Temp_11' from values
     pub fn new(temperature_11: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_11(temperature_11)?;
@@ -17681,7 +17681,7 @@ impl RtDl1mk3Temp11 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_11
+    /// Get value of 'Temperature_11'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -17691,7 +17691,7 @@ impl RtDl1mk3Temp11 {
     pub fn temperature_11(&self) -> f32 {
         self.temperature_11_raw()
     }
-    /// Get raw value of Temperature_11
+    /// Get raw value of 'Temperature_11'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -17706,7 +17706,7 @@ impl RtDl1mk3Temp11 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_11
+    /// Set value of 'Temperature_11'
     #[inline(always)]
     pub fn set_temperature_11(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -17784,7 +17784,7 @@ impl RtDl1mk3Temp10 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_10_MIN: f32 = 0_f32;
     pub const TEMPERATURE_10_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_10 from values
+    /// Construct new 'RT_DL1MK3_Temp_10' from values
     pub fn new(temperature_10: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_10(temperature_10)?;
@@ -17794,7 +17794,7 @@ impl RtDl1mk3Temp10 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_10
+    /// Get value of 'Temperature_10'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -17804,7 +17804,7 @@ impl RtDl1mk3Temp10 {
     pub fn temperature_10(&self) -> f32 {
         self.temperature_10_raw()
     }
-    /// Get raw value of Temperature_10
+    /// Get raw value of 'Temperature_10'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -17819,7 +17819,7 @@ impl RtDl1mk3Temp10 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_10
+    /// Set value of 'Temperature_10'
     #[inline(always)]
     pub fn set_temperature_10(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -17897,7 +17897,7 @@ impl RtDl1mk3Temp9 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_9_MIN: f32 = 0_f32;
     pub const TEMPERATURE_9_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_9 from values
+    /// Construct new 'RT_DL1MK3_Temp_9' from values
     pub fn new(temperature_9: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_9(temperature_9)?;
@@ -17907,7 +17907,7 @@ impl RtDl1mk3Temp9 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_9
+    /// Get value of 'Temperature_9'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -17917,7 +17917,7 @@ impl RtDl1mk3Temp9 {
     pub fn temperature_9(&self) -> f32 {
         self.temperature_9_raw()
     }
-    /// Get raw value of Temperature_9
+    /// Get raw value of 'Temperature_9'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -17932,7 +17932,7 @@ impl RtDl1mk3Temp9 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_9
+    /// Set value of 'Temperature_9'
     #[inline(always)]
     pub fn set_temperature_9(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -18010,7 +18010,7 @@ impl RtDl1mk3Temp8 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_8_MIN: f32 = 0_f32;
     pub const TEMPERATURE_8_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_8 from values
+    /// Construct new 'RT_DL1MK3_Temp_8' from values
     pub fn new(temperature_8: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_8(temperature_8)?;
@@ -18020,7 +18020,7 @@ impl RtDl1mk3Temp8 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_8
+    /// Get value of 'Temperature_8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -18030,7 +18030,7 @@ impl RtDl1mk3Temp8 {
     pub fn temperature_8(&self) -> f32 {
         self.temperature_8_raw()
     }
-    /// Get raw value of Temperature_8
+    /// Get raw value of 'Temperature_8'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -18045,7 +18045,7 @@ impl RtDl1mk3Temp8 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_8
+    /// Set value of 'Temperature_8'
     #[inline(always)]
     pub fn set_temperature_8(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -18123,7 +18123,7 @@ impl RtDl1mk3Temp7 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_7_MIN: f32 = 0_f32;
     pub const TEMPERATURE_7_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_7 from values
+    /// Construct new 'RT_DL1MK3_Temp_7' from values
     pub fn new(temperature_7: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_7(temperature_7)?;
@@ -18133,7 +18133,7 @@ impl RtDl1mk3Temp7 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_7
+    /// Get value of 'Temperature_7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -18143,7 +18143,7 @@ impl RtDl1mk3Temp7 {
     pub fn temperature_7(&self) -> f32 {
         self.temperature_7_raw()
     }
-    /// Get raw value of Temperature_7
+    /// Get raw value of 'Temperature_7'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -18158,7 +18158,7 @@ impl RtDl1mk3Temp7 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_7
+    /// Set value of 'Temperature_7'
     #[inline(always)]
     pub fn set_temperature_7(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -18236,7 +18236,7 @@ impl RtDl1mk3Temp6 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_6_MIN: f32 = 0_f32;
     pub const TEMPERATURE_6_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_6 from values
+    /// Construct new 'RT_DL1MK3_Temp_6' from values
     pub fn new(temperature_6: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_6(temperature_6)?;
@@ -18246,7 +18246,7 @@ impl RtDl1mk3Temp6 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_6
+    /// Get value of 'Temperature_6'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -18256,7 +18256,7 @@ impl RtDl1mk3Temp6 {
     pub fn temperature_6(&self) -> f32 {
         self.temperature_6_raw()
     }
-    /// Get raw value of Temperature_6
+    /// Get raw value of 'Temperature_6'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -18271,7 +18271,7 @@ impl RtDl1mk3Temp6 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_6
+    /// Set value of 'Temperature_6'
     #[inline(always)]
     pub fn set_temperature_6(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -18349,7 +18349,7 @@ impl RtDl1mk3Temp5 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_5_MIN: f32 = 0_f32;
     pub const TEMPERATURE_5_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_5 from values
+    /// Construct new 'RT_DL1MK3_Temp_5' from values
     pub fn new(temperature_5: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_5(temperature_5)?;
@@ -18359,7 +18359,7 @@ impl RtDl1mk3Temp5 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_5
+    /// Get value of 'Temperature_5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -18369,7 +18369,7 @@ impl RtDl1mk3Temp5 {
     pub fn temperature_5(&self) -> f32 {
         self.temperature_5_raw()
     }
-    /// Get raw value of Temperature_5
+    /// Get raw value of 'Temperature_5'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -18384,7 +18384,7 @@ impl RtDl1mk3Temp5 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_5
+    /// Set value of 'Temperature_5'
     #[inline(always)]
     pub fn set_temperature_5(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -18462,7 +18462,7 @@ impl RtDl1mk3Temp4 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_4_MIN: f32 = 0_f32;
     pub const TEMPERATURE_4_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_4 from values
+    /// Construct new 'RT_DL1MK3_Temp_4' from values
     pub fn new(temperature_4: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_4(temperature_4)?;
@@ -18472,7 +18472,7 @@ impl RtDl1mk3Temp4 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_4
+    /// Get value of 'Temperature_4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -18482,7 +18482,7 @@ impl RtDl1mk3Temp4 {
     pub fn temperature_4(&self) -> f32 {
         self.temperature_4_raw()
     }
-    /// Get raw value of Temperature_4
+    /// Get raw value of 'Temperature_4'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -18497,7 +18497,7 @@ impl RtDl1mk3Temp4 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_4
+    /// Set value of 'Temperature_4'
     #[inline(always)]
     pub fn set_temperature_4(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -18575,7 +18575,7 @@ impl RtDl1mk3Temp3 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_3_MIN: f32 = 0_f32;
     pub const TEMPERATURE_3_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_3 from values
+    /// Construct new 'RT_DL1MK3_Temp_3' from values
     pub fn new(temperature_3: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_3(temperature_3)?;
@@ -18585,7 +18585,7 @@ impl RtDl1mk3Temp3 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_3
+    /// Get value of 'Temperature_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -18595,7 +18595,7 @@ impl RtDl1mk3Temp3 {
     pub fn temperature_3(&self) -> f32 {
         self.temperature_3_raw()
     }
-    /// Get raw value of Temperature_3
+    /// Get raw value of 'Temperature_3'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -18610,7 +18610,7 @@ impl RtDl1mk3Temp3 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_3
+    /// Set value of 'Temperature_3'
     #[inline(always)]
     pub fn set_temperature_3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -18688,7 +18688,7 @@ impl RtDl1mk3Temp2 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_2_MIN: f32 = 0_f32;
     pub const TEMPERATURE_2_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_2 from values
+    /// Construct new 'RT_DL1MK3_Temp_2' from values
     pub fn new(temperature_2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_2(temperature_2)?;
@@ -18698,7 +18698,7 @@ impl RtDl1mk3Temp2 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_2
+    /// Get value of 'Temperature_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -18708,7 +18708,7 @@ impl RtDl1mk3Temp2 {
     pub fn temperature_2(&self) -> f32 {
         self.temperature_2_raw()
     }
-    /// Get raw value of Temperature_2
+    /// Get raw value of 'Temperature_2'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -18723,7 +18723,7 @@ impl RtDl1mk3Temp2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_2
+    /// Set value of 'Temperature_2'
     #[inline(always)]
     pub fn set_temperature_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -18801,7 +18801,7 @@ impl RtDl1mk3Temp1 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const TEMPERATURE_1_MIN: f32 = 0_f32;
     pub const TEMPERATURE_1_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Temp_1 from values
+    /// Construct new 'RT_DL1MK3_Temp_1' from values
     pub fn new(temperature_1: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_temperature_1(temperature_1)?;
@@ -18811,7 +18811,7 @@ impl RtDl1mk3Temp1 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Temperature_1
+    /// Get value of 'Temperature_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -18821,7 +18821,7 @@ impl RtDl1mk3Temp1 {
     pub fn temperature_1(&self) -> f32 {
         self.temperature_1_raw()
     }
-    /// Get raw value of Temperature_1
+    /// Get raw value of 'Temperature_1'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -18836,7 +18836,7 @@ impl RtDl1mk3Temp1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Temperature_1
+    /// Set value of 'Temperature_1'
     #[inline(always)]
     pub fn set_temperature_1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -18914,7 +18914,7 @@ impl RtDl1mk3Analog32 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_32_MIN: f32 = 0_f32;
     pub const ANALOG_32_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_32 from values
+    /// Construct new 'RT_DL1MK3_Analog_32' from values
     pub fn new(analog_32: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_32(analog_32)?;
@@ -18924,7 +18924,7 @@ impl RtDl1mk3Analog32 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_32
+    /// Get value of 'Analog_32'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -18934,7 +18934,7 @@ impl RtDl1mk3Analog32 {
     pub fn analog_32(&self) -> f32 {
         self.analog_32_raw()
     }
-    /// Get raw value of Analog_32
+    /// Get raw value of 'Analog_32'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -18949,7 +18949,7 @@ impl RtDl1mk3Analog32 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_32
+    /// Set value of 'Analog_32'
     #[inline(always)]
     pub fn set_analog_32(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -19026,7 +19026,7 @@ impl RtDl1mk3Analog31 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_31_MIN: f32 = 0_f32;
     pub const ANALOG_31_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_31 from values
+    /// Construct new 'RT_DL1MK3_Analog_31' from values
     pub fn new(analog_31: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_31(analog_31)?;
@@ -19036,7 +19036,7 @@ impl RtDl1mk3Analog31 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_31
+    /// Get value of 'Analog_31'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -19046,7 +19046,7 @@ impl RtDl1mk3Analog31 {
     pub fn analog_31(&self) -> f32 {
         self.analog_31_raw()
     }
-    /// Get raw value of Analog_31
+    /// Get raw value of 'Analog_31'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -19061,7 +19061,7 @@ impl RtDl1mk3Analog31 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_31
+    /// Set value of 'Analog_31'
     #[inline(always)]
     pub fn set_analog_31(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -19138,7 +19138,7 @@ impl RtDl1mk3Analog30 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_30_MIN: f32 = 0_f32;
     pub const ANALOG_30_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_30 from values
+    /// Construct new 'RT_DL1MK3_Analog_30' from values
     pub fn new(analog_30: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_30(analog_30)?;
@@ -19148,7 +19148,7 @@ impl RtDl1mk3Analog30 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_30
+    /// Get value of 'Analog_30'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -19158,7 +19158,7 @@ impl RtDl1mk3Analog30 {
     pub fn analog_30(&self) -> f32 {
         self.analog_30_raw()
     }
-    /// Get raw value of Analog_30
+    /// Get raw value of 'Analog_30'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -19173,7 +19173,7 @@ impl RtDl1mk3Analog30 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_30
+    /// Set value of 'Analog_30'
     #[inline(always)]
     pub fn set_analog_30(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -19250,7 +19250,7 @@ impl RtDl1mk3Analog29 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_29_MIN: f32 = 0_f32;
     pub const ANALOG_29_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_29 from values
+    /// Construct new 'RT_DL1MK3_Analog_29' from values
     pub fn new(analog_29: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_29(analog_29)?;
@@ -19260,7 +19260,7 @@ impl RtDl1mk3Analog29 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_29
+    /// Get value of 'Analog_29'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -19270,7 +19270,7 @@ impl RtDl1mk3Analog29 {
     pub fn analog_29(&self) -> f32 {
         self.analog_29_raw()
     }
-    /// Get raw value of Analog_29
+    /// Get raw value of 'Analog_29'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -19285,7 +19285,7 @@ impl RtDl1mk3Analog29 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_29
+    /// Set value of 'Analog_29'
     #[inline(always)]
     pub fn set_analog_29(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -19362,7 +19362,7 @@ impl RtDl1mk3Analog28 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_28_MIN: f32 = 0_f32;
     pub const ANALOG_28_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_28 from values
+    /// Construct new 'RT_DL1MK3_Analog_28' from values
     pub fn new(analog_28: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_28(analog_28)?;
@@ -19372,7 +19372,7 @@ impl RtDl1mk3Analog28 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_28
+    /// Get value of 'Analog_28'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -19382,7 +19382,7 @@ impl RtDl1mk3Analog28 {
     pub fn analog_28(&self) -> f32 {
         self.analog_28_raw()
     }
-    /// Get raw value of Analog_28
+    /// Get raw value of 'Analog_28'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -19397,7 +19397,7 @@ impl RtDl1mk3Analog28 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_28
+    /// Set value of 'Analog_28'
     #[inline(always)]
     pub fn set_analog_28(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -19474,7 +19474,7 @@ impl RtDl1mk3Analog27 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_27_MIN: f32 = 0_f32;
     pub const ANALOG_27_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_27 from values
+    /// Construct new 'RT_DL1MK3_Analog_27' from values
     pub fn new(analog_27: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_27(analog_27)?;
@@ -19484,7 +19484,7 @@ impl RtDl1mk3Analog27 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_27
+    /// Get value of 'Analog_27'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -19494,7 +19494,7 @@ impl RtDl1mk3Analog27 {
     pub fn analog_27(&self) -> f32 {
         self.analog_27_raw()
     }
-    /// Get raw value of Analog_27
+    /// Get raw value of 'Analog_27'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -19509,7 +19509,7 @@ impl RtDl1mk3Analog27 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_27
+    /// Set value of 'Analog_27'
     #[inline(always)]
     pub fn set_analog_27(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -19586,7 +19586,7 @@ impl RtDl1mk3Analog26 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_26_MIN: f32 = 0_f32;
     pub const ANALOG_26_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_26 from values
+    /// Construct new 'RT_DL1MK3_Analog_26' from values
     pub fn new(analog_26: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_26(analog_26)?;
@@ -19596,7 +19596,7 @@ impl RtDl1mk3Analog26 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_26
+    /// Get value of 'Analog_26'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -19606,7 +19606,7 @@ impl RtDl1mk3Analog26 {
     pub fn analog_26(&self) -> f32 {
         self.analog_26_raw()
     }
-    /// Get raw value of Analog_26
+    /// Get raw value of 'Analog_26'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -19621,7 +19621,7 @@ impl RtDl1mk3Analog26 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_26
+    /// Set value of 'Analog_26'
     #[inline(always)]
     pub fn set_analog_26(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -19698,7 +19698,7 @@ impl RtDl1mk3Analog25 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_25_MIN: f32 = 0_f32;
     pub const ANALOG_25_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_25 from values
+    /// Construct new 'RT_DL1MK3_Analog_25' from values
     pub fn new(analog_25: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_25(analog_25)?;
@@ -19708,7 +19708,7 @@ impl RtDl1mk3Analog25 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_25
+    /// Get value of 'Analog_25'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -19718,7 +19718,7 @@ impl RtDl1mk3Analog25 {
     pub fn analog_25(&self) -> f32 {
         self.analog_25_raw()
     }
-    /// Get raw value of Analog_25
+    /// Get raw value of 'Analog_25'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -19733,7 +19733,7 @@ impl RtDl1mk3Analog25 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_25
+    /// Set value of 'Analog_25'
     #[inline(always)]
     pub fn set_analog_25(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -19810,7 +19810,7 @@ impl RtDl1mk3Analog15 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_15_MIN: f32 = 0_f32;
     pub const ANALOG_15_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_15 from values
+    /// Construct new 'RT_DL1MK3_Analog_15' from values
     pub fn new(analog_15: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_15(analog_15)?;
@@ -19820,7 +19820,7 @@ impl RtDl1mk3Analog15 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_15
+    /// Get value of 'Analog_15'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -19830,7 +19830,7 @@ impl RtDl1mk3Analog15 {
     pub fn analog_15(&self) -> f32 {
         self.analog_15_raw()
     }
-    /// Get raw value of Analog_15
+    /// Get raw value of 'Analog_15'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -19845,7 +19845,7 @@ impl RtDl1mk3Analog15 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_15
+    /// Set value of 'Analog_15'
     #[inline(always)]
     pub fn set_analog_15(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -19922,7 +19922,7 @@ impl RtDl1mk3Analog14 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_14_MIN: f32 = 0_f32;
     pub const ANALOG_14_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_14 from values
+    /// Construct new 'RT_DL1MK3_Analog_14' from values
     pub fn new(analog_14: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_14(analog_14)?;
@@ -19932,7 +19932,7 @@ impl RtDl1mk3Analog14 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_14
+    /// Get value of 'Analog_14'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -19942,7 +19942,7 @@ impl RtDl1mk3Analog14 {
     pub fn analog_14(&self) -> f32 {
         self.analog_14_raw()
     }
-    /// Get raw value of Analog_14
+    /// Get raw value of 'Analog_14'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -19957,7 +19957,7 @@ impl RtDl1mk3Analog14 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_14
+    /// Set value of 'Analog_14'
     #[inline(always)]
     pub fn set_analog_14(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -20034,7 +20034,7 @@ impl RtDl1mk3Analog17 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_17_MIN: f32 = 0_f32;
     pub const ANALOG_17_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_17 from values
+    /// Construct new 'RT_DL1MK3_Analog_17' from values
     pub fn new(analog_17: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_17(analog_17)?;
@@ -20044,7 +20044,7 @@ impl RtDl1mk3Analog17 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_17
+    /// Get value of 'Analog_17'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -20054,7 +20054,7 @@ impl RtDl1mk3Analog17 {
     pub fn analog_17(&self) -> f32 {
         self.analog_17_raw()
     }
-    /// Get raw value of Analog_17
+    /// Get raw value of 'Analog_17'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -20069,7 +20069,7 @@ impl RtDl1mk3Analog17 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_17
+    /// Set value of 'Analog_17'
     #[inline(always)]
     pub fn set_analog_17(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -20146,7 +20146,7 @@ impl RtDl1mk3Analog24 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_24_MIN: f32 = 0_f32;
     pub const ANALOG_24_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_24 from values
+    /// Construct new 'RT_DL1MK3_Analog_24' from values
     pub fn new(analog_24: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_24(analog_24)?;
@@ -20156,7 +20156,7 @@ impl RtDl1mk3Analog24 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_24
+    /// Get value of 'Analog_24'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -20166,7 +20166,7 @@ impl RtDl1mk3Analog24 {
     pub fn analog_24(&self) -> f32 {
         self.analog_24_raw()
     }
-    /// Get raw value of Analog_24
+    /// Get raw value of 'Analog_24'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -20181,7 +20181,7 @@ impl RtDl1mk3Analog24 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_24
+    /// Set value of 'Analog_24'
     #[inline(always)]
     pub fn set_analog_24(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -20258,7 +20258,7 @@ impl RtDl1mk3Analog23 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_23_MIN: f32 = 0_f32;
     pub const ANALOG_23_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_23 from values
+    /// Construct new 'RT_DL1MK3_Analog_23' from values
     pub fn new(analog_23: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_23(analog_23)?;
@@ -20268,7 +20268,7 @@ impl RtDl1mk3Analog23 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_23
+    /// Get value of 'Analog_23'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -20278,7 +20278,7 @@ impl RtDl1mk3Analog23 {
     pub fn analog_23(&self) -> f32 {
         self.analog_23_raw()
     }
-    /// Get raw value of Analog_23
+    /// Get raw value of 'Analog_23'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -20293,7 +20293,7 @@ impl RtDl1mk3Analog23 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_23
+    /// Set value of 'Analog_23'
     #[inline(always)]
     pub fn set_analog_23(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -20370,7 +20370,7 @@ impl RtDl1mk3Analog22 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_22_MIN: f32 = 0_f32;
     pub const ANALOG_22_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_22 from values
+    /// Construct new 'RT_DL1MK3_Analog_22' from values
     pub fn new(analog_22: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_22(analog_22)?;
@@ -20380,7 +20380,7 @@ impl RtDl1mk3Analog22 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_22
+    /// Get value of 'Analog_22'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -20390,7 +20390,7 @@ impl RtDl1mk3Analog22 {
     pub fn analog_22(&self) -> f32 {
         self.analog_22_raw()
     }
-    /// Get raw value of Analog_22
+    /// Get raw value of 'Analog_22'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -20405,7 +20405,7 @@ impl RtDl1mk3Analog22 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_22
+    /// Set value of 'Analog_22'
     #[inline(always)]
     pub fn set_analog_22(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -20482,7 +20482,7 @@ impl RtDl1mk3Analog21 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_21_MIN: f32 = 0_f32;
     pub const ANALOG_21_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_21 from values
+    /// Construct new 'RT_DL1MK3_Analog_21' from values
     pub fn new(analog_21: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_21(analog_21)?;
@@ -20492,7 +20492,7 @@ impl RtDl1mk3Analog21 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_21
+    /// Get value of 'Analog_21'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -20502,7 +20502,7 @@ impl RtDl1mk3Analog21 {
     pub fn analog_21(&self) -> f32 {
         self.analog_21_raw()
     }
-    /// Get raw value of Analog_21
+    /// Get raw value of 'Analog_21'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -20517,7 +20517,7 @@ impl RtDl1mk3Analog21 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_21
+    /// Set value of 'Analog_21'
     #[inline(always)]
     pub fn set_analog_21(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -20594,7 +20594,7 @@ impl RtDl1mk3Analog20 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_20_MIN: f32 = 0_f32;
     pub const ANALOG_20_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_20 from values
+    /// Construct new 'RT_DL1MK3_Analog_20' from values
     pub fn new(analog_20: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_20(analog_20)?;
@@ -20604,7 +20604,7 @@ impl RtDl1mk3Analog20 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_20
+    /// Get value of 'Analog_20'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -20614,7 +20614,7 @@ impl RtDl1mk3Analog20 {
     pub fn analog_20(&self) -> f32 {
         self.analog_20_raw()
     }
-    /// Get raw value of Analog_20
+    /// Get raw value of 'Analog_20'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -20629,7 +20629,7 @@ impl RtDl1mk3Analog20 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_20
+    /// Set value of 'Analog_20'
     #[inline(always)]
     pub fn set_analog_20(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -20706,7 +20706,7 @@ impl RtDl1mk3Analog19 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_19_MIN: f32 = 0_f32;
     pub const ANALOG_19_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_19 from values
+    /// Construct new 'RT_DL1MK3_Analog_19' from values
     pub fn new(analog_19: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_19(analog_19)?;
@@ -20716,7 +20716,7 @@ impl RtDl1mk3Analog19 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_19
+    /// Get value of 'Analog_19'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -20726,7 +20726,7 @@ impl RtDl1mk3Analog19 {
     pub fn analog_19(&self) -> f32 {
         self.analog_19_raw()
     }
-    /// Get raw value of Analog_19
+    /// Get raw value of 'Analog_19'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -20741,7 +20741,7 @@ impl RtDl1mk3Analog19 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_19
+    /// Set value of 'Analog_19'
     #[inline(always)]
     pub fn set_analog_19(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -20818,7 +20818,7 @@ impl RtDl1mk3Analog16 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_16_MIN: f32 = 0_f32;
     pub const ANALOG_16_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_16 from values
+    /// Construct new 'RT_DL1MK3_Analog_16' from values
     pub fn new(analog_16: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_16(analog_16)?;
@@ -20828,7 +20828,7 @@ impl RtDl1mk3Analog16 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_16
+    /// Get value of 'Analog_16'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -20838,7 +20838,7 @@ impl RtDl1mk3Analog16 {
     pub fn analog_16(&self) -> f32 {
         self.analog_16_raw()
     }
-    /// Get raw value of Analog_16
+    /// Get raw value of 'Analog_16'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -20853,7 +20853,7 @@ impl RtDl1mk3Analog16 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_16
+    /// Set value of 'Analog_16'
     #[inline(always)]
     pub fn set_analog_16(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -20930,7 +20930,7 @@ impl RtDl1mk3Analog18 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_18_MIN: f32 = 0_f32;
     pub const ANALOG_18_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_18 from values
+    /// Construct new 'RT_DL1MK3_Analog_18' from values
     pub fn new(analog_18: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_18(analog_18)?;
@@ -20940,7 +20940,7 @@ impl RtDl1mk3Analog18 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_18
+    /// Get value of 'Analog_18'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -20950,7 +20950,7 @@ impl RtDl1mk3Analog18 {
     pub fn analog_18(&self) -> f32 {
         self.analog_18_raw()
     }
-    /// Get raw value of Analog_18
+    /// Get raw value of 'Analog_18'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -20965,7 +20965,7 @@ impl RtDl1mk3Analog18 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_18
+    /// Set value of 'Analog_18'
     #[inline(always)]
     pub fn set_analog_18(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -21042,7 +21042,7 @@ impl RtDl1mk3Analog12 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_12_MIN: f32 = 0_f32;
     pub const ANALOG_12_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_12 from values
+    /// Construct new 'RT_DL1MK3_Analog_12' from values
     pub fn new(analog_12: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_12(analog_12)?;
@@ -21052,7 +21052,7 @@ impl RtDl1mk3Analog12 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_12
+    /// Get value of 'Analog_12'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -21062,7 +21062,7 @@ impl RtDl1mk3Analog12 {
     pub fn analog_12(&self) -> f32 {
         self.analog_12_raw()
     }
-    /// Get raw value of Analog_12
+    /// Get raw value of 'Analog_12'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -21077,7 +21077,7 @@ impl RtDl1mk3Analog12 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_12
+    /// Set value of 'Analog_12'
     #[inline(always)]
     pub fn set_analog_12(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -21154,7 +21154,7 @@ impl RtDl1mk3Analog11 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_11_MIN: f32 = 0_f32;
     pub const ANALOG_11_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_11 from values
+    /// Construct new 'RT_DL1MK3_Analog_11' from values
     pub fn new(analog_11: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_11(analog_11)?;
@@ -21164,7 +21164,7 @@ impl RtDl1mk3Analog11 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_11
+    /// Get value of 'Analog_11'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -21174,7 +21174,7 @@ impl RtDl1mk3Analog11 {
     pub fn analog_11(&self) -> f32 {
         self.analog_11_raw()
     }
-    /// Get raw value of Analog_11
+    /// Get raw value of 'Analog_11'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -21189,7 +21189,7 @@ impl RtDl1mk3Analog11 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_11
+    /// Set value of 'Analog_11'
     #[inline(always)]
     pub fn set_analog_11(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -21266,7 +21266,7 @@ impl RtDl1mk3Analog10 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_10_MIN: f32 = 0_f32;
     pub const ANALOG_10_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_10 from values
+    /// Construct new 'RT_DL1MK3_Analog_10' from values
     pub fn new(analog_10: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_10(analog_10)?;
@@ -21276,7 +21276,7 @@ impl RtDl1mk3Analog10 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_10
+    /// Get value of 'Analog_10'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -21286,7 +21286,7 @@ impl RtDl1mk3Analog10 {
     pub fn analog_10(&self) -> f32 {
         self.analog_10_raw()
     }
-    /// Get raw value of Analog_10
+    /// Get raw value of 'Analog_10'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -21301,7 +21301,7 @@ impl RtDl1mk3Analog10 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_10
+    /// Set value of 'Analog_10'
     #[inline(always)]
     pub fn set_analog_10(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -21378,7 +21378,7 @@ impl RtDl1mk3Analog9 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_9_MIN: f32 = 0_f32;
     pub const ANALOG_9_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_9 from values
+    /// Construct new 'RT_DL1MK3_Analog_9' from values
     pub fn new(analog_9: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_9(analog_9)?;
@@ -21388,7 +21388,7 @@ impl RtDl1mk3Analog9 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_9
+    /// Get value of 'Analog_9'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -21398,7 +21398,7 @@ impl RtDl1mk3Analog9 {
     pub fn analog_9(&self) -> f32 {
         self.analog_9_raw()
     }
-    /// Get raw value of Analog_9
+    /// Get raw value of 'Analog_9'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -21413,7 +21413,7 @@ impl RtDl1mk3Analog9 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_9
+    /// Set value of 'Analog_9'
     #[inline(always)]
     pub fn set_analog_9(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -21490,7 +21490,7 @@ impl RtDl1mk3Analog8 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_8_MIN: f32 = 0_f32;
     pub const ANALOG_8_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_8 from values
+    /// Construct new 'RT_DL1MK3_Analog_8' from values
     pub fn new(analog_8: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_8(analog_8)?;
@@ -21500,7 +21500,7 @@ impl RtDl1mk3Analog8 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_8
+    /// Get value of 'Analog_8'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -21510,7 +21510,7 @@ impl RtDl1mk3Analog8 {
     pub fn analog_8(&self) -> f32 {
         self.analog_8_raw()
     }
-    /// Get raw value of Analog_8
+    /// Get raw value of 'Analog_8'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -21525,7 +21525,7 @@ impl RtDl1mk3Analog8 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_8
+    /// Set value of 'Analog_8'
     #[inline(always)]
     pub fn set_analog_8(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -21602,7 +21602,7 @@ impl RtDl1mk3Analog7 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_7_MIN: f32 = 0_f32;
     pub const ANALOG_7_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_7 from values
+    /// Construct new 'RT_DL1MK3_Analog_7' from values
     pub fn new(analog_7: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_7(analog_7)?;
@@ -21612,7 +21612,7 @@ impl RtDl1mk3Analog7 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_7
+    /// Get value of 'Analog_7'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -21622,7 +21622,7 @@ impl RtDl1mk3Analog7 {
     pub fn analog_7(&self) -> f32 {
         self.analog_7_raw()
     }
-    /// Get raw value of Analog_7
+    /// Get raw value of 'Analog_7'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -21637,7 +21637,7 @@ impl RtDl1mk3Analog7 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_7
+    /// Set value of 'Analog_7'
     #[inline(always)]
     pub fn set_analog_7(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -21714,7 +21714,7 @@ impl RtDl1mk3Analog6 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_6_MIN: f32 = 0_f32;
     pub const ANALOG_6_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_6 from values
+    /// Construct new 'RT_DL1MK3_Analog_6' from values
     pub fn new(analog_6: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_6(analog_6)?;
@@ -21724,7 +21724,7 @@ impl RtDl1mk3Analog6 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_6
+    /// Get value of 'Analog_6'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -21734,7 +21734,7 @@ impl RtDl1mk3Analog6 {
     pub fn analog_6(&self) -> f32 {
         self.analog_6_raw()
     }
-    /// Get raw value of Analog_6
+    /// Get raw value of 'Analog_6'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -21749,7 +21749,7 @@ impl RtDl1mk3Analog6 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_6
+    /// Set value of 'Analog_6'
     #[inline(always)]
     pub fn set_analog_6(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -21826,7 +21826,7 @@ impl RtDl1mk3Analog5 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_5_MIN: f32 = 0_f32;
     pub const ANALOG_5_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_5 from values
+    /// Construct new 'RT_DL1MK3_Analog_5' from values
     pub fn new(analog_5: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_5(analog_5)?;
@@ -21836,7 +21836,7 @@ impl RtDl1mk3Analog5 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_5
+    /// Get value of 'Analog_5'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -21846,7 +21846,7 @@ impl RtDl1mk3Analog5 {
     pub fn analog_5(&self) -> f32 {
         self.analog_5_raw()
     }
-    /// Get raw value of Analog_5
+    /// Get raw value of 'Analog_5'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -21861,7 +21861,7 @@ impl RtDl1mk3Analog5 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_5
+    /// Set value of 'Analog_5'
     #[inline(always)]
     pub fn set_analog_5(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -21938,7 +21938,7 @@ impl RtDl1mk3Analog4 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_4_MIN: f32 = 0_f32;
     pub const ANALOG_4_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_4 from values
+    /// Construct new 'RT_DL1MK3_Analog_4' from values
     pub fn new(analog_4: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_4(analog_4)?;
@@ -21948,7 +21948,7 @@ impl RtDl1mk3Analog4 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_4
+    /// Get value of 'Analog_4'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -21958,7 +21958,7 @@ impl RtDl1mk3Analog4 {
     pub fn analog_4(&self) -> f32 {
         self.analog_4_raw()
     }
-    /// Get raw value of Analog_4
+    /// Get raw value of 'Analog_4'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -21973,7 +21973,7 @@ impl RtDl1mk3Analog4 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_4
+    /// Set value of 'Analog_4'
     #[inline(always)]
     pub fn set_analog_4(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -22050,7 +22050,7 @@ impl RtDl1mk3Analog3 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_3_MIN: f32 = 0_f32;
     pub const ANALOG_3_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_3 from values
+    /// Construct new 'RT_DL1MK3_Analog_3' from values
     pub fn new(analog_3: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_3(analog_3)?;
@@ -22060,7 +22060,7 @@ impl RtDl1mk3Analog3 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_3
+    /// Get value of 'Analog_3'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -22070,7 +22070,7 @@ impl RtDl1mk3Analog3 {
     pub fn analog_3(&self) -> f32 {
         self.analog_3_raw()
     }
-    /// Get raw value of Analog_3
+    /// Get raw value of 'Analog_3'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -22085,7 +22085,7 @@ impl RtDl1mk3Analog3 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_3
+    /// Set value of 'Analog_3'
     #[inline(always)]
     pub fn set_analog_3(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -22162,7 +22162,7 @@ impl RtDl1mk3Analog2 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_2_MIN: f32 = 0_f32;
     pub const ANALOG_2_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_2 from values
+    /// Construct new 'RT_DL1MK3_Analog_2' from values
     pub fn new(analog_2: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_2(analog_2)?;
@@ -22172,7 +22172,7 @@ impl RtDl1mk3Analog2 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_2
+    /// Get value of 'Analog_2'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -22182,7 +22182,7 @@ impl RtDl1mk3Analog2 {
     pub fn analog_2(&self) -> f32 {
         self.analog_2_raw()
     }
-    /// Get raw value of Analog_2
+    /// Get raw value of 'Analog_2'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -22197,7 +22197,7 @@ impl RtDl1mk3Analog2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_2
+    /// Set value of 'Analog_2'
     #[inline(always)]
     pub fn set_analog_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -22274,7 +22274,7 @@ impl RtDl1mk3Analog1 {
     pub const MESSAGE_SIZE: usize = 2;
     pub const ANALOG_1_MIN: f32 = 0_f32;
     pub const ANALOG_1_MAX: f32 = 0_f32;
-    /// Construct new RT_DL1MK3_Analog_1 from values
+    /// Construct new 'RT_DL1MK3_Analog_1' from values
     pub fn new(analog_1: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 2] };
         res.set_analog_1(analog_1)?;
@@ -22284,7 +22284,7 @@ impl RtDl1mk3Analog1 {
     pub fn raw(&self) -> &[u8; 2] {
         &self.raw
     }
-    /// Analog_1
+    /// Get value of 'Analog_1'
     ///
     /// - Min: 0
     /// - Max: 0
@@ -22294,7 +22294,7 @@ impl RtDl1mk3Analog1 {
     pub fn analog_1(&self) -> f32 {
         self.analog_1_raw()
     }
-    /// Get raw value of Analog_1
+    /// Get raw value of 'Analog_1'
     ///
     /// - Start bit: 7
     /// - Signal size: 16 bits
@@ -22309,7 +22309,7 @@ impl RtDl1mk3Analog1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Analog_1
+    /// Set value of 'Analog_1'
     #[inline(always)]
     pub fn set_analog_1(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 0_f32 < value {
@@ -22392,7 +22392,7 @@ impl RtDl1mk3Accel {
     pub const ACCEL_LONGITUDINAL_MAX: f32 = 65_f32;
     pub const ACCURACY_ACCEL_MIN: u8 = 0_u8;
     pub const ACCURACY_ACCEL_MAX: u8 = 255_u8;
-    /// Construct new RT_DL1MK3_Accel from values
+    /// Construct new 'RT_DL1MK3_Accel' from values
     pub fn new(
         accel_vertical: f32,
         accel_lateral: f32,
@@ -22416,7 +22416,7 @@ impl RtDl1mk3Accel {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Accel_Vertical
+    /// Get value of 'Accel_Vertical'
     ///
     /// Vertical acceleration.  This is positive when the vehicle accelerates in an upwards direction, e.g. when travelling through a dip.
     ///
@@ -22428,7 +22428,7 @@ impl RtDl1mk3Accel {
     pub fn accel_vertical(&self) -> f32 {
         self.accel_vertical_raw()
     }
-    /// Get raw value of Accel_Vertical
+    /// Get raw value of 'Accel_Vertical'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -22443,7 +22443,7 @@ impl RtDl1mk3Accel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Accel_Vertical
+    /// Set value of 'Accel_Vertical'
     #[inline(always)]
     pub fn set_accel_vertical(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -22458,7 +22458,7 @@ impl RtDl1mk3Accel {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Accel_Lateral
+    /// Get value of 'Accel_Lateral'
     ///
     /// Lateral acceleration.  This is positive when the vehicle accelerates towards the right, e.g. when cornering around a right-hand bend.
     ///
@@ -22470,7 +22470,7 @@ impl RtDl1mk3Accel {
     pub fn accel_lateral(&self) -> f32 {
         self.accel_lateral_raw()
     }
-    /// Get raw value of Accel_Lateral
+    /// Get raw value of 'Accel_Lateral'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -22485,7 +22485,7 @@ impl RtDl1mk3Accel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Accel_Lateral
+    /// Set value of 'Accel_Lateral'
     #[inline(always)]
     pub fn set_accel_lateral(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -22500,7 +22500,7 @@ impl RtDl1mk3Accel {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Accel_Longitudinal
+    /// Get value of 'Accel_Longitudinal'
     ///
     /// Longitudinal acceleration.  This is positive when the vehicle accelerates in a forwards direction.
     ///
@@ -22512,7 +22512,7 @@ impl RtDl1mk3Accel {
     pub fn accel_longitudinal(&self) -> f32 {
         self.accel_longitudinal_raw()
     }
-    /// Get raw value of Accel_Longitudinal
+    /// Get raw value of 'Accel_Longitudinal'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -22527,7 +22527,7 @@ impl RtDl1mk3Accel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Accel_Longitudinal
+    /// Set value of 'Accel_Longitudinal'
     #[inline(always)]
     pub fn set_accel_longitudinal(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -22542,7 +22542,7 @@ impl RtDl1mk3Accel {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_Accel
+    /// Get value of 'Accuracy_Accel'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -22554,7 +22554,7 @@ impl RtDl1mk3Accel {
     pub fn accuracy_accel(&self) -> u8 {
         self.accuracy_accel_raw()
     }
-    /// Get raw value of Accuracy_Accel
+    /// Get raw value of 'Accuracy_Accel'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -22568,7 +22568,7 @@ impl RtDl1mk3Accel {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_Accel
+    /// Set value of 'Accuracy_Accel'
     #[inline(always)]
     pub fn set_accuracy_accel(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -22586,7 +22586,7 @@ impl RtDl1mk3Accel {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_Accel_Vertical
+    /// Get value of 'Validity_Accel_Vertical'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -22598,7 +22598,7 @@ impl RtDl1mk3Accel {
     pub fn validity_accel_vertical(&self) -> bool {
         self.validity_accel_vertical_raw()
     }
-    /// Get raw value of Validity_Accel_Vertical
+    /// Get raw value of 'Validity_Accel_Vertical'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -22611,14 +22611,14 @@ impl RtDl1mk3Accel {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Accel_Vertical
+    /// Set value of 'Validity_Accel_Vertical'
     #[inline(always)]
     pub fn set_validity_accel_vertical(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_Accel_Lateral
+    /// Get value of 'Validity_Accel_Lateral'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -22630,7 +22630,7 @@ impl RtDl1mk3Accel {
     pub fn validity_accel_lateral(&self) -> bool {
         self.validity_accel_lateral_raw()
     }
-    /// Get raw value of Validity_Accel_Lateral
+    /// Get raw value of 'Validity_Accel_Lateral'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -22643,14 +22643,14 @@ impl RtDl1mk3Accel {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Accel_Lateral
+    /// Set value of 'Validity_Accel_Lateral'
     #[inline(always)]
     pub fn set_validity_accel_lateral(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_Accel_Longitudinal
+    /// Get value of 'Validity_Accel_Longitudinal'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -22662,7 +22662,7 @@ impl RtDl1mk3Accel {
     pub fn validity_accel_longitudinal(&self) -> bool {
         self.validity_accel_longitudinal_raw()
     }
-    /// Get raw value of Validity_Accel_Longitudinal
+    /// Get raw value of 'Validity_Accel_Longitudinal'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -22675,7 +22675,7 @@ impl RtDl1mk3Accel {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Accel_Longitudinal
+    /// Set value of 'Validity_Accel_Longitudinal'
     #[inline(always)]
     pub fn set_validity_accel_longitudinal(
         &mut self,
@@ -22752,7 +22752,7 @@ impl RtSbInsVpt4VelNed2 {
     pub const VIRTUAL_4_HEADING_MAX: f32 = 180_f32;
     pub const VIRTUAL_4_VEL_NED_D_MIN: f32 = -838_f32;
     pub const VIRTUAL_4_VEL_NED_D_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_INS_Vpt_4_Vel_NED_2 from values
+    /// Construct new 'RT_SB_INS_Vpt_4_Vel_NED_2' from values
     pub fn new(
         virtual_4_slip: f32,
         virtual_4_heading: f32,
@@ -22768,7 +22768,7 @@ impl RtSbInsVpt4VelNed2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_4_Slip
+    /// Get value of 'Virtual_4_Slip'
     ///
     /// Slip is defined as the difference between yaw and heading.
     ///
@@ -22780,7 +22780,7 @@ impl RtSbInsVpt4VelNed2 {
     pub fn virtual_4_slip(&self) -> f32 {
         self.virtual_4_slip_raw()
     }
-    /// Get raw value of Virtual_4_Slip
+    /// Get raw value of 'Virtual_4_Slip'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -22795,7 +22795,7 @@ impl RtSbInsVpt4VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_4_Slip
+    /// Set value of 'Virtual_4_Slip'
     #[inline(always)]
     pub fn set_virtual_4_slip(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -22810,7 +22810,7 @@ impl RtSbInsVpt4VelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Virtual_4_Heading
+    /// Get value of 'Virtual_4_Heading'
     ///
     /// This is GPS heading, the direction that the vehicle is travelling in the local horizontal plane.
     ///
@@ -22822,7 +22822,7 @@ impl RtSbInsVpt4VelNed2 {
     pub fn virtual_4_heading(&self) -> f32 {
         self.virtual_4_heading_raw()
     }
-    /// Get raw value of Virtual_4_Heading
+    /// Get raw value of 'Virtual_4_Heading'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -22837,7 +22837,7 @@ impl RtSbInsVpt4VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_4_Heading
+    /// Set value of 'Virtual_4_Heading'
     #[inline(always)]
     pub fn set_virtual_4_heading(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -22852,7 +22852,7 @@ impl RtSbInsVpt4VelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Virtual_4_Vel_NED_D
+    /// Get value of 'Virtual_4_Vel_NED_D'
     ///
     /// VELNED D velocity.  This is the velocity vector directly downwards towards the Earth centre at the current local Earth surface position.
     ///
@@ -22864,7 +22864,7 @@ impl RtSbInsVpt4VelNed2 {
     pub fn virtual_4_vel_ned_d(&self) -> f32 {
         self.virtual_4_vel_ned_d_raw()
     }
-    /// Get raw value of Virtual_4_Vel_NED_D
+    /// Get raw value of 'Virtual_4_Vel_NED_D'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -22879,7 +22879,7 @@ impl RtSbInsVpt4VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_4_Vel_NED_D
+    /// Set value of 'Virtual_4_Vel_NED_D'
     #[inline(always)]
     pub fn set_virtual_4_vel_ned_d(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -22959,7 +22959,7 @@ impl RtSbInsVpt4VelNed1 {
     pub const VIRTUAL_4_VEL_NED_E_MAX: f32 = 838_f32;
     pub const VIRTUAL_4_VEL_NED_N_MIN: f32 = -838_f32;
     pub const VIRTUAL_4_VEL_NED_N_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_INS_Vpt_4_Vel_NED_1 from values
+    /// Construct new 'RT_SB_INS_Vpt_4_Vel_NED_1' from values
     pub fn new(
         virtual_4_vel_ned_e: f32,
         virtual_4_vel_ned_n: f32,
@@ -22973,7 +22973,7 @@ impl RtSbInsVpt4VelNed1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_4_Vel_NED_E
+    /// Get value of 'Virtual_4_Vel_NED_E'
     ///
     /// VELNED E velocity.  This is the velocity vector directly East at the current local Earth surface position.
     ///
@@ -22985,7 +22985,7 @@ impl RtSbInsVpt4VelNed1 {
     pub fn virtual_4_vel_ned_e(&self) -> f32 {
         self.virtual_4_vel_ned_e_raw()
     }
-    /// Get raw value of Virtual_4_Vel_NED_E
+    /// Get raw value of 'Virtual_4_Vel_NED_E'
     ///
     /// - Start bit: 32
     /// - Signal size: 24 bits
@@ -23000,7 +23000,7 @@ impl RtSbInsVpt4VelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_4_Vel_NED_E
+    /// Set value of 'Virtual_4_Vel_NED_E'
     #[inline(always)]
     pub fn set_virtual_4_vel_ned_e(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -23015,7 +23015,7 @@ impl RtSbInsVpt4VelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[32..56].store_le(value);
         Ok(())
     }
-    /// Virtual_4_Vel_NED_N
+    /// Get value of 'Virtual_4_Vel_NED_N'
     ///
     /// VELNED N velocity.  This is the velocity vector directly North at the current local Earth surface position.
     ///
@@ -23027,7 +23027,7 @@ impl RtSbInsVpt4VelNed1 {
     pub fn virtual_4_vel_ned_n(&self) -> f32 {
         self.virtual_4_vel_ned_n_raw()
     }
-    /// Get raw value of Virtual_4_Vel_NED_N
+    /// Get raw value of 'Virtual_4_Vel_NED_N'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -23042,7 +23042,7 @@ impl RtSbInsVpt4VelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_4_Vel_NED_N
+    /// Set value of 'Virtual_4_Vel_NED_N'
     #[inline(always)]
     pub fn set_virtual_4_vel_ned_n(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -23124,7 +23124,7 @@ impl RtSbInsVpt4Offset {
     pub const VIRTUAL_4_OFFSET_Y_MAX: f32 = 32.767_f32;
     pub const VIRTUAL_4_OFFSET_X_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_4_OFFSET_X_MAX: f32 = 32.767_f32;
-    /// Construct new RT_SB_INS_Vpt_4_Offset from values
+    /// Construct new 'RT_SB_INS_Vpt_4_Offset' from values
     pub fn new(
         virtual_4_offset_z: f32,
         virtual_4_offset_y: f32,
@@ -23140,7 +23140,7 @@ impl RtSbInsVpt4Offset {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_4_Offset_Z
+    /// Get value of 'Virtual_4_Offset_Z'
     ///
     /// Z offset (+ve downwards) of the virtual point in the vehicle body frame.
     ///
@@ -23152,7 +23152,7 @@ impl RtSbInsVpt4Offset {
     pub fn virtual_4_offset_z(&self) -> f32 {
         self.virtual_4_offset_z_raw()
     }
-    /// Get raw value of Virtual_4_Offset_Z
+    /// Get raw value of 'Virtual_4_Offset_Z'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -23167,7 +23167,7 @@ impl RtSbInsVpt4Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_4_Offset_Z
+    /// Set value of 'Virtual_4_Offset_Z'
     #[inline(always)]
     pub fn set_virtual_4_offset_z(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -23182,7 +23182,7 @@ impl RtSbInsVpt4Offset {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Virtual_4_Offset_Y
+    /// Get value of 'Virtual_4_Offset_Y'
     ///
     /// Y offset of the virtual point in the vehicle body frame.
     ///
@@ -23194,7 +23194,7 @@ impl RtSbInsVpt4Offset {
     pub fn virtual_4_offset_y(&self) -> f32 {
         self.virtual_4_offset_y_raw()
     }
-    /// Get raw value of Virtual_4_Offset_Y
+    /// Get raw value of 'Virtual_4_Offset_Y'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -23209,7 +23209,7 @@ impl RtSbInsVpt4Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_4_Offset_Y
+    /// Set value of 'Virtual_4_Offset_Y'
     #[inline(always)]
     pub fn set_virtual_4_offset_y(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -23224,7 +23224,7 @@ impl RtSbInsVpt4Offset {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Virtual_4_Offset_X
+    /// Get value of 'Virtual_4_Offset_X'
     ///
     /// X offset of the virtual point in the vehicle body frame.
     ///
@@ -23236,7 +23236,7 @@ impl RtSbInsVpt4Offset {
     pub fn virtual_4_offset_x(&self) -> f32 {
         self.virtual_4_offset_x_raw()
     }
-    /// Get raw value of Virtual_4_Offset_X
+    /// Get raw value of 'Virtual_4_Offset_X'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -23251,7 +23251,7 @@ impl RtSbInsVpt4Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_4_Offset_X
+    /// Set value of 'Virtual_4_Offset_X'
     #[inline(always)]
     pub fn set_virtual_4_offset_x(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -23333,7 +23333,7 @@ impl RtSbInsVpt3VelNed2 {
     pub const VIRTUAL_3_HEADING_MAX: f32 = 180_f32;
     pub const VIRTUAL_3_VEL_NED_D_MIN: f32 = -838_f32;
     pub const VIRTUAL_3_VEL_NED_D_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_INS_Vpt_3_Vel_NED_2 from values
+    /// Construct new 'RT_SB_INS_Vpt_3_Vel_NED_2' from values
     pub fn new(
         virtual_3_slip: f32,
         virtual_3_heading: f32,
@@ -23349,7 +23349,7 @@ impl RtSbInsVpt3VelNed2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_3_Slip
+    /// Get value of 'Virtual_3_Slip'
     ///
     /// Slip is defined as the difference between yaw and heading.
     ///
@@ -23361,7 +23361,7 @@ impl RtSbInsVpt3VelNed2 {
     pub fn virtual_3_slip(&self) -> f32 {
         self.virtual_3_slip_raw()
     }
-    /// Get raw value of Virtual_3_Slip
+    /// Get raw value of 'Virtual_3_Slip'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -23376,7 +23376,7 @@ impl RtSbInsVpt3VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_3_Slip
+    /// Set value of 'Virtual_3_Slip'
     #[inline(always)]
     pub fn set_virtual_3_slip(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -23391,7 +23391,7 @@ impl RtSbInsVpt3VelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Virtual_3_Heading
+    /// Get value of 'Virtual_3_Heading'
     ///
     /// This is GPS heading, the direction that the vehicle is travelling in the local horizontal plane.
     ///
@@ -23403,7 +23403,7 @@ impl RtSbInsVpt3VelNed2 {
     pub fn virtual_3_heading(&self) -> f32 {
         self.virtual_3_heading_raw()
     }
-    /// Get raw value of Virtual_3_Heading
+    /// Get raw value of 'Virtual_3_Heading'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -23418,7 +23418,7 @@ impl RtSbInsVpt3VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_3_Heading
+    /// Set value of 'Virtual_3_Heading'
     #[inline(always)]
     pub fn set_virtual_3_heading(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -23433,7 +23433,7 @@ impl RtSbInsVpt3VelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Virtual_3_Vel_NED_D
+    /// Get value of 'Virtual_3_Vel_NED_D'
     ///
     /// VELNED D velocity.  This is the velocity vector directly downwards towards the Earth centre at the current local Earth surface position.
     ///
@@ -23445,7 +23445,7 @@ impl RtSbInsVpt3VelNed2 {
     pub fn virtual_3_vel_ned_d(&self) -> f32 {
         self.virtual_3_vel_ned_d_raw()
     }
-    /// Get raw value of Virtual_3_Vel_NED_D
+    /// Get raw value of 'Virtual_3_Vel_NED_D'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -23460,7 +23460,7 @@ impl RtSbInsVpt3VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_3_Vel_NED_D
+    /// Set value of 'Virtual_3_Vel_NED_D'
     #[inline(always)]
     pub fn set_virtual_3_vel_ned_d(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -23540,7 +23540,7 @@ impl RtSbInsVpt3VelNed1 {
     pub const VIRTUAL_3_VEL_NED_E_MAX: f32 = 838_f32;
     pub const VIRTUAL_3_VEL_NED_N_MIN: f32 = -838_f32;
     pub const VIRTUAL_3_VEL_NED_N_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_INS_Vpt_3_Vel_NED_1 from values
+    /// Construct new 'RT_SB_INS_Vpt_3_Vel_NED_1' from values
     pub fn new(
         virtual_3_vel_ned_e: f32,
         virtual_3_vel_ned_n: f32,
@@ -23554,7 +23554,7 @@ impl RtSbInsVpt3VelNed1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_3_Vel_NED_E
+    /// Get value of 'Virtual_3_Vel_NED_E'
     ///
     /// VELNED E velocity.  This is the velocity vector directly East at the current local Earth surface position.
     ///
@@ -23566,7 +23566,7 @@ impl RtSbInsVpt3VelNed1 {
     pub fn virtual_3_vel_ned_e(&self) -> f32 {
         self.virtual_3_vel_ned_e_raw()
     }
-    /// Get raw value of Virtual_3_Vel_NED_E
+    /// Get raw value of 'Virtual_3_Vel_NED_E'
     ///
     /// - Start bit: 32
     /// - Signal size: 24 bits
@@ -23581,7 +23581,7 @@ impl RtSbInsVpt3VelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_3_Vel_NED_E
+    /// Set value of 'Virtual_3_Vel_NED_E'
     #[inline(always)]
     pub fn set_virtual_3_vel_ned_e(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -23596,7 +23596,7 @@ impl RtSbInsVpt3VelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[32..56].store_le(value);
         Ok(())
     }
-    /// Virtual_3_Vel_NED_N
+    /// Get value of 'Virtual_3_Vel_NED_N'
     ///
     /// VELNED N velocity.  This is the velocity vector directly North at the current local Earth surface position.
     ///
@@ -23608,7 +23608,7 @@ impl RtSbInsVpt3VelNed1 {
     pub fn virtual_3_vel_ned_n(&self) -> f32 {
         self.virtual_3_vel_ned_n_raw()
     }
-    /// Get raw value of Virtual_3_Vel_NED_N
+    /// Get raw value of 'Virtual_3_Vel_NED_N'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -23623,7 +23623,7 @@ impl RtSbInsVpt3VelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_3_Vel_NED_N
+    /// Set value of 'Virtual_3_Vel_NED_N'
     #[inline(always)]
     pub fn set_virtual_3_vel_ned_n(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -23705,7 +23705,7 @@ impl RtSbInsVpt3Offset {
     pub const VIRTUAL_3_OFFSET_Y_MAX: f32 = 32.767_f32;
     pub const VIRTUAL_3_OFFSET_X_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_3_OFFSET_X_MAX: f32 = 32.767_f32;
-    /// Construct new RT_SB_INS_Vpt_3_Offset from values
+    /// Construct new 'RT_SB_INS_Vpt_3_Offset' from values
     pub fn new(
         virtual_3_offset_z: f32,
         virtual_3_offset_y: f32,
@@ -23721,7 +23721,7 @@ impl RtSbInsVpt3Offset {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_3_Offset_Z
+    /// Get value of 'Virtual_3_Offset_Z'
     ///
     /// Z offset (+ve downwards) of the virtual point in the vehicle body frame.
     ///
@@ -23733,7 +23733,7 @@ impl RtSbInsVpt3Offset {
     pub fn virtual_3_offset_z(&self) -> f32 {
         self.virtual_3_offset_z_raw()
     }
-    /// Get raw value of Virtual_3_Offset_Z
+    /// Get raw value of 'Virtual_3_Offset_Z'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -23748,7 +23748,7 @@ impl RtSbInsVpt3Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_3_Offset_Z
+    /// Set value of 'Virtual_3_Offset_Z'
     #[inline(always)]
     pub fn set_virtual_3_offset_z(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -23763,7 +23763,7 @@ impl RtSbInsVpt3Offset {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Virtual_3_Offset_Y
+    /// Get value of 'Virtual_3_Offset_Y'
     ///
     /// Y offset of the virtual point in the vehicle body frame.
     ///
@@ -23775,7 +23775,7 @@ impl RtSbInsVpt3Offset {
     pub fn virtual_3_offset_y(&self) -> f32 {
         self.virtual_3_offset_y_raw()
     }
-    /// Get raw value of Virtual_3_Offset_Y
+    /// Get raw value of 'Virtual_3_Offset_Y'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -23790,7 +23790,7 @@ impl RtSbInsVpt3Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_3_Offset_Y
+    /// Set value of 'Virtual_3_Offset_Y'
     #[inline(always)]
     pub fn set_virtual_3_offset_y(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -23805,7 +23805,7 @@ impl RtSbInsVpt3Offset {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Virtual_3_Offset_X
+    /// Get value of 'Virtual_3_Offset_X'
     ///
     /// X offset of the virtual point in the vehicle body frame.
     ///
@@ -23817,7 +23817,7 @@ impl RtSbInsVpt3Offset {
     pub fn virtual_3_offset_x(&self) -> f32 {
         self.virtual_3_offset_x_raw()
     }
-    /// Get raw value of Virtual_3_Offset_X
+    /// Get raw value of 'Virtual_3_Offset_X'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -23832,7 +23832,7 @@ impl RtSbInsVpt3Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_3_Offset_X
+    /// Set value of 'Virtual_3_Offset_X'
     #[inline(always)]
     pub fn set_virtual_3_offset_x(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -23914,7 +23914,7 @@ impl RtSbInsVpt2VelNed2 {
     pub const VIRTUAL_2_HEADING_MAX: f32 = 180_f32;
     pub const VIRTUAL_2_VEL_NED_D_MIN: f32 = -838_f32;
     pub const VIRTUAL_2_VEL_NED_D_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_INS_Vpt_2_Vel_NED_2 from values
+    /// Construct new 'RT_SB_INS_Vpt_2_Vel_NED_2' from values
     pub fn new(
         virtual_2_slip: f32,
         virtual_2_heading: f32,
@@ -23930,7 +23930,7 @@ impl RtSbInsVpt2VelNed2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_2_Slip
+    /// Get value of 'Virtual_2_Slip'
     ///
     /// Slip is defined as the difference between yaw and heading.
     ///
@@ -23942,7 +23942,7 @@ impl RtSbInsVpt2VelNed2 {
     pub fn virtual_2_slip(&self) -> f32 {
         self.virtual_2_slip_raw()
     }
-    /// Get raw value of Virtual_2_Slip
+    /// Get raw value of 'Virtual_2_Slip'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -23957,7 +23957,7 @@ impl RtSbInsVpt2VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_2_Slip
+    /// Set value of 'Virtual_2_Slip'
     #[inline(always)]
     pub fn set_virtual_2_slip(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -23972,7 +23972,7 @@ impl RtSbInsVpt2VelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Virtual_2_Heading
+    /// Get value of 'Virtual_2_Heading'
     ///
     /// This is GPS heading, the direction that the vehicle is travelling in the local horizontal plane.
     ///
@@ -23984,7 +23984,7 @@ impl RtSbInsVpt2VelNed2 {
     pub fn virtual_2_heading(&self) -> f32 {
         self.virtual_2_heading_raw()
     }
-    /// Get raw value of Virtual_2_Heading
+    /// Get raw value of 'Virtual_2_Heading'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -23999,7 +23999,7 @@ impl RtSbInsVpt2VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_2_Heading
+    /// Set value of 'Virtual_2_Heading'
     #[inline(always)]
     pub fn set_virtual_2_heading(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -24014,7 +24014,7 @@ impl RtSbInsVpt2VelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Virtual_2_Vel_NED_D
+    /// Get value of 'Virtual_2_Vel_NED_D'
     ///
     /// VELNED D velocity.  This is the velocity vector directly downwards towards the Earth centre at the current local Earth surface position.
     ///
@@ -24026,7 +24026,7 @@ impl RtSbInsVpt2VelNed2 {
     pub fn virtual_2_vel_ned_d(&self) -> f32 {
         self.virtual_2_vel_ned_d_raw()
     }
-    /// Get raw value of Virtual_2_Vel_NED_D
+    /// Get raw value of 'Virtual_2_Vel_NED_D'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -24041,7 +24041,7 @@ impl RtSbInsVpt2VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_2_Vel_NED_D
+    /// Set value of 'Virtual_2_Vel_NED_D'
     #[inline(always)]
     pub fn set_virtual_2_vel_ned_d(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -24121,7 +24121,7 @@ impl RtSbInsVpt2VelNed1 {
     pub const VIRTUAL_2_VEL_NED_E_MAX: f32 = 838_f32;
     pub const VIRTUAL_2_VEL_NED_N_MIN: f32 = -838_f32;
     pub const VIRTUAL_2_VEL_NED_N_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_INS_Vpt_2_Vel_NED_1 from values
+    /// Construct new 'RT_SB_INS_Vpt_2_Vel_NED_1' from values
     pub fn new(
         virtual_2_vel_ned_e: f32,
         virtual_2_vel_ned_n: f32,
@@ -24135,7 +24135,7 @@ impl RtSbInsVpt2VelNed1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_2_Vel_NED_E
+    /// Get value of 'Virtual_2_Vel_NED_E'
     ///
     /// VELNED E velocity.  This is the velocity vector directly East at the current local Earth surface position.
     ///
@@ -24147,7 +24147,7 @@ impl RtSbInsVpt2VelNed1 {
     pub fn virtual_2_vel_ned_e(&self) -> f32 {
         self.virtual_2_vel_ned_e_raw()
     }
-    /// Get raw value of Virtual_2_Vel_NED_E
+    /// Get raw value of 'Virtual_2_Vel_NED_E'
     ///
     /// - Start bit: 32
     /// - Signal size: 24 bits
@@ -24162,7 +24162,7 @@ impl RtSbInsVpt2VelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_2_Vel_NED_E
+    /// Set value of 'Virtual_2_Vel_NED_E'
     #[inline(always)]
     pub fn set_virtual_2_vel_ned_e(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -24177,7 +24177,7 @@ impl RtSbInsVpt2VelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[32..56].store_le(value);
         Ok(())
     }
-    /// Virtual_2_Vel_NED_N
+    /// Get value of 'Virtual_2_Vel_NED_N'
     ///
     /// VELNED N velocity.  This is the velocity vector directly North at the current local Earth surface position.
     ///
@@ -24189,7 +24189,7 @@ impl RtSbInsVpt2VelNed1 {
     pub fn virtual_2_vel_ned_n(&self) -> f32 {
         self.virtual_2_vel_ned_n_raw()
     }
-    /// Get raw value of Virtual_2_Vel_NED_N
+    /// Get raw value of 'Virtual_2_Vel_NED_N'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -24204,7 +24204,7 @@ impl RtSbInsVpt2VelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_2_Vel_NED_N
+    /// Set value of 'Virtual_2_Vel_NED_N'
     #[inline(always)]
     pub fn set_virtual_2_vel_ned_n(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -24286,7 +24286,7 @@ impl RtSbInsVpt2Offset {
     pub const VIRTUAL_2_OFFSET_Y_MAX: f32 = 32.767_f32;
     pub const VIRTUAL_2_OFFSET_X_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_2_OFFSET_X_MAX: f32 = 32.767_f32;
-    /// Construct new RT_SB_INS_Vpt_2_Offset from values
+    /// Construct new 'RT_SB_INS_Vpt_2_Offset' from values
     pub fn new(
         virtual_2_offset_z: f32,
         virtual_2_offset_y: f32,
@@ -24302,7 +24302,7 @@ impl RtSbInsVpt2Offset {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_2_Offset_Z
+    /// Get value of 'Virtual_2_Offset_Z'
     ///
     /// Z offset (+ve downwards) of the virtual point in the vehicle body frame.
     ///
@@ -24314,7 +24314,7 @@ impl RtSbInsVpt2Offset {
     pub fn virtual_2_offset_z(&self) -> f32 {
         self.virtual_2_offset_z_raw()
     }
-    /// Get raw value of Virtual_2_Offset_Z
+    /// Get raw value of 'Virtual_2_Offset_Z'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -24329,7 +24329,7 @@ impl RtSbInsVpt2Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_2_Offset_Z
+    /// Set value of 'Virtual_2_Offset_Z'
     #[inline(always)]
     pub fn set_virtual_2_offset_z(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -24344,7 +24344,7 @@ impl RtSbInsVpt2Offset {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Virtual_2_Offset_Y
+    /// Get value of 'Virtual_2_Offset_Y'
     ///
     /// Y offset of the virtual point in the vehicle body frame.
     ///
@@ -24356,7 +24356,7 @@ impl RtSbInsVpt2Offset {
     pub fn virtual_2_offset_y(&self) -> f32 {
         self.virtual_2_offset_y_raw()
     }
-    /// Get raw value of Virtual_2_Offset_Y
+    /// Get raw value of 'Virtual_2_Offset_Y'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -24371,7 +24371,7 @@ impl RtSbInsVpt2Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_2_Offset_Y
+    /// Set value of 'Virtual_2_Offset_Y'
     #[inline(always)]
     pub fn set_virtual_2_offset_y(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -24386,7 +24386,7 @@ impl RtSbInsVpt2Offset {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Virtual_2_Offset_X
+    /// Get value of 'Virtual_2_Offset_X'
     ///
     /// X offset of the virtual point in the vehicle body frame.
     ///
@@ -24398,7 +24398,7 @@ impl RtSbInsVpt2Offset {
     pub fn virtual_2_offset_x(&self) -> f32 {
         self.virtual_2_offset_x_raw()
     }
-    /// Get raw value of Virtual_2_Offset_X
+    /// Get raw value of 'Virtual_2_Offset_X'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -24413,7 +24413,7 @@ impl RtSbInsVpt2Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_2_Offset_X
+    /// Set value of 'Virtual_2_Offset_X'
     #[inline(always)]
     pub fn set_virtual_2_offset_x(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -24495,7 +24495,7 @@ impl RtSbInsVpt1VelNed2 {
     pub const VIRTUAL_1_HEADING_MAX: f32 = 180_f32;
     pub const VIRTUAL_1_VEL_NED_D_MIN: f32 = -838_f32;
     pub const VIRTUAL_1_VEL_NED_D_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_INS_Vpt_1_Vel_NED_2 from values
+    /// Construct new 'RT_SB_INS_Vpt_1_Vel_NED_2' from values
     pub fn new(
         virtual_1_slip: f32,
         virtual_1_heading: f32,
@@ -24511,7 +24511,7 @@ impl RtSbInsVpt1VelNed2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_1_Slip
+    /// Get value of 'Virtual_1_Slip'
     ///
     /// Slip is defined as the difference between yaw and heading.
     ///
@@ -24523,7 +24523,7 @@ impl RtSbInsVpt1VelNed2 {
     pub fn virtual_1_slip(&self) -> f32 {
         self.virtual_1_slip_raw()
     }
-    /// Get raw value of Virtual_1_Slip
+    /// Get raw value of 'Virtual_1_Slip'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -24538,7 +24538,7 @@ impl RtSbInsVpt1VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_1_Slip
+    /// Set value of 'Virtual_1_Slip'
     #[inline(always)]
     pub fn set_virtual_1_slip(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -24553,7 +24553,7 @@ impl RtSbInsVpt1VelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Virtual_1_Heading
+    /// Get value of 'Virtual_1_Heading'
     ///
     /// This is GPS heading, the direction that the vehicle is travelling in the local horizontal plane.
     ///
@@ -24565,7 +24565,7 @@ impl RtSbInsVpt1VelNed2 {
     pub fn virtual_1_heading(&self) -> f32 {
         self.virtual_1_heading_raw()
     }
-    /// Get raw value of Virtual_1_Heading
+    /// Get raw value of 'Virtual_1_Heading'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -24580,7 +24580,7 @@ impl RtSbInsVpt1VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_1_Heading
+    /// Set value of 'Virtual_1_Heading'
     #[inline(always)]
     pub fn set_virtual_1_heading(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -24595,7 +24595,7 @@ impl RtSbInsVpt1VelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Virtual_1_Vel_NED_D
+    /// Get value of 'Virtual_1_Vel_NED_D'
     ///
     /// VELNED D velocity.  This is the velocity vector directly downwards towards the Earth centre at the current local Earth surface position.
     ///
@@ -24607,7 +24607,7 @@ impl RtSbInsVpt1VelNed2 {
     pub fn virtual_1_vel_ned_d(&self) -> f32 {
         self.virtual_1_vel_ned_d_raw()
     }
-    /// Get raw value of Virtual_1_Vel_NED_D
+    /// Get raw value of 'Virtual_1_Vel_NED_D'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -24622,7 +24622,7 @@ impl RtSbInsVpt1VelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_1_Vel_NED_D
+    /// Set value of 'Virtual_1_Vel_NED_D'
     #[inline(always)]
     pub fn set_virtual_1_vel_ned_d(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -24702,7 +24702,7 @@ impl RtSbInsVpt1VelNed1 {
     pub const VIRTUAL_1_VEL_NED_E_MAX: f32 = 838_f32;
     pub const VIRTUAL_1_VEL_NED_N_MIN: f32 = -838_f32;
     pub const VIRTUAL_1_VEL_NED_N_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_INS_Vpt_1_Vel_NED_1 from values
+    /// Construct new 'RT_SB_INS_Vpt_1_Vel_NED_1' from values
     pub fn new(
         virtual_1_vel_ned_e: f32,
         virtual_1_vel_ned_n: f32,
@@ -24716,7 +24716,7 @@ impl RtSbInsVpt1VelNed1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_1_Vel_NED_E
+    /// Get value of 'Virtual_1_Vel_NED_E'
     ///
     /// VELNED E velocity.  This is the velocity vector directly East at the current local Earth surface position.
     ///
@@ -24728,7 +24728,7 @@ impl RtSbInsVpt1VelNed1 {
     pub fn virtual_1_vel_ned_e(&self) -> f32 {
         self.virtual_1_vel_ned_e_raw()
     }
-    /// Get raw value of Virtual_1_Vel_NED_E
+    /// Get raw value of 'Virtual_1_Vel_NED_E'
     ///
     /// - Start bit: 32
     /// - Signal size: 24 bits
@@ -24743,7 +24743,7 @@ impl RtSbInsVpt1VelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_1_Vel_NED_E
+    /// Set value of 'Virtual_1_Vel_NED_E'
     #[inline(always)]
     pub fn set_virtual_1_vel_ned_e(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -24758,7 +24758,7 @@ impl RtSbInsVpt1VelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[32..56].store_le(value);
         Ok(())
     }
-    /// Virtual_1_Vel_NED_N
+    /// Get value of 'Virtual_1_Vel_NED_N'
     ///
     /// VELNED N velocity.  This is the velocity vector directly North at the current local Earth surface position.
     ///
@@ -24770,7 +24770,7 @@ impl RtSbInsVpt1VelNed1 {
     pub fn virtual_1_vel_ned_n(&self) -> f32 {
         self.virtual_1_vel_ned_n_raw()
     }
-    /// Get raw value of Virtual_1_Vel_NED_N
+    /// Get raw value of 'Virtual_1_Vel_NED_N'
     ///
     /// - Start bit: 0
     /// - Signal size: 24 bits
@@ -24785,7 +24785,7 @@ impl RtSbInsVpt1VelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_1_Vel_NED_N
+    /// Set value of 'Virtual_1_Vel_NED_N'
     #[inline(always)]
     pub fn set_virtual_1_vel_ned_n(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -24867,7 +24867,7 @@ impl RtSbInsVpt1Offset {
     pub const VIRTUAL_1_OFFSET_Y_MAX: f32 = 32.767_f32;
     pub const VIRTUAL_1_OFFSET_X_MIN: f32 = -32.768_f32;
     pub const VIRTUAL_1_OFFSET_X_MAX: f32 = 32.767_f32;
-    /// Construct new RT_SB_INS_Vpt_1_Offset from values
+    /// Construct new 'RT_SB_INS_Vpt_1_Offset' from values
     pub fn new(
         virtual_1_offset_z: f32,
         virtual_1_offset_y: f32,
@@ -24883,7 +24883,7 @@ impl RtSbInsVpt1Offset {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Virtual_1_Offset_Z
+    /// Get value of 'Virtual_1_Offset_Z'
     ///
     /// Z offset (+ve downwards) of the virtual point in the vehicle body frame.
     ///
@@ -24895,7 +24895,7 @@ impl RtSbInsVpt1Offset {
     pub fn virtual_1_offset_z(&self) -> f32 {
         self.virtual_1_offset_z_raw()
     }
-    /// Get raw value of Virtual_1_Offset_Z
+    /// Get raw value of 'Virtual_1_Offset_Z'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -24910,7 +24910,7 @@ impl RtSbInsVpt1Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_1_Offset_Z
+    /// Set value of 'Virtual_1_Offset_Z'
     #[inline(always)]
     pub fn set_virtual_1_offset_z(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -24925,7 +24925,7 @@ impl RtSbInsVpt1Offset {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Virtual_1_Offset_Y
+    /// Get value of 'Virtual_1_Offset_Y'
     ///
     /// Y offset of the virtual point in the vehicle body frame.
     ///
@@ -24937,7 +24937,7 @@ impl RtSbInsVpt1Offset {
     pub fn virtual_1_offset_y(&self) -> f32 {
         self.virtual_1_offset_y_raw()
     }
-    /// Get raw value of Virtual_1_Offset_Y
+    /// Get raw value of 'Virtual_1_Offset_Y'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -24952,7 +24952,7 @@ impl RtSbInsVpt1Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_1_Offset_Y
+    /// Set value of 'Virtual_1_Offset_Y'
     #[inline(always)]
     pub fn set_virtual_1_offset_y(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -24967,7 +24967,7 @@ impl RtSbInsVpt1Offset {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Virtual_1_Offset_X
+    /// Get value of 'Virtual_1_Offset_X'
     ///
     /// X offset of the virtual point in the vehicle body frame.
     ///
@@ -24979,7 +24979,7 @@ impl RtSbInsVpt1Offset {
     pub fn virtual_1_offset_x(&self) -> f32 {
         self.virtual_1_offset_x_raw()
     }
-    /// Get raw value of Virtual_1_Offset_X
+    /// Get raw value of 'Virtual_1_Offset_X'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -24994,7 +24994,7 @@ impl RtSbInsVpt1Offset {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Virtual_1_Offset_X
+    /// Set value of 'Virtual_1_Offset_X'
     #[inline(always)]
     pub fn set_virtual_1_offset_x(&mut self, value: f32) -> Result<(), CanError> {
         if value < -32.768_f32 || 32.767_f32 < value {
@@ -25078,7 +25078,7 @@ impl RtSbInsSlip {
     pub const INS_SLIP_MAX: f32 = 360_f32;
     pub const ACCURACY_INS_SLIP_MIN: u8 = 0_u8;
     pub const ACCURACY_INS_SLIP_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Slip from values
+    /// Construct new 'RT_SB_INS_Slip' from values
     pub fn new(
         ins_squat: f32,
         accuracy_ins_squat: u8,
@@ -25100,7 +25100,7 @@ impl RtSbInsSlip {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Squat
+    /// Get value of 'INS_Squat'
     ///
     /// Squat is defined as the difference between pitch and gradient
     ///
@@ -25112,7 +25112,7 @@ impl RtSbInsSlip {
     pub fn ins_squat(&self) -> f32 {
         self.ins_squat_raw()
     }
-    /// Get raw value of INS_Squat
+    /// Get raw value of 'INS_Squat'
     ///
     /// - Start bit: 40
     /// - Signal size: 16 bits
@@ -25127,7 +25127,7 @@ impl RtSbInsSlip {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Squat
+    /// Set value of 'INS_Squat'
     #[inline(always)]
     pub fn set_ins_squat(&mut self, value: f32) -> Result<(), CanError> {
         if value < -360_f32 || 360_f32 < value {
@@ -25142,7 +25142,7 @@ impl RtSbInsSlip {
         self.raw.view_bits_mut::<Lsb0>()[40..56].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Squat
+    /// Get value of 'Accuracy_INS_Squat'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -25154,7 +25154,7 @@ impl RtSbInsSlip {
     pub fn accuracy_ins_squat(&self) -> u8 {
         self.accuracy_ins_squat_raw()
     }
-    /// Get raw value of Accuracy_INS_Squat
+    /// Get raw value of 'Accuracy_INS_Squat'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -25168,7 +25168,7 @@ impl RtSbInsSlip {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Squat
+    /// Set value of 'Accuracy_INS_Squat'
     #[inline(always)]
     pub fn set_accuracy_ins_squat(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -25186,7 +25186,7 @@ impl RtSbInsSlip {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// INS_Slip
+    /// Get value of 'INS_Slip'
     ///
     /// Slip is defined as the difference between yaw and heading
     ///
@@ -25198,7 +25198,7 @@ impl RtSbInsSlip {
     pub fn ins_slip(&self) -> f32 {
         self.ins_slip_raw()
     }
-    /// Get raw value of INS_Slip
+    /// Get raw value of 'INS_Slip'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -25213,7 +25213,7 @@ impl RtSbInsSlip {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Slip
+    /// Set value of 'INS_Slip'
     #[inline(always)]
     pub fn set_ins_slip(&mut self, value: f32) -> Result<(), CanError> {
         if value < -360_f32 || 360_f32 < value {
@@ -25228,7 +25228,7 @@ impl RtSbInsSlip {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Slip
+    /// Get value of 'Accuracy_INS_Slip'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -25240,7 +25240,7 @@ impl RtSbInsSlip {
     pub fn accuracy_ins_slip(&self) -> u8 {
         self.accuracy_ins_slip_raw()
     }
-    /// Get raw value of Accuracy_INS_Slip
+    /// Get raw value of 'Accuracy_INS_Slip'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -25254,7 +25254,7 @@ impl RtSbInsSlip {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Slip
+    /// Set value of 'Accuracy_INS_Slip'
     #[inline(always)]
     pub fn set_accuracy_ins_slip(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -25272,7 +25272,7 @@ impl RtSbInsSlip {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Squat
+    /// Get value of 'Validity_INS_Squat'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -25282,7 +25282,7 @@ impl RtSbInsSlip {
     pub fn validity_ins_squat(&self) -> bool {
         self.validity_ins_squat_raw()
     }
-    /// Get raw value of Validity_INS_Squat
+    /// Get raw value of 'Validity_INS_Squat'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -25295,14 +25295,14 @@ impl RtSbInsSlip {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Squat
+    /// Set value of 'Validity_INS_Squat'
     #[inline(always)]
     pub fn set_validity_ins_squat(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Slip
+    /// Get value of 'Validity_INS_Slip'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -25312,7 +25312,7 @@ impl RtSbInsSlip {
     pub fn validity_ins_slip(&self) -> bool {
         self.validity_ins_slip_raw()
     }
-    /// Get raw value of Validity_INS_Slip
+    /// Get raw value of 'Validity_INS_Slip'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -25325,7 +25325,7 @@ impl RtSbInsSlip {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Slip
+    /// Set value of 'Validity_INS_Slip'
     #[inline(always)]
     pub fn set_validity_ins_slip(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -25397,7 +25397,7 @@ impl RtSbInsVelEcef2 {
     pub const INS_VEL_ECEF_Z_MAX: f32 = 838_f32;
     pub const INS_VEL_ECEF_Y_MIN: f32 = -838_f32;
     pub const INS_VEL_ECEF_Y_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_INS_Vel_ECEF_2 from values
+    /// Construct new 'RT_SB_INS_Vel_ECEF_2' from values
     pub fn new(
         ins_vel_ecef_z: f32,
         ins_vel_ecef_y: f32,
@@ -25415,7 +25415,7 @@ impl RtSbInsVelEcef2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Vel_ECEF_Z
+    /// Get value of 'INS_Vel_ECEF_Z'
     ///
     /// ECEF Z velocity.  The ECEF Z axis originates from the Earth centre, and the positive Z axis intersects the Earth surface at the North Pole.
     ///
@@ -25427,7 +25427,7 @@ impl RtSbInsVelEcef2 {
     pub fn ins_vel_ecef_z(&self) -> f32 {
         self.ins_vel_ecef_z_raw()
     }
-    /// Get raw value of INS_Vel_ECEF_Z
+    /// Get raw value of 'INS_Vel_ECEF_Z'
     ///
     /// - Start bit: 32
     /// - Signal size: 24 bits
@@ -25442,7 +25442,7 @@ impl RtSbInsVelEcef2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Vel_ECEF_Z
+    /// Set value of 'INS_Vel_ECEF_Z'
     #[inline(always)]
     pub fn set_ins_vel_ecef_z(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -25457,7 +25457,7 @@ impl RtSbInsVelEcef2 {
         self.raw.view_bits_mut::<Lsb0>()[32..56].store_le(value);
         Ok(())
     }
-    /// INS_Vel_ECEF_Y
+    /// Get value of 'INS_Vel_ECEF_Y'
     ///
     /// ECEF Y velocity.  The ECEF Y axis originates from the Earth centre, and the positive Y axis intersects the Earth surface at zero degrees latittude and 90 degrees longitude.
     ///
@@ -25469,7 +25469,7 @@ impl RtSbInsVelEcef2 {
     pub fn ins_vel_ecef_y(&self) -> f32 {
         self.ins_vel_ecef_y_raw()
     }
-    /// Get raw value of INS_Vel_ECEF_Y
+    /// Get raw value of 'INS_Vel_ECEF_Y'
     ///
     /// - Start bit: 8
     /// - Signal size: 24 bits
@@ -25484,7 +25484,7 @@ impl RtSbInsVelEcef2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Vel_ECEF_Y
+    /// Set value of 'INS_Vel_ECEF_Y'
     #[inline(always)]
     pub fn set_ins_vel_ecef_y(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -25499,7 +25499,7 @@ impl RtSbInsVelEcef2 {
         self.raw.view_bits_mut::<Lsb0>()[8..32].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Vel_ECEF_Z
+    /// Get value of 'Validity_INS_Vel_ECEF_Z'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -25511,7 +25511,7 @@ impl RtSbInsVelEcef2 {
     pub fn validity_ins_vel_ecef_z(&self) -> bool {
         self.validity_ins_vel_ecef_z_raw()
     }
-    /// Get raw value of Validity_INS_Vel_ECEF_Z
+    /// Get raw value of 'Validity_INS_Vel_ECEF_Z'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -25524,14 +25524,14 @@ impl RtSbInsVelEcef2 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Vel_ECEF_Z
+    /// Set value of 'Validity_INS_Vel_ECEF_Z'
     #[inline(always)]
     pub fn set_validity_ins_vel_ecef_z(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Vel_ECEF_Y
+    /// Get value of 'Validity_INS_Vel_ECEF_Y'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -25543,7 +25543,7 @@ impl RtSbInsVelEcef2 {
     pub fn validity_ins_vel_ecef_y(&self) -> bool {
         self.validity_ins_vel_ecef_y_raw()
     }
-    /// Get raw value of Validity_INS_Vel_ECEF_Y
+    /// Get raw value of 'Validity_INS_Vel_ECEF_Y'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -25556,7 +25556,7 @@ impl RtSbInsVelEcef2 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Vel_ECEF_Y
+    /// Set value of 'Validity_INS_Vel_ECEF_Y'
     #[inline(always)]
     pub fn set_validity_ins_vel_ecef_y(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -25632,7 +25632,7 @@ impl RtSbInsVelEcef1 {
     pub const ACCURACY_INS_VEL_ECEF_Y_MAX: u8 = 255_u8;
     pub const ACCURACY_INS_VEL_ECEF_X_MIN: u8 = 0_u8;
     pub const ACCURACY_INS_VEL_ECEF_X_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Vel_ECEF_1 from values
+    /// Construct new 'RT_SB_INS_Vel_ECEF_1' from values
     pub fn new(
         ins_vel_ecef_x: f32,
         accuracy_ins_vel_ecef_z: u8,
@@ -25652,7 +25652,7 @@ impl RtSbInsVelEcef1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Vel_ECEF_X
+    /// Get value of 'INS_Vel_ECEF_X'
     ///
     /// ECEF X velocity.  The ECEF X axis originates from the Earth centre, and the positive X axis intersects the Earth surface at zero degrees latittude and zero degrees longitude (the intersection of the equator and the prime meridian).
     ///
@@ -25664,7 +25664,7 @@ impl RtSbInsVelEcef1 {
     pub fn ins_vel_ecef_x(&self) -> f32 {
         self.ins_vel_ecef_x_raw()
     }
-    /// Get raw value of INS_Vel_ECEF_X
+    /// Get raw value of 'INS_Vel_ECEF_X'
     ///
     /// - Start bit: 32
     /// - Signal size: 24 bits
@@ -25679,7 +25679,7 @@ impl RtSbInsVelEcef1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Vel_ECEF_X
+    /// Set value of 'INS_Vel_ECEF_X'
     #[inline(always)]
     pub fn set_ins_vel_ecef_x(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -25694,7 +25694,7 @@ impl RtSbInsVelEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[32..56].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Vel_ECEF_Z
+    /// Get value of 'Accuracy_INS_Vel_ECEF_Z'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -25704,7 +25704,7 @@ impl RtSbInsVelEcef1 {
     pub fn accuracy_ins_vel_ecef_z(&self) -> u8 {
         self.accuracy_ins_vel_ecef_z_raw()
     }
-    /// Get raw value of Accuracy_INS_Vel_ECEF_Z
+    /// Get raw value of 'Accuracy_INS_Vel_ECEF_Z'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -25718,7 +25718,7 @@ impl RtSbInsVelEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Vel_ECEF_Z
+    /// Set value of 'Accuracy_INS_Vel_ECEF_Z'
     #[inline(always)]
     pub fn set_accuracy_ins_vel_ecef_z(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -25736,7 +25736,7 @@ impl RtSbInsVelEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Vel_ECEF_Y
+    /// Get value of 'Accuracy_INS_Vel_ECEF_Y'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -25746,7 +25746,7 @@ impl RtSbInsVelEcef1 {
     pub fn accuracy_ins_vel_ecef_y(&self) -> u8 {
         self.accuracy_ins_vel_ecef_y_raw()
     }
-    /// Get raw value of Accuracy_INS_Vel_ECEF_Y
+    /// Get raw value of 'Accuracy_INS_Vel_ECEF_Y'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -25760,7 +25760,7 @@ impl RtSbInsVelEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Vel_ECEF_Y
+    /// Set value of 'Accuracy_INS_Vel_ECEF_Y'
     #[inline(always)]
     pub fn set_accuracy_ins_vel_ecef_y(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -25778,7 +25778,7 @@ impl RtSbInsVelEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Vel_ECEF_X
+    /// Get value of 'Accuracy_INS_Vel_ECEF_X'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -25788,7 +25788,7 @@ impl RtSbInsVelEcef1 {
     pub fn accuracy_ins_vel_ecef_x(&self) -> u8 {
         self.accuracy_ins_vel_ecef_x_raw()
     }
-    /// Get raw value of Accuracy_INS_Vel_ECEF_X
+    /// Get raw value of 'Accuracy_INS_Vel_ECEF_X'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -25802,7 +25802,7 @@ impl RtSbInsVelEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Vel_ECEF_X
+    /// Set value of 'Accuracy_INS_Vel_ECEF_X'
     #[inline(always)]
     pub fn set_accuracy_ins_vel_ecef_x(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -25820,7 +25820,7 @@ impl RtSbInsVelEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Vel_ECEF_X
+    /// Get value of 'Validity_INS_Vel_ECEF_X'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -25832,7 +25832,7 @@ impl RtSbInsVelEcef1 {
     pub fn validity_ins_vel_ecef_x(&self) -> bool {
         self.validity_ins_vel_ecef_x_raw()
     }
-    /// Get raw value of Validity_INS_Vel_ECEF_X
+    /// Get raw value of 'Validity_INS_Vel_ECEF_X'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -25845,7 +25845,7 @@ impl RtSbInsVelEcef1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Vel_ECEF_X
+    /// Set value of 'Validity_INS_Vel_ECEF_X'
     #[inline(always)]
     pub fn set_validity_ins_vel_ecef_x(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -25917,7 +25917,7 @@ impl RtSbInsVelNed2 {
     pub const INS_VEL_NED_D_MAX: f32 = 838_f32;
     pub const ACCURACY_INS_VEL_D_MIN: u8 = 0_u8;
     pub const ACCURACY_INS_VEL_D_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Vel_NED_2 from values
+    /// Construct new 'RT_SB_INS_Vel_NED_2' from values
     pub fn new(
         ins_vel_ned_d: f32,
         accuracy_ins_vel_d: u8,
@@ -25933,7 +25933,7 @@ impl RtSbInsVelNed2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Vel_NED_D
+    /// Get value of 'INS_Vel_NED_D'
     ///
     /// VELNED D velocity.  This is the velocity vector directly downwards towards the Earth centre at the current local Earth surface position.
     ///
@@ -25945,7 +25945,7 @@ impl RtSbInsVelNed2 {
     pub fn ins_vel_ned_d(&self) -> f32 {
         self.ins_vel_ned_d_raw()
     }
-    /// Get raw value of INS_Vel_NED_D
+    /// Get raw value of 'INS_Vel_NED_D'
     ///
     /// - Start bit: 16
     /// - Signal size: 24 bits
@@ -25960,7 +25960,7 @@ impl RtSbInsVelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Vel_NED_D
+    /// Set value of 'INS_Vel_NED_D'
     #[inline(always)]
     pub fn set_ins_vel_ned_d(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -25975,7 +25975,7 @@ impl RtSbInsVelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[16..40].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Vel_D
+    /// Get value of 'Accuracy_INS_Vel_D'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -25985,7 +25985,7 @@ impl RtSbInsVelNed2 {
     pub fn accuracy_ins_vel_d(&self) -> u8 {
         self.accuracy_ins_vel_d_raw()
     }
-    /// Get raw value of Accuracy_INS_Vel_D
+    /// Get raw value of 'Accuracy_INS_Vel_D'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -25999,7 +25999,7 @@ impl RtSbInsVelNed2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Vel_D
+    /// Set value of 'Accuracy_INS_Vel_D'
     #[inline(always)]
     pub fn set_accuracy_ins_vel_d(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -26017,7 +26017,7 @@ impl RtSbInsVelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Vel_NED_D
+    /// Get value of 'Validity_INS_Vel_NED_D'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -26029,7 +26029,7 @@ impl RtSbInsVelNed2 {
     pub fn validity_ins_vel_ned_d(&self) -> bool {
         self.validity_ins_vel_ned_d_raw()
     }
-    /// Get raw value of Validity_INS_Vel_NED_D
+    /// Get raw value of 'Validity_INS_Vel_NED_D'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -26042,7 +26042,7 @@ impl RtSbInsVelNed2 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Vel_NED_D
+    /// Set value of 'Validity_INS_Vel_NED_D'
     #[inline(always)]
     pub fn set_validity_ins_vel_ned_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -26116,7 +26116,7 @@ impl RtSbInsVelNed1 {
     pub const INS_VEL_NED_N_MAX: f32 = 838_f32;
     pub const ACCURACY_INS_VEL_NE_MIN: u8 = 0_u8;
     pub const ACCURACY_INS_VEL_NE_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Vel_NED_1 from values
+    /// Construct new 'RT_SB_INS_Vel_NED_1' from values
     pub fn new(
         ins_vel_ned_e: f32,
         ins_vel_ned_n: f32,
@@ -26136,7 +26136,7 @@ impl RtSbInsVelNed1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Vel_NED_E
+    /// Get value of 'INS_Vel_NED_E'
     ///
     /// VELNED E velocity.  This is the velocity vector directly East at the current local Earth surface position.
     ///
@@ -26148,7 +26148,7 @@ impl RtSbInsVelNed1 {
     pub fn ins_vel_ned_e(&self) -> f32 {
         self.ins_vel_ned_e_raw()
     }
-    /// Get raw value of INS_Vel_NED_E
+    /// Get raw value of 'INS_Vel_NED_E'
     ///
     /// - Start bit: 40
     /// - Signal size: 24 bits
@@ -26163,7 +26163,7 @@ impl RtSbInsVelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Vel_NED_E
+    /// Set value of 'INS_Vel_NED_E'
     #[inline(always)]
     pub fn set_ins_vel_ned_e(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -26178,7 +26178,7 @@ impl RtSbInsVelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[40..64].store_le(value);
         Ok(())
     }
-    /// INS_Vel_NED_N
+    /// Get value of 'INS_Vel_NED_N'
     ///
     /// VELNED N velocity.  This is the velocity vector directly North at the current local Earth surface position.
     ///
@@ -26190,7 +26190,7 @@ impl RtSbInsVelNed1 {
     pub fn ins_vel_ned_n(&self) -> f32 {
         self.ins_vel_ned_n_raw()
     }
-    /// Get raw value of INS_Vel_NED_N
+    /// Get raw value of 'INS_Vel_NED_N'
     ///
     /// - Start bit: 16
     /// - Signal size: 24 bits
@@ -26205,7 +26205,7 @@ impl RtSbInsVelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Vel_NED_N
+    /// Set value of 'INS_Vel_NED_N'
     #[inline(always)]
     pub fn set_ins_vel_ned_n(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -26220,7 +26220,7 @@ impl RtSbInsVelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[16..40].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Vel_NE
+    /// Get value of 'Accuracy_INS_Vel_NE'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -26230,7 +26230,7 @@ impl RtSbInsVelNed1 {
     pub fn accuracy_ins_vel_ne(&self) -> u8 {
         self.accuracy_ins_vel_ne_raw()
     }
-    /// Get raw value of Accuracy_INS_Vel_NE
+    /// Get raw value of 'Accuracy_INS_Vel_NE'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -26244,7 +26244,7 @@ impl RtSbInsVelNed1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Vel_NE
+    /// Set value of 'Accuracy_INS_Vel_NE'
     #[inline(always)]
     pub fn set_accuracy_ins_vel_ne(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -26262,7 +26262,7 @@ impl RtSbInsVelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Vel_NED_E
+    /// Get value of 'Validity_INS_Vel_NED_E'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -26274,7 +26274,7 @@ impl RtSbInsVelNed1 {
     pub fn validity_ins_vel_ned_e(&self) -> bool {
         self.validity_ins_vel_ned_e_raw()
     }
-    /// Get raw value of Validity_INS_Vel_NED_E
+    /// Get raw value of 'Validity_INS_Vel_NED_E'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -26287,14 +26287,14 @@ impl RtSbInsVelNed1 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Vel_NED_E
+    /// Set value of 'Validity_INS_Vel_NED_E'
     #[inline(always)]
     pub fn set_validity_ins_vel_ned_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Vel_NED_N
+    /// Get value of 'Validity_INS_Vel_NED_N'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -26306,7 +26306,7 @@ impl RtSbInsVelNed1 {
     pub fn validity_ins_vel_ned_n(&self) -> bool {
         self.validity_ins_vel_ned_n_raw()
     }
-    /// Get raw value of Validity_INS_Vel_NED_N
+    /// Get raw value of 'Validity_INS_Vel_NED_N'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -26319,7 +26319,7 @@ impl RtSbInsVelNed1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Vel_NED_N
+    /// Set value of 'Validity_INS_Vel_NED_N'
     #[inline(always)]
     pub fn set_validity_ins_vel_ned_n(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -26391,7 +26391,7 @@ impl RtSbInsPosEcef2 {
     pub const INS_POS_ECEF_Z_MAX: f32 = 10000000_f32;
     pub const INS_POS_ECEF_Y_MIN: f32 = -10000000_f32;
     pub const INS_POS_ECEF_Y_MAX: f32 = 10000000_f32;
-    /// Construct new RT_SB_INS_Pos_ECEF_2 from values
+    /// Construct new 'RT_SB_INS_Pos_ECEF_2' from values
     pub fn new(ins_pos_ecef_z: f32, ins_pos_ecef_y: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_ins_pos_ecef_z(ins_pos_ecef_z)?;
@@ -26402,7 +26402,7 @@ impl RtSbInsPosEcef2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Pos_ECEF_Z
+    /// Get value of 'INS_Pos_ECEF_Z'
     ///
     /// ECEF Z position.  The ECEF Z axis originates from the Earth centre, and the positive Z axis intersects the Earth surface at the North Pole.
     ///
@@ -26414,7 +26414,7 @@ impl RtSbInsPosEcef2 {
     pub fn ins_pos_ecef_z(&self) -> f32 {
         self.ins_pos_ecef_z_raw()
     }
-    /// Get raw value of INS_Pos_ECEF_Z
+    /// Get raw value of 'INS_Pos_ECEF_Z'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -26429,7 +26429,7 @@ impl RtSbInsPosEcef2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Pos_ECEF_Z
+    /// Set value of 'INS_Pos_ECEF_Z'
     #[inline(always)]
     pub fn set_ins_pos_ecef_z(&mut self, value: f32) -> Result<(), CanError> {
         if value < -10000000_f32 || 10000000_f32 < value {
@@ -26444,7 +26444,7 @@ impl RtSbInsPosEcef2 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// INS_Pos_ECEF_Y
+    /// Get value of 'INS_Pos_ECEF_Y'
     ///
     /// ECEF Y position.  The ECEF Y axis originates from the Earth centre, and the positive Y axis intersects the Earth surface at zero degrees latittude and 90 degrees longitude.
     ///
@@ -26456,7 +26456,7 @@ impl RtSbInsPosEcef2 {
     pub fn ins_pos_ecef_y(&self) -> f32 {
         self.ins_pos_ecef_y_raw()
     }
-    /// Get raw value of INS_Pos_ECEF_Y
+    /// Get raw value of 'INS_Pos_ECEF_Y'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -26471,7 +26471,7 @@ impl RtSbInsPosEcef2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Pos_ECEF_Y
+    /// Set value of 'INS_Pos_ECEF_Y'
     #[inline(always)]
     pub fn set_ins_pos_ecef_y(&mut self, value: f32) -> Result<(), CanError> {
         if value < -10000000_f32 || 10000000_f32 < value {
@@ -26555,7 +26555,7 @@ impl RtSbInsPosEcef1 {
     pub const ACCURACY_INS_POS_ECEF_Y_MAX: u8 = 255_u8;
     pub const ACCURACY_INS_POS_ECEF_X_MIN: u8 = 0_u8;
     pub const ACCURACY_INS_POS_ECEF_X_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Pos_ECEF_1 from values
+    /// Construct new 'RT_SB_INS_Pos_ECEF_1' from values
     pub fn new(
         ins_pos_ecef_x: f32,
         accuracy_ins_pos_ecef_z: u8,
@@ -26579,7 +26579,7 @@ impl RtSbInsPosEcef1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Pos_ECEF_X
+    /// Get value of 'INS_Pos_ECEF_X'
     ///
     /// ECEF X position.  The ECEF X axis originates from the Earth centre, and the positive X axis intersects the Earth surface at zero degrees latittude and zero degrees longitude (the intersection of the equator and the prime meridian).
     ///
@@ -26591,7 +26591,7 @@ impl RtSbInsPosEcef1 {
     pub fn ins_pos_ecef_x(&self) -> f32 {
         self.ins_pos_ecef_x_raw()
     }
-    /// Get raw value of INS_Pos_ECEF_X
+    /// Get raw value of 'INS_Pos_ECEF_X'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -26606,7 +26606,7 @@ impl RtSbInsPosEcef1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Pos_ECEF_X
+    /// Set value of 'INS_Pos_ECEF_X'
     #[inline(always)]
     pub fn set_ins_pos_ecef_x(&mut self, value: f32) -> Result<(), CanError> {
         if value < -10000000_f32 || 10000000_f32 < value {
@@ -26621,7 +26621,7 @@ impl RtSbInsPosEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Pos_ECEF_Z
+    /// Get value of 'Accuracy_INS_Pos_ECEF_Z'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -26633,7 +26633,7 @@ impl RtSbInsPosEcef1 {
     pub fn accuracy_ins_pos_ecef_z(&self) -> u8 {
         self.accuracy_ins_pos_ecef_z_raw()
     }
-    /// Get raw value of Accuracy_INS_Pos_ECEF_Z
+    /// Get raw value of 'Accuracy_INS_Pos_ECEF_Z'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -26647,7 +26647,7 @@ impl RtSbInsPosEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Pos_ECEF_Z
+    /// Set value of 'Accuracy_INS_Pos_ECEF_Z'
     #[inline(always)]
     pub fn set_accuracy_ins_pos_ecef_z(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -26665,7 +26665,7 @@ impl RtSbInsPosEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Pos_ECEF_Y
+    /// Get value of 'Accuracy_INS_Pos_ECEF_Y'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -26677,7 +26677,7 @@ impl RtSbInsPosEcef1 {
     pub fn accuracy_ins_pos_ecef_y(&self) -> u8 {
         self.accuracy_ins_pos_ecef_y_raw()
     }
-    /// Get raw value of Accuracy_INS_Pos_ECEF_Y
+    /// Get raw value of 'Accuracy_INS_Pos_ECEF_Y'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -26691,7 +26691,7 @@ impl RtSbInsPosEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Pos_ECEF_Y
+    /// Set value of 'Accuracy_INS_Pos_ECEF_Y'
     #[inline(always)]
     pub fn set_accuracy_ins_pos_ecef_y(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -26709,7 +26709,7 @@ impl RtSbInsPosEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Pos_ECEF_X
+    /// Get value of 'Accuracy_INS_Pos_ECEF_X'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -26721,7 +26721,7 @@ impl RtSbInsPosEcef1 {
     pub fn accuracy_ins_pos_ecef_x(&self) -> u8 {
         self.accuracy_ins_pos_ecef_x_raw()
     }
-    /// Get raw value of Accuracy_INS_Pos_ECEF_X
+    /// Get raw value of 'Accuracy_INS_Pos_ECEF_X'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -26735,7 +26735,7 @@ impl RtSbInsPosEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Pos_ECEF_X
+    /// Set value of 'Accuracy_INS_Pos_ECEF_X'
     #[inline(always)]
     pub fn set_accuracy_ins_pos_ecef_x(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -26753,7 +26753,7 @@ impl RtSbInsPosEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Pos_ECEF_Z
+    /// Get value of 'Validity_INS_Pos_ECEF_Z'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -26765,7 +26765,7 @@ impl RtSbInsPosEcef1 {
     pub fn validity_ins_pos_ecef_z(&self) -> bool {
         self.validity_ins_pos_ecef_z_raw()
     }
-    /// Get raw value of Validity_INS_Pos_ECEF_Z
+    /// Get raw value of 'Validity_INS_Pos_ECEF_Z'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -26778,14 +26778,14 @@ impl RtSbInsPosEcef1 {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Pos_ECEF_Z
+    /// Set value of 'Validity_INS_Pos_ECEF_Z'
     #[inline(always)]
     pub fn set_validity_ins_pos_ecef_z(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Pos_ECEF_Y
+    /// Get value of 'Validity_INS_Pos_ECEF_Y'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -26797,7 +26797,7 @@ impl RtSbInsPosEcef1 {
     pub fn validity_ins_pos_ecef_y(&self) -> bool {
         self.validity_ins_pos_ecef_y_raw()
     }
-    /// Get raw value of Validity_INS_Pos_ECEF_Y
+    /// Get raw value of 'Validity_INS_Pos_ECEF_Y'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -26810,14 +26810,14 @@ impl RtSbInsPosEcef1 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Pos_ECEF_Y
+    /// Set value of 'Validity_INS_Pos_ECEF_Y'
     #[inline(always)]
     pub fn set_validity_ins_pos_ecef_y(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Pos_ECEF_X
+    /// Get value of 'Validity_INS_Pos_ECEF_X'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -26829,7 +26829,7 @@ impl RtSbInsPosEcef1 {
     pub fn validity_ins_pos_ecef_x(&self) -> bool {
         self.validity_ins_pos_ecef_x_raw()
     }
-    /// Get raw value of Validity_INS_Pos_ECEF_X
+    /// Get raw value of 'Validity_INS_Pos_ECEF_X'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -26842,7 +26842,7 @@ impl RtSbInsPosEcef1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Pos_ECEF_X
+    /// Set value of 'Validity_INS_Pos_ECEF_X'
     #[inline(always)]
     pub fn set_validity_ins_pos_ecef_x(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -26914,7 +26914,7 @@ impl RtSbInsPosLlh2 {
     pub const INS_POS_LLH_ALTITUDE_MAX: f32 = 100000_f32;
     pub const INS_POS_LLH_LONGITUDE_MIN: f32 = -180_f32;
     pub const INS_POS_LLH_LONGITUDE_MAX: f32 = 180_f32;
-    /// Construct new RT_SB_INS_Pos_LLH_2 from values
+    /// Construct new 'RT_SB_INS_Pos_LLH_2' from values
     pub fn new(
         ins_pos_llh_altitude: f32,
         ins_pos_llh_longitude: f32,
@@ -26928,7 +26928,7 @@ impl RtSbInsPosLlh2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Pos_LLH_Altitude
+    /// Get value of 'INS_Pos_LLH_Altitude'
     ///
     /// - Min: -1000
     /// - Max: 100000
@@ -26938,7 +26938,7 @@ impl RtSbInsPosLlh2 {
     pub fn ins_pos_llh_altitude(&self) -> f32 {
         self.ins_pos_llh_altitude_raw()
     }
-    /// Get raw value of INS_Pos_LLH_Altitude
+    /// Get raw value of 'INS_Pos_LLH_Altitude'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -26953,7 +26953,7 @@ impl RtSbInsPosLlh2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Pos_LLH_Altitude
+    /// Set value of 'INS_Pos_LLH_Altitude'
     #[inline(always)]
     pub fn set_ins_pos_llh_altitude(&mut self, value: f32) -> Result<(), CanError> {
         if value < -1000_f32 || 100000_f32 < value {
@@ -26968,7 +26968,7 @@ impl RtSbInsPosLlh2 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// INS_Pos_LLH_Longitude
+    /// Get value of 'INS_Pos_LLH_Longitude'
     ///
     /// - Min: -180
     /// - Max: 180
@@ -26978,7 +26978,7 @@ impl RtSbInsPosLlh2 {
     pub fn ins_pos_llh_longitude(&self) -> f32 {
         self.ins_pos_llh_longitude_raw()
     }
-    /// Get raw value of INS_Pos_LLH_Longitude
+    /// Get raw value of 'INS_Pos_LLH_Longitude'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -26993,7 +26993,7 @@ impl RtSbInsPosLlh2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Pos_LLH_Longitude
+    /// Set value of 'INS_Pos_LLH_Longitude'
     #[inline(always)]
     pub fn set_ins_pos_llh_longitude(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -27077,7 +27077,7 @@ impl RtSbInsPosLlh1 {
     pub const ACCURACY_INS_POS_LLH_LONGITUDE_MAX: u8 = 255_u8;
     pub const ACCURACY_INS_POS_LLH_LATITUDE_MIN: u8 = 0_u8;
     pub const ACCURACY_INS_POS_LLH_LATITUDE_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Pos_LLH_1 from values
+    /// Construct new 'RT_SB_INS_Pos_LLH_1' from values
     pub fn new(
         ins_pos_llh_latitude: f32,
         accuracy_ins_pos_llh_altitude: u8,
@@ -27101,7 +27101,7 @@ impl RtSbInsPosLlh1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Pos_LLH_Latitude
+    /// Get value of 'INS_Pos_LLH_Latitude'
     ///
     /// - Min: -90
     /// - Max: 90
@@ -27111,7 +27111,7 @@ impl RtSbInsPosLlh1 {
     pub fn ins_pos_llh_latitude(&self) -> f32 {
         self.ins_pos_llh_latitude_raw()
     }
-    /// Get raw value of INS_Pos_LLH_Latitude
+    /// Get raw value of 'INS_Pos_LLH_Latitude'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -27126,7 +27126,7 @@ impl RtSbInsPosLlh1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Pos_LLH_Latitude
+    /// Set value of 'INS_Pos_LLH_Latitude'
     #[inline(always)]
     pub fn set_ins_pos_llh_latitude(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -27141,7 +27141,7 @@ impl RtSbInsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Pos_LLH_Altitude
+    /// Get value of 'Accuracy_INS_Pos_LLH_Altitude'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -27153,7 +27153,7 @@ impl RtSbInsPosLlh1 {
     pub fn accuracy_ins_pos_llh_altitude(&self) -> u8 {
         self.accuracy_ins_pos_llh_altitude_raw()
     }
-    /// Get raw value of Accuracy_INS_Pos_LLH_Altitude
+    /// Get raw value of 'Accuracy_INS_Pos_LLH_Altitude'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -27167,7 +27167,7 @@ impl RtSbInsPosLlh1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Pos_LLH_Altitude
+    /// Set value of 'Accuracy_INS_Pos_LLH_Altitude'
     #[inline(always)]
     pub fn set_accuracy_ins_pos_llh_altitude(
         &mut self,
@@ -27188,7 +27188,7 @@ impl RtSbInsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Pos_LLH_Longitude
+    /// Get value of 'Accuracy_INS_Pos_LLH_Longitude'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -27200,7 +27200,7 @@ impl RtSbInsPosLlh1 {
     pub fn accuracy_ins_pos_llh_longitude(&self) -> u8 {
         self.accuracy_ins_pos_llh_longitude_raw()
     }
-    /// Get raw value of Accuracy_INS_Pos_LLH_Longitude
+    /// Get raw value of 'Accuracy_INS_Pos_LLH_Longitude'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -27214,7 +27214,7 @@ impl RtSbInsPosLlh1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Pos_LLH_Longitude
+    /// Set value of 'Accuracy_INS_Pos_LLH_Longitude'
     #[inline(always)]
     pub fn set_accuracy_ins_pos_llh_longitude(
         &mut self,
@@ -27235,7 +27235,7 @@ impl RtSbInsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Pos_LLH_Latitude
+    /// Get value of 'Accuracy_INS_Pos_LLH_Latitude'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -27247,7 +27247,7 @@ impl RtSbInsPosLlh1 {
     pub fn accuracy_ins_pos_llh_latitude(&self) -> u8 {
         self.accuracy_ins_pos_llh_latitude_raw()
     }
-    /// Get raw value of Accuracy_INS_Pos_LLH_Latitude
+    /// Get raw value of 'Accuracy_INS_Pos_LLH_Latitude'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -27261,7 +27261,7 @@ impl RtSbInsPosLlh1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Pos_LLH_Latitude
+    /// Set value of 'Accuracy_INS_Pos_LLH_Latitude'
     #[inline(always)]
     pub fn set_accuracy_ins_pos_llh_latitude(
         &mut self,
@@ -27282,7 +27282,7 @@ impl RtSbInsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Pos_LLH_Altitude
+    /// Get value of 'Validity_INS_Pos_LLH_Altitude'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -27294,7 +27294,7 @@ impl RtSbInsPosLlh1 {
     pub fn validity_ins_pos_llh_altitude(&self) -> bool {
         self.validity_ins_pos_llh_altitude_raw()
     }
-    /// Get raw value of Validity_INS_Pos_LLH_Altitude
+    /// Get raw value of 'Validity_INS_Pos_LLH_Altitude'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -27307,7 +27307,7 @@ impl RtSbInsPosLlh1 {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Pos_LLH_Altitude
+    /// Set value of 'Validity_INS_Pos_LLH_Altitude'
     #[inline(always)]
     pub fn set_validity_ins_pos_llh_altitude(
         &mut self,
@@ -27317,7 +27317,7 @@ impl RtSbInsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Pos_LLH_Longitude
+    /// Get value of 'Validity_INS_Pos_LLH_Longitude'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -27329,7 +27329,7 @@ impl RtSbInsPosLlh1 {
     pub fn validity_ins_pos_llh_longitude(&self) -> bool {
         self.validity_ins_pos_llh_longitude_raw()
     }
-    /// Get raw value of Validity_INS_Pos_LLH_Longitude
+    /// Get raw value of 'Validity_INS_Pos_LLH_Longitude'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -27342,7 +27342,7 @@ impl RtSbInsPosLlh1 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Pos_LLH_Longitude
+    /// Set value of 'Validity_INS_Pos_LLH_Longitude'
     #[inline(always)]
     pub fn set_validity_ins_pos_llh_longitude(
         &mut self,
@@ -27352,7 +27352,7 @@ impl RtSbInsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Pos_LLH_Latitude
+    /// Get value of 'Validity_INS_Pos_LLH_Latitude'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -27364,7 +27364,7 @@ impl RtSbInsPosLlh1 {
     pub fn validity_ins_pos_llh_latitude(&self) -> bool {
         self.validity_ins_pos_llh_latitude_raw()
     }
-    /// Get raw value of Validity_INS_Pos_LLH_Latitude
+    /// Get raw value of 'Validity_INS_Pos_LLH_Latitude'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -27377,7 +27377,7 @@ impl RtSbInsPosLlh1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Pos_LLH_Latitude
+    /// Set value of 'Validity_INS_Pos_LLH_Latitude'
     #[inline(always)]
     pub fn set_validity_ins_pos_llh_latitude(
         &mut self,
@@ -27456,7 +27456,7 @@ impl RtSbInsHeadingGradient2 {
     pub const INS_HEADING_2_MAX: f32 = 360_f32;
     pub const ACCURACY_INS_HEADING_MIN: u8 = 0_u8;
     pub const ACCURACY_INS_HEADING_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Heading_Gradient_2 from values
+    /// Construct new 'RT_SB_INS_Heading_Gradient_2' from values
     pub fn new(
         ins_gradient: f32,
         accuracy_ins_gradient: u8,
@@ -27478,7 +27478,7 @@ impl RtSbInsHeadingGradient2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Gradient
+    /// Get value of 'INS_Gradient'
     ///
     /// This is GPS gradient, i.e. the vertical direction that the vehicle is travelling, NOT pointing (pitch).
     ///
@@ -27490,7 +27490,7 @@ impl RtSbInsHeadingGradient2 {
     pub fn ins_gradient(&self) -> f32 {
         self.ins_gradient_raw()
     }
-    /// Get raw value of INS_Gradient
+    /// Get raw value of 'INS_Gradient'
     ///
     /// - Start bit: 40
     /// - Signal size: 16 bits
@@ -27505,7 +27505,7 @@ impl RtSbInsHeadingGradient2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Gradient
+    /// Set value of 'INS_Gradient'
     #[inline(always)]
     pub fn set_ins_gradient(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -27520,7 +27520,7 @@ impl RtSbInsHeadingGradient2 {
         self.raw.view_bits_mut::<Lsb0>()[40..56].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Gradient
+    /// Get value of 'Accuracy_INS_Gradient'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -27532,7 +27532,7 @@ impl RtSbInsHeadingGradient2 {
     pub fn accuracy_ins_gradient(&self) -> u8 {
         self.accuracy_ins_gradient_raw()
     }
-    /// Get raw value of Accuracy_INS_Gradient
+    /// Get raw value of 'Accuracy_INS_Gradient'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -27546,7 +27546,7 @@ impl RtSbInsHeadingGradient2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Gradient
+    /// Set value of 'Accuracy_INS_Gradient'
     #[inline(always)]
     pub fn set_accuracy_ins_gradient(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -27564,7 +27564,7 @@ impl RtSbInsHeadingGradient2 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// INS_Heading_2
+    /// Get value of 'INS_Heading_2'
     ///
     /// This is GPS heading in the range 0 - 360°, the direction that the vehicle is travelling in the local horizontal plane.
     ///
@@ -27576,7 +27576,7 @@ impl RtSbInsHeadingGradient2 {
     pub fn ins_heading_2(&self) -> f32 {
         self.ins_heading_2_raw()
     }
-    /// Get raw value of INS_Heading_2
+    /// Get raw value of 'INS_Heading_2'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -27591,7 +27591,7 @@ impl RtSbInsHeadingGradient2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Heading_2
+    /// Set value of 'INS_Heading_2'
     #[inline(always)]
     pub fn set_ins_heading_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 360_f32 < value {
@@ -27605,7 +27605,7 @@ impl RtSbInsHeadingGradient2 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Heading
+    /// Get value of 'Accuracy_INS_Heading'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -27617,7 +27617,7 @@ impl RtSbInsHeadingGradient2 {
     pub fn accuracy_ins_heading(&self) -> u8 {
         self.accuracy_ins_heading_raw()
     }
-    /// Get raw value of Accuracy_INS_Heading
+    /// Get raw value of 'Accuracy_INS_Heading'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -27631,7 +27631,7 @@ impl RtSbInsHeadingGradient2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Heading
+    /// Set value of 'Accuracy_INS_Heading'
     #[inline(always)]
     pub fn set_accuracy_ins_heading(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -27649,7 +27649,7 @@ impl RtSbInsHeadingGradient2 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Gradient
+    /// Get value of 'Validity_INS_Gradient'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -27661,7 +27661,7 @@ impl RtSbInsHeadingGradient2 {
     pub fn validity_ins_gradient(&self) -> bool {
         self.validity_ins_gradient_raw()
     }
-    /// Get raw value of Validity_INS_Gradient
+    /// Get raw value of 'Validity_INS_Gradient'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -27674,14 +27674,14 @@ impl RtSbInsHeadingGradient2 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Gradient
+    /// Set value of 'Validity_INS_Gradient'
     #[inline(always)]
     pub fn set_validity_ins_gradient(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Heading
+    /// Get value of 'Validity_INS_Heading'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -27693,7 +27693,7 @@ impl RtSbInsHeadingGradient2 {
     pub fn validity_ins_heading(&self) -> bool {
         self.validity_ins_heading_raw()
     }
-    /// Get raw value of Validity_INS_Heading
+    /// Get raw value of 'Validity_INS_Heading'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -27706,7 +27706,7 @@ impl RtSbInsHeadingGradient2 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Heading
+    /// Set value of 'Validity_INS_Heading'
     #[inline(always)]
     pub fn set_validity_ins_heading(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -27782,7 +27782,7 @@ impl RtSbInsHeadingGradient {
     pub const INS_HEADING_MAX: f32 = 180_f32;
     pub const ACCURACY_INS_HEADING_MIN: u8 = 0_u8;
     pub const ACCURACY_INS_HEADING_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Heading_Gradient from values
+    /// Construct new 'RT_SB_INS_Heading_Gradient' from values
     pub fn new(
         ins_gradient: f32,
         accuracy_ins_gradient: u8,
@@ -27804,7 +27804,7 @@ impl RtSbInsHeadingGradient {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Gradient
+    /// Get value of 'INS_Gradient'
     ///
     /// This is GPS gradient, i.e. the vertical direction that the vehicle is travelling, NOT pointing (pitch).
     ///
@@ -27816,7 +27816,7 @@ impl RtSbInsHeadingGradient {
     pub fn ins_gradient(&self) -> f32 {
         self.ins_gradient_raw()
     }
-    /// Get raw value of INS_Gradient
+    /// Get raw value of 'INS_Gradient'
     ///
     /// - Start bit: 40
     /// - Signal size: 16 bits
@@ -27831,7 +27831,7 @@ impl RtSbInsHeadingGradient {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Gradient
+    /// Set value of 'INS_Gradient'
     #[inline(always)]
     pub fn set_ins_gradient(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -27846,7 +27846,7 @@ impl RtSbInsHeadingGradient {
         self.raw.view_bits_mut::<Lsb0>()[40..56].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Gradient
+    /// Get value of 'Accuracy_INS_Gradient'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -27858,7 +27858,7 @@ impl RtSbInsHeadingGradient {
     pub fn accuracy_ins_gradient(&self) -> u8 {
         self.accuracy_ins_gradient_raw()
     }
-    /// Get raw value of Accuracy_INS_Gradient
+    /// Get raw value of 'Accuracy_INS_Gradient'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -27872,7 +27872,7 @@ impl RtSbInsHeadingGradient {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Gradient
+    /// Set value of 'Accuracy_INS_Gradient'
     #[inline(always)]
     pub fn set_accuracy_ins_gradient(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -27890,7 +27890,7 @@ impl RtSbInsHeadingGradient {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// INS_Heading
+    /// Get value of 'INS_Heading'
     ///
     /// This is GPS heading, the direction that the vehicle is travelling in the local horizontal plane.
     ///
@@ -27902,7 +27902,7 @@ impl RtSbInsHeadingGradient {
     pub fn ins_heading(&self) -> f32 {
         self.ins_heading_raw()
     }
-    /// Get raw value of INS_Heading
+    /// Get raw value of 'INS_Heading'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -27917,7 +27917,7 @@ impl RtSbInsHeadingGradient {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of INS_Heading
+    /// Set value of 'INS_Heading'
     #[inline(always)]
     pub fn set_ins_heading(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -27932,7 +27932,7 @@ impl RtSbInsHeadingGradient {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_INS_Heading
+    /// Get value of 'Accuracy_INS_Heading'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -27944,7 +27944,7 @@ impl RtSbInsHeadingGradient {
     pub fn accuracy_ins_heading(&self) -> u8 {
         self.accuracy_ins_heading_raw()
     }
-    /// Get raw value of Accuracy_INS_Heading
+    /// Get raw value of 'Accuracy_INS_Heading'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -27958,7 +27958,7 @@ impl RtSbInsHeadingGradient {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_INS_Heading
+    /// Set value of 'Accuracy_INS_Heading'
     #[inline(always)]
     pub fn set_accuracy_ins_heading(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -27976,7 +27976,7 @@ impl RtSbInsHeadingGradient {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Gradient
+    /// Get value of 'Validity_INS_Gradient'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -27988,7 +27988,7 @@ impl RtSbInsHeadingGradient {
     pub fn validity_ins_gradient(&self) -> bool {
         self.validity_ins_gradient_raw()
     }
-    /// Get raw value of Validity_INS_Gradient
+    /// Get raw value of 'Validity_INS_Gradient'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -28001,14 +28001,14 @@ impl RtSbInsHeadingGradient {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Gradient
+    /// Set value of 'Validity_INS_Gradient'
     #[inline(always)]
     pub fn set_validity_ins_gradient(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_INS_Heading
+    /// Get value of 'Validity_INS_Heading'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -28020,7 +28020,7 @@ impl RtSbInsHeadingGradient {
     pub fn validity_ins_heading(&self) -> bool {
         self.validity_ins_heading_raw()
     }
-    /// Get raw value of Validity_INS_Heading
+    /// Get raw value of 'Validity_INS_Heading'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -28033,7 +28033,7 @@ impl RtSbInsHeadingGradient {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_INS_Heading
+    /// Set value of 'Validity_INS_Heading'
     #[inline(always)]
     pub fn set_validity_ins_heading(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -28103,8 +28103,8 @@ impl RtSbInsStatus {
     pub const MESSAGE_SIZE: usize = 8;
     pub const INS_STATUS_MIN: u8 = 0_u8;
     pub const INS_STATUS_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Status from values
-    pub fn new(ins_status: u8) -> Result<Self, CanError> {
+    /// Construct new 'RT_SB_INS_Status' from values
+    pub fn new(ins_status: RtSbInsStatusInsStatus) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_ins_status(ins_status)?;
         Ok(res)
@@ -28113,7 +28113,7 @@ impl RtSbInsStatus {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// INS_Status
+    /// Get value of 'INS_Status'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -28129,7 +28129,7 @@ impl RtSbInsStatus {
             _ => RtSbInsStatusInsStatus::_Other(self.ins_status_raw()),
         }
     }
-    /// Get raw value of INS_Status
+    /// Get raw value of 'INS_Status'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -28143,9 +28143,17 @@ impl RtSbInsStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of INS_Status
+    /// Set value of 'INS_Status'
     #[inline(always)]
-    pub fn set_ins_status(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_ins_status(
+        &mut self,
+        value: RtSbInsStatusInsStatus,
+    ) -> Result<(), CanError> {
+        self.set_ins_status_raw(u8::from(value))
+    }
+    /// Set raw value of 'INS_Status'
+    #[inline(always)]
+    pub fn set_ins_status_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: RtSbInsStatus::MESSAGE_ID,
@@ -28257,15 +28265,15 @@ impl RtSbInsAttitude {
     pub const ATTITUDE_YAW_MAX: f32 = 360_f32;
     pub const ACCURACY_ATTITUDE_MIN: u8 = 0_u8;
     pub const ACCURACY_ATTITUDE_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_INS_Attitude from values
+    /// Construct new 'RT_SB_INS_Attitude' from values
     pub fn new(
         attitude_roll: f32,
         attitude_pitch: f32,
         attitude_yaw: f32,
         accuracy_attitude: u8,
-        validity_roll: bool,
-        validity_pitch: bool,
-        validity_yaw: bool,
+        validity_roll: RtSbInsAttitudeValidityRoll,
+        validity_pitch: RtSbInsAttitudeValidityPitch,
+        validity_yaw: RtSbInsAttitudeValidityYaw,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_attitude_roll(attitude_roll)?;
@@ -28281,7 +28289,7 @@ impl RtSbInsAttitude {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Attitude_Roll
+    /// Get value of 'Attitude_Roll'
     ///
     /// - Min: -360
     /// - Max: 360
@@ -28291,7 +28299,7 @@ impl RtSbInsAttitude {
     pub fn attitude_roll(&self) -> f32 {
         self.attitude_roll_raw()
     }
-    /// Get raw value of Attitude_Roll
+    /// Get raw value of 'Attitude_Roll'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -28306,7 +28314,7 @@ impl RtSbInsAttitude {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Attitude_Roll
+    /// Set value of 'Attitude_Roll'
     #[inline(always)]
     pub fn set_attitude_roll(&mut self, value: f32) -> Result<(), CanError> {
         if value < -360_f32 || 360_f32 < value {
@@ -28321,7 +28329,7 @@ impl RtSbInsAttitude {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Attitude_Pitch
+    /// Get value of 'Attitude_Pitch'
     ///
     /// - Min: -360
     /// - Max: 360
@@ -28331,7 +28339,7 @@ impl RtSbInsAttitude {
     pub fn attitude_pitch(&self) -> f32 {
         self.attitude_pitch_raw()
     }
-    /// Get raw value of Attitude_Pitch
+    /// Get raw value of 'Attitude_Pitch'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -28346,7 +28354,7 @@ impl RtSbInsAttitude {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Attitude_Pitch
+    /// Set value of 'Attitude_Pitch'
     #[inline(always)]
     pub fn set_attitude_pitch(&mut self, value: f32) -> Result<(), CanError> {
         if value < -360_f32 || 360_f32 < value {
@@ -28361,7 +28369,7 @@ impl RtSbInsAttitude {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Attitude_Yaw
+    /// Get value of 'Attitude_Yaw'
     ///
     /// - Min: -360
     /// - Max: 360
@@ -28371,7 +28379,7 @@ impl RtSbInsAttitude {
     pub fn attitude_yaw(&self) -> f32 {
         self.attitude_yaw_raw()
     }
-    /// Get raw value of Attitude_Yaw
+    /// Get raw value of 'Attitude_Yaw'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -28386,7 +28394,7 @@ impl RtSbInsAttitude {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Attitude_Yaw
+    /// Set value of 'Attitude_Yaw'
     #[inline(always)]
     pub fn set_attitude_yaw(&mut self, value: f32) -> Result<(), CanError> {
         if value < -360_f32 || 360_f32 < value {
@@ -28401,7 +28409,7 @@ impl RtSbInsAttitude {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_Attitude
+    /// Get value of 'Accuracy_Attitude'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -28411,7 +28419,7 @@ impl RtSbInsAttitude {
     pub fn accuracy_attitude(&self) -> u8 {
         self.accuracy_attitude_raw()
     }
-    /// Get raw value of Accuracy_Attitude
+    /// Get raw value of 'Accuracy_Attitude'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -28425,7 +28433,7 @@ impl RtSbInsAttitude {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_Attitude
+    /// Set value of 'Accuracy_Attitude'
     #[inline(always)]
     pub fn set_accuracy_attitude(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -28443,7 +28451,7 @@ impl RtSbInsAttitude {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_Roll
+    /// Get value of 'Validity_Roll'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -28458,7 +28466,7 @@ impl RtSbInsAttitude {
             _ => RtSbInsAttitudeValidityRoll::_Other(self.validity_roll_raw()),
         }
     }
-    /// Get raw value of Validity_Roll
+    /// Get raw value of 'Validity_Roll'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -28471,14 +28479,22 @@ impl RtSbInsAttitude {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Roll
+    /// Set value of 'Validity_Roll'
     #[inline(always)]
-    pub fn set_validity_roll(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_validity_roll(
+        &mut self,
+        value: RtSbInsAttitudeValidityRoll,
+    ) -> Result<(), CanError> {
+        self.set_validity_roll_raw(bool::from(value))
+    }
+    /// Set raw value of 'Validity_Roll'
+    #[inline(always)]
+    pub fn set_validity_roll_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_Pitch
+    /// Get value of 'Validity_Pitch'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -28493,7 +28509,7 @@ impl RtSbInsAttitude {
             _ => RtSbInsAttitudeValidityPitch::_Other(self.validity_pitch_raw()),
         }
     }
-    /// Get raw value of Validity_Pitch
+    /// Get raw value of 'Validity_Pitch'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -28506,14 +28522,22 @@ impl RtSbInsAttitude {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Pitch
+    /// Set value of 'Validity_Pitch'
     #[inline(always)]
-    pub fn set_validity_pitch(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_validity_pitch(
+        &mut self,
+        value: RtSbInsAttitudeValidityPitch,
+    ) -> Result<(), CanError> {
+        self.set_validity_pitch_raw(bool::from(value))
+    }
+    /// Set raw value of 'Validity_Pitch'
+    #[inline(always)]
+    pub fn set_validity_pitch_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_Yaw
+    /// Get value of 'Validity_Yaw'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -28528,7 +28552,7 @@ impl RtSbInsAttitude {
             _ => RtSbInsAttitudeValidityYaw::_Other(self.validity_yaw_raw()),
         }
     }
-    /// Get raw value of Validity_Yaw
+    /// Get raw value of 'Validity_Yaw'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -28541,9 +28565,17 @@ impl RtSbInsAttitude {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Yaw
+    /// Set value of 'Validity_Yaw'
     #[inline(always)]
-    pub fn set_validity_yaw(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_validity_yaw(
+        &mut self,
+        value: RtSbInsAttitudeValidityYaw,
+    ) -> Result<(), CanError> {
+        self.set_validity_yaw_raw(bool::from(value))
+    }
+    /// Set raw value of 'Validity_Yaw'
+    #[inline(always)]
+    pub fn set_validity_yaw_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[0..1].store_le(value);
         Ok(())
@@ -28686,17 +28718,17 @@ impl RtSbOutputStatus {
     pub const MESSAGE_SIZE: usize = 8;
     pub const GPS_TIME_MIN: f32 = 0_f32;
     pub const GPS_TIME_MAX: f32 = 604800_f32;
-    /// Construct new RT_SB_Output_Status from values
+    /// Construct new 'RT_SB_Output_Status' from values
     pub fn new(
         gps_time: f32,
-        status_trigger: bool,
-        status_serial_output_2: bool,
-        status_serial_output_1: bool,
-        status_pulse_output: bool,
-        status_analogue_4: bool,
-        status_analogue_3: bool,
-        status_analogue_2: bool,
-        status_analogue_1: bool,
+        status_trigger: RtSbOutputStatusStatusTrigger,
+        status_serial_output_2: RtSbOutputStatusStatusSerialOutput2,
+        status_serial_output_1: RtSbOutputStatusStatusSerialOutput1,
+        status_pulse_output: RtSbOutputStatusStatusPulseOutput,
+        status_analogue_4: RtSbOutputStatusStatusAnalogue4,
+        status_analogue_3: RtSbOutputStatusStatusAnalogue3,
+        status_analogue_2: RtSbOutputStatusStatusAnalogue2,
+        status_analogue_1: RtSbOutputStatusStatusAnalogue1,
         validity_status_timestamp: bool,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
@@ -28716,7 +28748,7 @@ impl RtSbOutputStatus {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Time
+    /// Get value of 'GPS_Time'
     ///
     /// GPS time is the time in seconds since midnight GMT on Saturday night.
     ///
@@ -28728,7 +28760,7 @@ impl RtSbOutputStatus {
     pub fn gps_time(&self) -> f32 {
         self.gps_time_raw()
     }
-    /// Get raw value of GPS_Time
+    /// Get raw value of 'GPS_Time'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -28743,7 +28775,7 @@ impl RtSbOutputStatus {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Time
+    /// Set value of 'GPS_Time'
     #[inline(always)]
     pub fn set_gps_time(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 604800_f32 < value {
@@ -28757,7 +28789,7 @@ impl RtSbOutputStatus {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Status_Trigger
+    /// Get value of 'Status_Trigger'
     ///
     /// Status of the trigger input
     ///
@@ -28774,7 +28806,7 @@ impl RtSbOutputStatus {
             _ => RtSbOutputStatusStatusTrigger::_Other(self.status_trigger_raw()),
         }
     }
-    /// Get raw value of Status_Trigger
+    /// Get raw value of 'Status_Trigger'
     ///
     /// - Start bit: 15
     /// - Signal size: 1 bits
@@ -28787,14 +28819,22 @@ impl RtSbOutputStatus {
         let signal = self.raw.view_bits::<Lsb0>()[15..16].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Status_Trigger
+    /// Set value of 'Status_Trigger'
     #[inline(always)]
-    pub fn set_status_trigger(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_status_trigger(
+        &mut self,
+        value: RtSbOutputStatusStatusTrigger,
+    ) -> Result<(), CanError> {
+        self.set_status_trigger_raw(bool::from(value))
+    }
+    /// Set raw value of 'Status_Trigger'
+    #[inline(always)]
+    pub fn set_status_trigger_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[15..16].store_le(value);
         Ok(())
     }
-    /// Status_Serial_Output_2
+    /// Get value of 'Status_Serial_Output_2'
     ///
     /// Status output of serial port 1
     ///
@@ -28815,7 +28855,7 @@ impl RtSbOutputStatus {
             }
         }
     }
-    /// Get raw value of Status_Serial_Output_2
+    /// Get raw value of 'Status_Serial_Output_2'
     ///
     /// - Start bit: 14
     /// - Signal size: 1 bits
@@ -28828,14 +28868,25 @@ impl RtSbOutputStatus {
         let signal = self.raw.view_bits::<Lsb0>()[14..15].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Status_Serial_Output_2
+    /// Set value of 'Status_Serial_Output_2'
     #[inline(always)]
-    pub fn set_status_serial_output_2(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_status_serial_output_2(
+        &mut self,
+        value: RtSbOutputStatusStatusSerialOutput2,
+    ) -> Result<(), CanError> {
+        self.set_status_serial_output_2_raw(bool::from(value))
+    }
+    /// Set raw value of 'Status_Serial_Output_2'
+    #[inline(always)]
+    pub fn set_status_serial_output_2_raw(
+        &mut self,
+        value: bool,
+    ) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[14..15].store_le(value);
         Ok(())
     }
-    /// Status_Serial_Output_1
+    /// Get value of 'Status_Serial_Output_1'
     ///
     /// Status output of serial port 1
     ///
@@ -28856,7 +28907,7 @@ impl RtSbOutputStatus {
             }
         }
     }
-    /// Get raw value of Status_Serial_Output_1
+    /// Get raw value of 'Status_Serial_Output_1'
     ///
     /// - Start bit: 13
     /// - Signal size: 1 bits
@@ -28869,14 +28920,25 @@ impl RtSbOutputStatus {
         let signal = self.raw.view_bits::<Lsb0>()[13..14].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Status_Serial_Output_1
+    /// Set value of 'Status_Serial_Output_1'
     #[inline(always)]
-    pub fn set_status_serial_output_1(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_status_serial_output_1(
+        &mut self,
+        value: RtSbOutputStatusStatusSerialOutput1,
+    ) -> Result<(), CanError> {
+        self.set_status_serial_output_1_raw(bool::from(value))
+    }
+    /// Set raw value of 'Status_Serial_Output_1'
+    #[inline(always)]
+    pub fn set_status_serial_output_1_raw(
+        &mut self,
+        value: bool,
+    ) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[13..14].store_le(value);
         Ok(())
     }
-    /// Status_Pulse_Output
+    /// Get value of 'Status_Pulse_Output'
     ///
     /// Pulse output activity status
     ///
@@ -28895,7 +28957,7 @@ impl RtSbOutputStatus {
             }
         }
     }
-    /// Get raw value of Status_Pulse_Output
+    /// Get raw value of 'Status_Pulse_Output'
     ///
     /// - Start bit: 12
     /// - Signal size: 1 bits
@@ -28908,14 +28970,22 @@ impl RtSbOutputStatus {
         let signal = self.raw.view_bits::<Lsb0>()[12..13].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Status_Pulse_Output
+    /// Set value of 'Status_Pulse_Output'
     #[inline(always)]
-    pub fn set_status_pulse_output(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_status_pulse_output(
+        &mut self,
+        value: RtSbOutputStatusStatusPulseOutput,
+    ) -> Result<(), CanError> {
+        self.set_status_pulse_output_raw(bool::from(value))
+    }
+    /// Set raw value of 'Status_Pulse_Output'
+    #[inline(always)]
+    pub fn set_status_pulse_output_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[12..13].store_le(value);
         Ok(())
     }
-    /// Status_Analogue_4
+    /// Get value of 'Status_Analogue_4'
     ///
     /// Analogue output status for channel 4.
     ///
@@ -28932,7 +29002,7 @@ impl RtSbOutputStatus {
             _ => RtSbOutputStatusStatusAnalogue4::_Other(self.status_analogue_4_raw()),
         }
     }
-    /// Get raw value of Status_Analogue_4
+    /// Get raw value of 'Status_Analogue_4'
     ///
     /// - Start bit: 11
     /// - Signal size: 1 bits
@@ -28945,14 +29015,22 @@ impl RtSbOutputStatus {
         let signal = self.raw.view_bits::<Lsb0>()[11..12].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Status_Analogue_4
+    /// Set value of 'Status_Analogue_4'
     #[inline(always)]
-    pub fn set_status_analogue_4(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_status_analogue_4(
+        &mut self,
+        value: RtSbOutputStatusStatusAnalogue4,
+    ) -> Result<(), CanError> {
+        self.set_status_analogue_4_raw(bool::from(value))
+    }
+    /// Set raw value of 'Status_Analogue_4'
+    #[inline(always)]
+    pub fn set_status_analogue_4_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[11..12].store_le(value);
         Ok(())
     }
-    /// Status_Analogue_3
+    /// Get value of 'Status_Analogue_3'
     ///
     /// Analogue output status for channel 3.
     ///
@@ -28969,7 +29047,7 @@ impl RtSbOutputStatus {
             _ => RtSbOutputStatusStatusAnalogue3::_Other(self.status_analogue_3_raw()),
         }
     }
-    /// Get raw value of Status_Analogue_3
+    /// Get raw value of 'Status_Analogue_3'
     ///
     /// - Start bit: 10
     /// - Signal size: 1 bits
@@ -28982,14 +29060,22 @@ impl RtSbOutputStatus {
         let signal = self.raw.view_bits::<Lsb0>()[10..11].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Status_Analogue_3
+    /// Set value of 'Status_Analogue_3'
     #[inline(always)]
-    pub fn set_status_analogue_3(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_status_analogue_3(
+        &mut self,
+        value: RtSbOutputStatusStatusAnalogue3,
+    ) -> Result<(), CanError> {
+        self.set_status_analogue_3_raw(bool::from(value))
+    }
+    /// Set raw value of 'Status_Analogue_3'
+    #[inline(always)]
+    pub fn set_status_analogue_3_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[10..11].store_le(value);
         Ok(())
     }
-    /// Status_Analogue_2
+    /// Get value of 'Status_Analogue_2'
     ///
     /// Analogue output status for channel 1.
     ///
@@ -29006,7 +29092,7 @@ impl RtSbOutputStatus {
             _ => RtSbOutputStatusStatusAnalogue2::_Other(self.status_analogue_2_raw()),
         }
     }
-    /// Get raw value of Status_Analogue_2
+    /// Get raw value of 'Status_Analogue_2'
     ///
     /// - Start bit: 9
     /// - Signal size: 1 bits
@@ -29019,14 +29105,22 @@ impl RtSbOutputStatus {
         let signal = self.raw.view_bits::<Lsb0>()[9..10].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Status_Analogue_2
+    /// Set value of 'Status_Analogue_2'
     #[inline(always)]
-    pub fn set_status_analogue_2(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_status_analogue_2(
+        &mut self,
+        value: RtSbOutputStatusStatusAnalogue2,
+    ) -> Result<(), CanError> {
+        self.set_status_analogue_2_raw(bool::from(value))
+    }
+    /// Set raw value of 'Status_Analogue_2'
+    #[inline(always)]
+    pub fn set_status_analogue_2_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[9..10].store_le(value);
         Ok(())
     }
-    /// Status_Analogue_1
+    /// Get value of 'Status_Analogue_1'
     ///
     /// Analogue output status for channel 1.
     ///
@@ -29043,7 +29137,7 @@ impl RtSbOutputStatus {
             _ => RtSbOutputStatusStatusAnalogue1::_Other(self.status_analogue_1_raw()),
         }
     }
-    /// Get raw value of Status_Analogue_1
+    /// Get raw value of 'Status_Analogue_1'
     ///
     /// - Start bit: 8
     /// - Signal size: 1 bits
@@ -29056,14 +29150,22 @@ impl RtSbOutputStatus {
         let signal = self.raw.view_bits::<Lsb0>()[8..9].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Status_Analogue_1
+    /// Set value of 'Status_Analogue_1'
     #[inline(always)]
-    pub fn set_status_analogue_1(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_status_analogue_1(
+        &mut self,
+        value: RtSbOutputStatusStatusAnalogue1,
+    ) -> Result<(), CanError> {
+        self.set_status_analogue_1_raw(bool::from(value))
+    }
+    /// Set raw value of 'Status_Analogue_1'
+    #[inline(always)]
+    pub fn set_status_analogue_1_raw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[8..9].store_le(value);
         Ok(())
     }
-    /// Validity_Status_Timestamp
+    /// Get value of 'Validity_Status_Timestamp'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -29075,7 +29177,7 @@ impl RtSbOutputStatus {
     pub fn validity_status_timestamp(&self) -> bool {
         self.validity_status_timestamp_raw()
     }
-    /// Get raw value of Validity_Status_Timestamp
+    /// Get raw value of 'Validity_Status_Timestamp'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -29088,7 +29190,7 @@ impl RtSbOutputStatus {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Status_Timestamp
+    /// Set value of 'Validity_Status_Timestamp'
     #[inline(always)]
     pub fn set_validity_status_timestamp(
         &mut self,
@@ -29367,7 +29469,7 @@ impl RtSbGpsHeadingGradient2 {
     pub const GPS_HEADING_2_MAX: f32 = 360_f32;
     pub const ACCURACY_GPS_HEADING_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_HEADING_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Heading_Gradient_2 from values
+    /// Construct new 'RT_SB_GPS_Heading_Gradient_2' from values
     pub fn new(
         gps_gradient: f32,
         accuracy_gps_gradient: u8,
@@ -29389,7 +29491,7 @@ impl RtSbGpsHeadingGradient2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Gradient
+    /// Get value of 'GPS_Gradient'
     ///
     /// This is GPS gradient, i.e. the vertical direction that the vehicle is travelling, NOT pointing (pitch).
     ///
@@ -29401,7 +29503,7 @@ impl RtSbGpsHeadingGradient2 {
     pub fn gps_gradient(&self) -> f32 {
         self.gps_gradient_raw()
     }
-    /// Get raw value of GPS_Gradient
+    /// Get raw value of 'GPS_Gradient'
     ///
     /// - Start bit: 40
     /// - Signal size: 16 bits
@@ -29416,7 +29518,7 @@ impl RtSbGpsHeadingGradient2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Gradient
+    /// Set value of 'GPS_Gradient'
     #[inline(always)]
     pub fn set_gps_gradient(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -29431,7 +29533,7 @@ impl RtSbGpsHeadingGradient2 {
         self.raw.view_bits_mut::<Lsb0>()[40..56].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Gradient
+    /// Get value of 'Accuracy_GPS_Gradient'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -29443,7 +29545,7 @@ impl RtSbGpsHeadingGradient2 {
     pub fn accuracy_gps_gradient(&self) -> u8 {
         self.accuracy_gps_gradient_raw()
     }
-    /// Get raw value of Accuracy_GPS_Gradient
+    /// Get raw value of 'Accuracy_GPS_Gradient'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -29457,7 +29559,7 @@ impl RtSbGpsHeadingGradient2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Gradient
+    /// Set value of 'Accuracy_GPS_Gradient'
     #[inline(always)]
     pub fn set_accuracy_gps_gradient(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -29475,7 +29577,7 @@ impl RtSbGpsHeadingGradient2 {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// GPS_Heading_2
+    /// Get value of 'GPS_Heading_2'
     ///
     /// This is GPS heading in the range 0 - 360°, the direction that the vehicle is travelling in the local horizontal plane.
     ///
@@ -29487,7 +29589,7 @@ impl RtSbGpsHeadingGradient2 {
     pub fn gps_heading_2(&self) -> f32 {
         self.gps_heading_2_raw()
     }
-    /// Get raw value of GPS_Heading_2
+    /// Get raw value of 'GPS_Heading_2'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -29502,7 +29604,7 @@ impl RtSbGpsHeadingGradient2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Heading_2
+    /// Set value of 'GPS_Heading_2'
     #[inline(always)]
     pub fn set_gps_heading_2(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 360_f32 < value {
@@ -29516,7 +29618,7 @@ impl RtSbGpsHeadingGradient2 {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Heading
+    /// Get value of 'Accuracy_GPS_Heading'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -29528,7 +29630,7 @@ impl RtSbGpsHeadingGradient2 {
     pub fn accuracy_gps_heading(&self) -> u8 {
         self.accuracy_gps_heading_raw()
     }
-    /// Get raw value of Accuracy_GPS_Heading
+    /// Get raw value of 'Accuracy_GPS_Heading'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -29542,7 +29644,7 @@ impl RtSbGpsHeadingGradient2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Heading
+    /// Set value of 'Accuracy_GPS_Heading'
     #[inline(always)]
     pub fn set_accuracy_gps_heading(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -29560,7 +29662,7 @@ impl RtSbGpsHeadingGradient2 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Gradient
+    /// Get value of 'Validity_GPS_Gradient'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -29572,7 +29674,7 @@ impl RtSbGpsHeadingGradient2 {
     pub fn validity_gps_gradient(&self) -> bool {
         self.validity_gps_gradient_raw()
     }
-    /// Get raw value of Validity_GPS_Gradient
+    /// Get raw value of 'Validity_GPS_Gradient'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -29585,14 +29687,14 @@ impl RtSbGpsHeadingGradient2 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Gradient
+    /// Set value of 'Validity_GPS_Gradient'
     #[inline(always)]
     pub fn set_validity_gps_gradient(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Heading
+    /// Get value of 'Validity_GPS_Heading'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -29604,7 +29706,7 @@ impl RtSbGpsHeadingGradient2 {
     pub fn validity_gps_heading(&self) -> bool {
         self.validity_gps_heading_raw()
     }
-    /// Get raw value of Validity_GPS_Heading
+    /// Get raw value of 'Validity_GPS_Heading'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -29617,7 +29719,7 @@ impl RtSbGpsHeadingGradient2 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Heading
+    /// Set value of 'Validity_GPS_Heading'
     #[inline(always)]
     pub fn set_validity_gps_heading(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -29691,7 +29793,7 @@ impl RtSbCumulativeDistance2 {
     pub const CUMULATIVE_DISTANCE_MAX: f32 = 4294967_f32;
     pub const CUMULATIVE_TIME_MIN: f32 = 0_f32;
     pub const CUMULATIVE_TIME_MAX: f32 = 167772_f32;
-    /// Construct new RT_SB_Cumulative_Distance_2 from values
+    /// Construct new 'RT_SB_Cumulative_Distance_2' from values
     pub fn new(
         cumulative_distance: f32,
         cumulative_time: f32,
@@ -29709,7 +29811,7 @@ impl RtSbCumulativeDistance2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Cumulative_Distance
+    /// Get value of 'Cumulative_Distance'
     ///
     /// - Min: 0
     /// - Max: 4294967
@@ -29719,7 +29821,7 @@ impl RtSbCumulativeDistance2 {
     pub fn cumulative_distance(&self) -> f32 {
         self.cumulative_distance_raw()
     }
-    /// Get raw value of Cumulative_Distance
+    /// Get raw value of 'Cumulative_Distance'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -29734,7 +29836,7 @@ impl RtSbCumulativeDistance2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Cumulative_Distance
+    /// Set value of 'Cumulative_Distance'
     #[inline(always)]
     pub fn set_cumulative_distance(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 4294967_f32 < value {
@@ -29748,7 +29850,7 @@ impl RtSbCumulativeDistance2 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Cumulative_Time
+    /// Get value of 'Cumulative_Time'
     ///
     /// - Min: 0
     /// - Max: 167772
@@ -29758,7 +29860,7 @@ impl RtSbCumulativeDistance2 {
     pub fn cumulative_time(&self) -> f32 {
         self.cumulative_time_raw()
     }
-    /// Get raw value of Cumulative_Time
+    /// Get raw value of 'Cumulative_Time'
     ///
     /// - Start bit: 8
     /// - Signal size: 24 bits
@@ -29773,7 +29875,7 @@ impl RtSbCumulativeDistance2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Cumulative_Time
+    /// Set value of 'Cumulative_Time'
     #[inline(always)]
     pub fn set_cumulative_time(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 167772_f32 < value {
@@ -29787,7 +29889,7 @@ impl RtSbCumulativeDistance2 {
         self.raw.view_bits_mut::<Lsb0>()[8..32].store_le(value);
         Ok(())
     }
-    /// Validity_Cumulative_Distance
+    /// Get value of 'Validity_Cumulative_Distance'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -29799,7 +29901,7 @@ impl RtSbCumulativeDistance2 {
     pub fn validity_cumulative_distance(&self) -> bool {
         self.validity_cumulative_distance_raw()
     }
-    /// Get raw value of Validity_Cumulative_Distance
+    /// Get raw value of 'Validity_Cumulative_Distance'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -29812,7 +29914,7 @@ impl RtSbCumulativeDistance2 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Cumulative_Distance
+    /// Set value of 'Validity_Cumulative_Distance'
     #[inline(always)]
     pub fn set_validity_cumulative_distance(
         &mut self,
@@ -29822,7 +29924,7 @@ impl RtSbCumulativeDistance2 {
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_Cumulative_Time
+    /// Get value of 'Validity_Cumulative_Time'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -29834,7 +29936,7 @@ impl RtSbCumulativeDistance2 {
     pub fn validity_cumulative_time(&self) -> bool {
         self.validity_cumulative_time_raw()
     }
-    /// Get raw value of Validity_Cumulative_Time
+    /// Get raw value of 'Validity_Cumulative_Time'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -29847,7 +29949,7 @@ impl RtSbCumulativeDistance2 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Cumulative_Time
+    /// Set value of 'Validity_Cumulative_Time'
     #[inline(always)]
     pub fn set_validity_cumulative_time(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -29921,7 +30023,7 @@ impl RtSbCumulativeDistance1 {
     pub const CUMULATIVE_DISTANCE_MAX: f32 = 4294967_f32;
     pub const CUMULATIVE_TIME_MIN: f32 = 0_f32;
     pub const CUMULATIVE_TIME_MAX: f32 = 167772_f32;
-    /// Construct new RT_SB_Cumulative_Distance_1 from values
+    /// Construct new 'RT_SB_Cumulative_Distance_1' from values
     pub fn new(
         cumulative_distance: f32,
         cumulative_time: f32,
@@ -29939,7 +30041,7 @@ impl RtSbCumulativeDistance1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Cumulative_Distance
+    /// Get value of 'Cumulative_Distance'
     ///
     /// - Min: 0
     /// - Max: 4294967
@@ -29949,7 +30051,7 @@ impl RtSbCumulativeDistance1 {
     pub fn cumulative_distance(&self) -> f32 {
         self.cumulative_distance_raw()
     }
-    /// Get raw value of Cumulative_Distance
+    /// Get raw value of 'Cumulative_Distance'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -29964,7 +30066,7 @@ impl RtSbCumulativeDistance1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Cumulative_Distance
+    /// Set value of 'Cumulative_Distance'
     #[inline(always)]
     pub fn set_cumulative_distance(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 4294967_f32 < value {
@@ -29978,7 +30080,7 @@ impl RtSbCumulativeDistance1 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Cumulative_Time
+    /// Get value of 'Cumulative_Time'
     ///
     /// - Min: 0
     /// - Max: 167772
@@ -29988,7 +30090,7 @@ impl RtSbCumulativeDistance1 {
     pub fn cumulative_time(&self) -> f32 {
         self.cumulative_time_raw()
     }
-    /// Get raw value of Cumulative_Time
+    /// Get raw value of 'Cumulative_Time'
     ///
     /// - Start bit: 8
     /// - Signal size: 24 bits
@@ -30003,7 +30105,7 @@ impl RtSbCumulativeDistance1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Cumulative_Time
+    /// Set value of 'Cumulative_Time'
     #[inline(always)]
     pub fn set_cumulative_time(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 167772_f32 < value {
@@ -30017,7 +30119,7 @@ impl RtSbCumulativeDistance1 {
         self.raw.view_bits_mut::<Lsb0>()[8..32].store_le(value);
         Ok(())
     }
-    /// Validity_Cumulative_Distance
+    /// Get value of 'Validity_Cumulative_Distance'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -30029,7 +30131,7 @@ impl RtSbCumulativeDistance1 {
     pub fn validity_cumulative_distance(&self) -> bool {
         self.validity_cumulative_distance_raw()
     }
-    /// Get raw value of Validity_Cumulative_Distance
+    /// Get raw value of 'Validity_Cumulative_Distance'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -30042,7 +30144,7 @@ impl RtSbCumulativeDistance1 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Cumulative_Distance
+    /// Set value of 'Validity_Cumulative_Distance'
     #[inline(always)]
     pub fn set_validity_cumulative_distance(
         &mut self,
@@ -30052,7 +30154,7 @@ impl RtSbCumulativeDistance1 {
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_Cumulative_Time
+    /// Get value of 'Validity_Cumulative_Time'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -30064,7 +30166,7 @@ impl RtSbCumulativeDistance1 {
     pub fn validity_cumulative_time(&self) -> bool {
         self.validity_cumulative_time_raw()
     }
-    /// Get raw value of Validity_Cumulative_Time
+    /// Get raw value of 'Validity_Cumulative_Time'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -30077,7 +30179,7 @@ impl RtSbCumulativeDistance1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Cumulative_Time
+    /// Set value of 'Validity_Cumulative_Time'
     #[inline(always)]
     pub fn set_validity_cumulative_time(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -30151,10 +30253,10 @@ impl RtSbTriggerTimestamp {
     pub const TRIGGER_NUMBER_MAX: u8 = 128_u8;
     pub const ACCURACY_TRIGGER_TIMESTAMP_MIN: u8 = 0_u8;
     pub const ACCURACY_TRIGGER_TIMESTAMP_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_Trigger_Timestamp from values
+    /// Construct new 'RT_SB_Trigger_Timestamp' from values
     pub fn new(
         gps_high_resolution_time: f32,
-        trigger_timestamp_type: bool,
+        trigger_timestamp_type: RtSbTriggerTimestampTriggerTimestampType,
         trigger_number: u8,
         accuracy_trigger_timestamp: u8,
         validity_trigger_timestamp: bool,
@@ -30171,7 +30273,7 @@ impl RtSbTriggerTimestamp {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_High_Resolution_Time
+    /// Get value of 'GPS_High_Resolution_Time'
     ///
     /// GPS time of week to micro-second resolution.
     ///
@@ -30183,7 +30285,7 @@ impl RtSbTriggerTimestamp {
     pub fn gps_high_resolution_time(&self) -> f32 {
         self.gps_high_resolution_time_raw()
     }
-    /// Get raw value of GPS_High_Resolution_Time
+    /// Get raw value of 'GPS_High_Resolution_Time'
     ///
     /// - Start bit: 24
     /// - Signal size: 40 bits
@@ -30198,7 +30300,7 @@ impl RtSbTriggerTimestamp {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_High_Resolution_Time
+    /// Set value of 'GPS_High_Resolution_Time'
     #[inline(always)]
     pub fn set_gps_high_resolution_time(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 604800_f32 < value {
@@ -30212,7 +30314,7 @@ impl RtSbTriggerTimestamp {
         self.raw.view_bits_mut::<Lsb0>()[24..64].store_le(value);
         Ok(())
     }
-    /// Trigger_Timestamp_Type
+    /// Get value of 'Trigger_Timestamp_Type'
     ///
     /// - Min: 0
     /// - Max: 1
@@ -30231,7 +30333,7 @@ impl RtSbTriggerTimestamp {
             }
         }
     }
-    /// Get raw value of Trigger_Timestamp_Type
+    /// Get raw value of 'Trigger_Timestamp_Type'
     ///
     /// - Start bit: 23
     /// - Signal size: 1 bits
@@ -30244,14 +30346,25 @@ impl RtSbTriggerTimestamp {
         let signal = self.raw.view_bits::<Lsb0>()[23..24].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Trigger_Timestamp_Type
+    /// Set value of 'Trigger_Timestamp_Type'
     #[inline(always)]
-    pub fn set_trigger_timestamp_type(&mut self, value: bool) -> Result<(), CanError> {
+    pub fn set_trigger_timestamp_type(
+        &mut self,
+        value: RtSbTriggerTimestampTriggerTimestampType,
+    ) -> Result<(), CanError> {
+        self.set_trigger_timestamp_type_raw(bool::from(value))
+    }
+    /// Set raw value of 'Trigger_Timestamp_Type'
+    #[inline(always)]
+    pub fn set_trigger_timestamp_type_raw(
+        &mut self,
+        value: bool,
+    ) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[23..24].store_le(value);
         Ok(())
     }
-    /// Trigger_Number
+    /// Get value of 'Trigger_Number'
     ///
     /// This is the ID of the trigger that generated the event, as marked on the case of the logger
     ///
@@ -30263,7 +30376,7 @@ impl RtSbTriggerTimestamp {
     pub fn trigger_number(&self) -> u8 {
         self.trigger_number_raw()
     }
-    /// Get raw value of Trigger_Number
+    /// Get raw value of 'Trigger_Number'
     ///
     /// - Start bit: 16
     /// - Signal size: 7 bits
@@ -30277,7 +30390,7 @@ impl RtSbTriggerTimestamp {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(1)
     }
-    /// Set value of Trigger_Number
+    /// Set value of 'Trigger_Number'
     #[inline(always)]
     pub fn set_trigger_number(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 128_u8 < value {
@@ -30295,7 +30408,7 @@ impl RtSbTriggerTimestamp {
         self.raw.view_bits_mut::<Lsb0>()[16..23].store_le(value);
         Ok(())
     }
-    /// Accuracy_Trigger_Timestamp
+    /// Get value of 'Accuracy_Trigger_Timestamp'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -30307,7 +30420,7 @@ impl RtSbTriggerTimestamp {
     pub fn accuracy_trigger_timestamp(&self) -> u8 {
         self.accuracy_trigger_timestamp_raw()
     }
-    /// Get raw value of Accuracy_Trigger_Timestamp
+    /// Get raw value of 'Accuracy_Trigger_Timestamp'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -30321,7 +30434,7 @@ impl RtSbTriggerTimestamp {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_Trigger_Timestamp
+    /// Set value of 'Accuracy_Trigger_Timestamp'
     #[inline(always)]
     pub fn set_accuracy_trigger_timestamp(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -30339,7 +30452,7 @@ impl RtSbTriggerTimestamp {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_Trigger_Timestamp
+    /// Get value of 'Validity_Trigger_Timestamp'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -30351,7 +30464,7 @@ impl RtSbTriggerTimestamp {
     pub fn validity_trigger_timestamp(&self) -> bool {
         self.validity_trigger_timestamp_raw()
     }
-    /// Get raw value of Validity_Trigger_Timestamp
+    /// Get raw value of 'Validity_Trigger_Timestamp'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -30364,7 +30477,7 @@ impl RtSbTriggerTimestamp {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Trigger_Timestamp
+    /// Set value of 'Validity_Trigger_Timestamp'
     #[inline(always)]
     pub fn set_validity_trigger_timestamp(
         &mut self,
@@ -30468,7 +30581,7 @@ impl RtImu06GyroRates {
     pub const GYRO_RATE_YAW_MAX: f32 = 327_f32;
     pub const ACCURACY_GYRO_RATES_MIN: u8 = 0_u8;
     pub const ACCURACY_GYRO_RATES_MAX: u8 = 0_u8;
-    /// Construct new RT_IMU06_Gyro_Rates from values
+    /// Construct new 'RT_IMU06_Gyro_Rates' from values
     pub fn new(
         gyro_rate_roll: f32,
         gyro_rate_pitch: f32,
@@ -30492,7 +30605,7 @@ impl RtImu06GyroRates {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Gyro_Rate_Roll
+    /// Get value of 'Gyro_Rate_Roll'
     ///
     /// Roll rate is positive for clockwise rotation when looking at the rear of the vehicle from behind the vehicle.
     ///
@@ -30504,7 +30617,7 @@ impl RtImu06GyroRates {
     pub fn gyro_rate_roll(&self) -> f32 {
         self.gyro_rate_roll_raw()
     }
-    /// Get raw value of Gyro_Rate_Roll
+    /// Get raw value of 'Gyro_Rate_Roll'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -30519,7 +30632,7 @@ impl RtImu06GyroRates {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Gyro_Rate_Roll
+    /// Set value of 'Gyro_Rate_Roll'
     #[inline(always)]
     pub fn set_gyro_rate_roll(&mut self, value: f32) -> Result<(), CanError> {
         if value < -327_f32 || 327_f32 < value {
@@ -30534,7 +30647,7 @@ impl RtImu06GyroRates {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Gyro_Rate_Pitch
+    /// Get value of 'Gyro_Rate_Pitch'
     ///
     /// Pitch rate is positive for clockwise rotation when looking at the left hand side of the vehicle from the left of the vehicle.
     ///
@@ -30546,7 +30659,7 @@ impl RtImu06GyroRates {
     pub fn gyro_rate_pitch(&self) -> f32 {
         self.gyro_rate_pitch_raw()
     }
-    /// Get raw value of Gyro_Rate_Pitch
+    /// Get raw value of 'Gyro_Rate_Pitch'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -30561,7 +30674,7 @@ impl RtImu06GyroRates {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Gyro_Rate_Pitch
+    /// Set value of 'Gyro_Rate_Pitch'
     #[inline(always)]
     pub fn set_gyro_rate_pitch(&mut self, value: f32) -> Result<(), CanError> {
         if value < -327_f32 || 327_f32 < value {
@@ -30576,7 +30689,7 @@ impl RtImu06GyroRates {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Gyro_Rate_Yaw
+    /// Get value of 'Gyro_Rate_Yaw'
     ///
     /// Yaw rate is positive for clockwise rotation when looking down on the vehicle from above.
     ///
@@ -30588,7 +30701,7 @@ impl RtImu06GyroRates {
     pub fn gyro_rate_yaw(&self) -> f32 {
         self.gyro_rate_yaw_raw()
     }
-    /// Get raw value of Gyro_Rate_Yaw
+    /// Get raw value of 'Gyro_Rate_Yaw'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -30603,7 +30716,7 @@ impl RtImu06GyroRates {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Gyro_Rate_Yaw
+    /// Set value of 'Gyro_Rate_Yaw'
     #[inline(always)]
     pub fn set_gyro_rate_yaw(&mut self, value: f32) -> Result<(), CanError> {
         if value < -327_f32 || 327_f32 < value {
@@ -30618,7 +30731,7 @@ impl RtImu06GyroRates {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_Gyro_Rates
+    /// Get value of 'Accuracy_Gyro_Rates'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -30630,7 +30743,7 @@ impl RtImu06GyroRates {
     pub fn accuracy_gyro_rates(&self) -> u8 {
         self.accuracy_gyro_rates_raw()
     }
-    /// Get raw value of Accuracy_Gyro_Rates
+    /// Get raw value of 'Accuracy_Gyro_Rates'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -30644,7 +30757,7 @@ impl RtImu06GyroRates {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_Gyro_Rates
+    /// Set value of 'Accuracy_Gyro_Rates'
     #[inline(always)]
     pub fn set_accuracy_gyro_rates(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -30662,7 +30775,7 @@ impl RtImu06GyroRates {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_Gyro_Rate_Roll
+    /// Get value of 'Validity_Gyro_Rate_Roll'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -30674,7 +30787,7 @@ impl RtImu06GyroRates {
     pub fn validity_gyro_rate_roll(&self) -> bool {
         self.validity_gyro_rate_roll_raw()
     }
-    /// Get raw value of Validity_Gyro_Rate_Roll
+    /// Get raw value of 'Validity_Gyro_Rate_Roll'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -30687,14 +30800,14 @@ impl RtImu06GyroRates {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Gyro_Rate_Roll
+    /// Set value of 'Validity_Gyro_Rate_Roll'
     #[inline(always)]
     pub fn set_validity_gyro_rate_roll(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_Gyro_Rate_Pitch
+    /// Get value of 'Validity_Gyro_Rate_Pitch'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -30706,7 +30819,7 @@ impl RtImu06GyroRates {
     pub fn validity_gyro_rate_pitch(&self) -> bool {
         self.validity_gyro_rate_pitch_raw()
     }
-    /// Get raw value of Validity_Gyro_Rate_Pitch
+    /// Get raw value of 'Validity_Gyro_Rate_Pitch'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -30719,14 +30832,14 @@ impl RtImu06GyroRates {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Gyro_Rate_Pitch
+    /// Set value of 'Validity_Gyro_Rate_Pitch'
     #[inline(always)]
     pub fn set_validity_gyro_rate_pitch(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_Gyro_Rate_Yaw
+    /// Get value of 'Validity_Gyro_Rate_Yaw'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -30738,7 +30851,7 @@ impl RtImu06GyroRates {
     pub fn validity_gyro_rate_yaw(&self) -> bool {
         self.validity_gyro_rate_yaw_raw()
     }
-    /// Get raw value of Validity_Gyro_Rate_Yaw
+    /// Get raw value of 'Validity_Gyro_Rate_Yaw'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -30751,7 +30864,7 @@ impl RtImu06GyroRates {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Gyro_Rate_Yaw
+    /// Set value of 'Validity_Gyro_Rate_Yaw'
     #[inline(always)]
     pub fn set_validity_gyro_rate_yaw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -30827,7 +30940,7 @@ impl RtImu06Accel {
     pub const ACCEL_LONGITUDINAL_MAX: f32 = 65_f32;
     pub const ACCURACY_ACCEL_MIN: u8 = 0_u8;
     pub const ACCURACY_ACCEL_MAX: u8 = 255_u8;
-    /// Construct new RT_IMU06_Accel from values
+    /// Construct new 'RT_IMU06_Accel' from values
     pub fn new(
         accel_vertical: f32,
         accel_lateral: f32,
@@ -30851,7 +30964,7 @@ impl RtImu06Accel {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Accel_Vertical
+    /// Get value of 'Accel_Vertical'
     ///
     /// Vertical acceleration.  This is positive when the vehicle accelerates in an upwards direction, e.g. when travelling through a dip.
     ///
@@ -30863,7 +30976,7 @@ impl RtImu06Accel {
     pub fn accel_vertical(&self) -> f32 {
         self.accel_vertical_raw()
     }
-    /// Get raw value of Accel_Vertical
+    /// Get raw value of 'Accel_Vertical'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -30878,7 +30991,7 @@ impl RtImu06Accel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Accel_Vertical
+    /// Set value of 'Accel_Vertical'
     #[inline(always)]
     pub fn set_accel_vertical(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -30893,7 +31006,7 @@ impl RtImu06Accel {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Accel_Lateral
+    /// Get value of 'Accel_Lateral'
     ///
     /// Lateral acceleration.  This is positive when the vehicle accelerates towards the right, e.g. when cornering around a right-hand bend.
     ///
@@ -30905,7 +31018,7 @@ impl RtImu06Accel {
     pub fn accel_lateral(&self) -> f32 {
         self.accel_lateral_raw()
     }
-    /// Get raw value of Accel_Lateral
+    /// Get raw value of 'Accel_Lateral'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -30920,7 +31033,7 @@ impl RtImu06Accel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Accel_Lateral
+    /// Set value of 'Accel_Lateral'
     #[inline(always)]
     pub fn set_accel_lateral(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -30935,7 +31048,7 @@ impl RtImu06Accel {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Accel_Longitudinal
+    /// Get value of 'Accel_Longitudinal'
     ///
     /// Longitudinal acceleration.  This is positive when the vehicle accelerates in a forwards direction.
     ///
@@ -30947,7 +31060,7 @@ impl RtImu06Accel {
     pub fn accel_longitudinal(&self) -> f32 {
         self.accel_longitudinal_raw()
     }
-    /// Get raw value of Accel_Longitudinal
+    /// Get raw value of 'Accel_Longitudinal'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -30962,7 +31075,7 @@ impl RtImu06Accel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Accel_Longitudinal
+    /// Set value of 'Accel_Longitudinal'
     #[inline(always)]
     pub fn set_accel_longitudinal(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -30977,7 +31090,7 @@ impl RtImu06Accel {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_Accel
+    /// Get value of 'Accuracy_Accel'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -30989,7 +31102,7 @@ impl RtImu06Accel {
     pub fn accuracy_accel(&self) -> u8 {
         self.accuracy_accel_raw()
     }
-    /// Get raw value of Accuracy_Accel
+    /// Get raw value of 'Accuracy_Accel'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -31003,7 +31116,7 @@ impl RtImu06Accel {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_Accel
+    /// Set value of 'Accuracy_Accel'
     #[inline(always)]
     pub fn set_accuracy_accel(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -31021,7 +31134,7 @@ impl RtImu06Accel {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_Accel_Vertical
+    /// Get value of 'Validity_Accel_Vertical'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -31033,7 +31146,7 @@ impl RtImu06Accel {
     pub fn validity_accel_vertical(&self) -> bool {
         self.validity_accel_vertical_raw()
     }
-    /// Get raw value of Validity_Accel_Vertical
+    /// Get raw value of 'Validity_Accel_Vertical'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -31046,14 +31159,14 @@ impl RtImu06Accel {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Accel_Vertical
+    /// Set value of 'Validity_Accel_Vertical'
     #[inline(always)]
     pub fn set_validity_accel_vertical(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_Accel_Lateral
+    /// Get value of 'Validity_Accel_Lateral'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -31065,7 +31178,7 @@ impl RtImu06Accel {
     pub fn validity_accel_lateral(&self) -> bool {
         self.validity_accel_lateral_raw()
     }
-    /// Get raw value of Validity_Accel_Lateral
+    /// Get raw value of 'Validity_Accel_Lateral'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -31078,14 +31191,14 @@ impl RtImu06Accel {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Accel_Lateral
+    /// Set value of 'Validity_Accel_Lateral'
     #[inline(always)]
     pub fn set_validity_accel_lateral(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_Accel_Longitudinal
+    /// Get value of 'Validity_Accel_Longitudinal'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -31097,7 +31210,7 @@ impl RtImu06Accel {
     pub fn validity_accel_longitudinal(&self) -> bool {
         self.validity_accel_longitudinal_raw()
     }
-    /// Get raw value of Validity_Accel_Longitudinal
+    /// Get raw value of 'Validity_Accel_Longitudinal'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -31110,7 +31223,7 @@ impl RtImu06Accel {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Accel_Longitudinal
+    /// Set value of 'Validity_Accel_Longitudinal'
     #[inline(always)]
     pub fn set_validity_accel_longitudinal(
         &mut self,
@@ -31185,7 +31298,7 @@ impl RtSbSpeed {
     pub const SPEED_MAX: f32 = 20000_f32;
     pub const ACCURACY_SPEED_MIN: u8 = 0_u8;
     pub const ACCURACY_SPEED_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_Speed from values
+    /// Construct new 'RT_SB_Speed' from values
     pub fn new(
         speed: f32,
         accuracy_speed: u8,
@@ -31201,7 +31314,7 @@ impl RtSbSpeed {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Speed
+    /// Get value of 'Speed'
     ///
     /// - Min: -20000
     /// - Max: 20000
@@ -31211,7 +31324,7 @@ impl RtSbSpeed {
     pub fn speed(&self) -> f32 {
         self.speed_raw()
     }
-    /// Get raw value of Speed
+    /// Get raw value of 'Speed'
     ///
     /// - Start bit: 16
     /// - Signal size: 32 bits
@@ -31226,7 +31339,7 @@ impl RtSbSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Speed
+    /// Set value of 'Speed'
     #[inline(always)]
     pub fn set_speed(&mut self, value: f32) -> Result<(), CanError> {
         if value < -20000_f32 || 20000_f32 < value {
@@ -31241,7 +31354,7 @@ impl RtSbSpeed {
         self.raw.view_bits_mut::<Lsb0>()[16..48].store_le(value);
         Ok(())
     }
-    /// Accuracy_Speed
+    /// Get value of 'Accuracy_Speed'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -31253,7 +31366,7 @@ impl RtSbSpeed {
     pub fn accuracy_speed(&self) -> u8 {
         self.accuracy_speed_raw()
     }
-    /// Get raw value of Accuracy_Speed
+    /// Get raw value of 'Accuracy_Speed'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -31267,7 +31380,7 @@ impl RtSbSpeed {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_Speed
+    /// Set value of 'Accuracy_Speed'
     #[inline(always)]
     pub fn set_accuracy_speed(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -31285,7 +31398,7 @@ impl RtSbSpeed {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_Speed
+    /// Get value of 'Validity_Speed'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -31297,7 +31410,7 @@ impl RtSbSpeed {
     pub fn validity_speed(&self) -> bool {
         self.validity_speed_raw()
     }
-    /// Get raw value of Validity_Speed
+    /// Get raw value of 'Validity_Speed'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -31310,7 +31423,7 @@ impl RtSbSpeed {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Speed
+    /// Set value of 'Validity_Speed'
     #[inline(always)]
     pub fn set_validity_speed(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -31386,7 +31499,7 @@ impl RtSbRtkSlip {
     pub const RTK_SLIP_MAX: f32 = 360_f32;
     pub const ACCURACY_RTK_BASELINE_MIN: u8 = 0_u8;
     pub const ACCURACY_RTK_BASELINE_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_RTK_Slip from values
+    /// Construct new 'RT_SB_RTK_Slip' from values
     pub fn new(
         rtk_baseline: u16,
         rtk_squat: f32,
@@ -31410,7 +31523,7 @@ impl RtSbRtkSlip {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// RTK_Baseline
+    /// Get value of 'RTK_Baseline'
     ///
     /// This is the estimated baseline length calculated by the RTK solution.
     ///
@@ -31422,7 +31535,7 @@ impl RtSbRtkSlip {
     pub fn rtk_baseline(&self) -> u16 {
         self.rtk_baseline_raw()
     }
-    /// Get raw value of RTK_Baseline
+    /// Get raw value of 'RTK_Baseline'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -31436,7 +31549,7 @@ impl RtSbRtkSlip {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of RTK_Baseline
+    /// Set value of 'RTK_Baseline'
     #[inline(always)]
     pub fn set_rtk_baseline(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -31454,7 +31567,7 @@ impl RtSbRtkSlip {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// RTK_Squat
+    /// Get value of 'RTK_Squat'
     ///
     /// Squat is defined as the difference between pitch and gradient.
     ///
@@ -31466,7 +31579,7 @@ impl RtSbRtkSlip {
     pub fn rtk_squat(&self) -> f32 {
         self.rtk_squat_raw()
     }
-    /// Get raw value of RTK_Squat
+    /// Get raw value of 'RTK_Squat'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -31481,7 +31594,7 @@ impl RtSbRtkSlip {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of RTK_Squat
+    /// Set value of 'RTK_Squat'
     #[inline(always)]
     pub fn set_rtk_squat(&mut self, value: f32) -> Result<(), CanError> {
         if value < -360_f32 || 360_f32 < value {
@@ -31496,7 +31609,7 @@ impl RtSbRtkSlip {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// RTK_Slip
+    /// Get value of 'RTK_Slip'
     ///
     /// Slip is defined as the difference between yaw and heading.
     ///
@@ -31508,7 +31621,7 @@ impl RtSbRtkSlip {
     pub fn rtk_slip(&self) -> f32 {
         self.rtk_slip_raw()
     }
-    /// Get raw value of RTK_Slip
+    /// Get raw value of 'RTK_Slip'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -31523,7 +31636,7 @@ impl RtSbRtkSlip {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of RTK_Slip
+    /// Set value of 'RTK_Slip'
     #[inline(always)]
     pub fn set_rtk_slip(&mut self, value: f32) -> Result<(), CanError> {
         if value < -360_f32 || 360_f32 < value {
@@ -31538,7 +31651,7 @@ impl RtSbRtkSlip {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_RTK_Baseline
+    /// Get value of 'Accuracy_RTK_Baseline'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -31548,7 +31661,7 @@ impl RtSbRtkSlip {
     pub fn accuracy_rtk_baseline(&self) -> u8 {
         self.accuracy_rtk_baseline_raw()
     }
-    /// Get raw value of Accuracy_RTK_Baseline
+    /// Get raw value of 'Accuracy_RTK_Baseline'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -31562,7 +31675,7 @@ impl RtSbRtkSlip {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_RTK_Baseline
+    /// Set value of 'Accuracy_RTK_Baseline'
     #[inline(always)]
     pub fn set_accuracy_rtk_baseline(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -31580,7 +31693,7 @@ impl RtSbRtkSlip {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_RTK_Baseline
+    /// Get value of 'Validity_RTK_Baseline'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -31592,7 +31705,7 @@ impl RtSbRtkSlip {
     pub fn validity_rtk_baseline(&self) -> bool {
         self.validity_rtk_baseline_raw()
     }
-    /// Get raw value of Validity_RTK_Baseline
+    /// Get raw value of 'Validity_RTK_Baseline'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -31605,14 +31718,14 @@ impl RtSbRtkSlip {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_RTK_Baseline
+    /// Set value of 'Validity_RTK_Baseline'
     #[inline(always)]
     pub fn set_validity_rtk_baseline(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_RTK_Squat
+    /// Get value of 'Validity_RTK_Squat'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -31624,7 +31737,7 @@ impl RtSbRtkSlip {
     pub fn validity_rtk_squat(&self) -> bool {
         self.validity_rtk_squat_raw()
     }
-    /// Get raw value of Validity_RTK_Squat
+    /// Get raw value of 'Validity_RTK_Squat'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -31637,14 +31750,14 @@ impl RtSbRtkSlip {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_RTK_Squat
+    /// Set value of 'Validity_RTK_Squat'
     #[inline(always)]
     pub fn set_validity_rtk_squat(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_RTK_Slip
+    /// Get value of 'Validity_RTK_Slip'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -31656,7 +31769,7 @@ impl RtSbRtkSlip {
     pub fn validity_rtk_slip(&self) -> bool {
         self.validity_rtk_slip_raw()
     }
-    /// Get raw value of Validity_RTK_Slip
+    /// Get raw value of 'Validity_RTK_Slip'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -31669,7 +31782,7 @@ impl RtSbRtkSlip {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_RTK_Slip
+    /// Set value of 'Validity_RTK_Slip'
     #[inline(always)]
     pub fn set_validity_rtk_slip(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -31745,7 +31858,7 @@ impl RtSbRtkAttitude {
     pub const RTK_ATTITUDE_YAW_MAX: f32 = 360_f32;
     pub const ACCURACY_RTK_ATTITUDE_MIN: u8 = 0_u8;
     pub const ACCURACY_RTK_ATTITUDE_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_RTK_Attitude from values
+    /// Construct new 'RT_SB_RTK_Attitude' from values
     pub fn new(
         rtk_attitude_roll: f32,
         rtk_attitude_pitch: f32,
@@ -31769,7 +31882,7 @@ impl RtSbRtkAttitude {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// RTK_Attitude_Roll
+    /// Get value of 'RTK_Attitude_Roll'
     ///
     /// RTK attitude is determined from the MB-RTK solution only.  Roll is positive for a clockwise rotational displacement relative to the local horizontal plane when looking at the vehicle from the rear of it.
     ///
@@ -31781,7 +31894,7 @@ impl RtSbRtkAttitude {
     pub fn rtk_attitude_roll(&self) -> f32 {
         self.rtk_attitude_roll_raw()
     }
-    /// Get raw value of RTK_Attitude_Roll
+    /// Get raw value of 'RTK_Attitude_Roll'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -31796,7 +31909,7 @@ impl RtSbRtkAttitude {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of RTK_Attitude_Roll
+    /// Set value of 'RTK_Attitude_Roll'
     #[inline(always)]
     pub fn set_rtk_attitude_roll(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -31811,7 +31924,7 @@ impl RtSbRtkAttitude {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// RTK_Attitude_Pitch
+    /// Get value of 'RTK_Attitude_Pitch'
     ///
     /// RTK attitude is determined from the MB-RTK solution only.  Pitch is positive for a clockwise rotational displacement from the local horizontal plane when looking at the vehicle from the left hand side of it.
     ///
@@ -31823,7 +31936,7 @@ impl RtSbRtkAttitude {
     pub fn rtk_attitude_pitch(&self) -> f32 {
         self.rtk_attitude_pitch_raw()
     }
-    /// Get raw value of RTK_Attitude_Pitch
+    /// Get raw value of 'RTK_Attitude_Pitch'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -31838,7 +31951,7 @@ impl RtSbRtkAttitude {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of RTK_Attitude_Pitch
+    /// Set value of 'RTK_Attitude_Pitch'
     #[inline(always)]
     pub fn set_rtk_attitude_pitch(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -31853,7 +31966,7 @@ impl RtSbRtkAttitude {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// RTK_Attitude_Yaw
+    /// Get value of 'RTK_Attitude_Yaw'
     ///
     /// RTK attitude is determined from the MB-RTK solution only.  Yaw is positive for a clockwise rotational displacement from due North, looking down on the vehicle from above.
     ///
@@ -31865,7 +31978,7 @@ impl RtSbRtkAttitude {
     pub fn rtk_attitude_yaw(&self) -> f32 {
         self.rtk_attitude_yaw_raw()
     }
-    /// Get raw value of RTK_Attitude_Yaw
+    /// Get raw value of 'RTK_Attitude_Yaw'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -31880,7 +31993,7 @@ impl RtSbRtkAttitude {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of RTK_Attitude_Yaw
+    /// Set value of 'RTK_Attitude_Yaw'
     #[inline(always)]
     pub fn set_rtk_attitude_yaw(&mut self, value: f32) -> Result<(), CanError> {
         if value < -360_f32 || 360_f32 < value {
@@ -31895,7 +32008,7 @@ impl RtSbRtkAttitude {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_RTK_Attitude
+    /// Get value of 'Accuracy_RTK_Attitude'
     ///
     /// Note that RTK yaw is typically up to about 4 times more accurate than RTK pitch or roll.
     ///
@@ -31907,7 +32020,7 @@ impl RtSbRtkAttitude {
     pub fn accuracy_rtk_attitude(&self) -> u8 {
         self.accuracy_rtk_attitude_raw()
     }
-    /// Get raw value of Accuracy_RTK_Attitude
+    /// Get raw value of 'Accuracy_RTK_Attitude'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -31921,7 +32034,7 @@ impl RtSbRtkAttitude {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_RTK_Attitude
+    /// Set value of 'Accuracy_RTK_Attitude'
     #[inline(always)]
     pub fn set_accuracy_rtk_attitude(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -31939,7 +32052,7 @@ impl RtSbRtkAttitude {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_RTK_Roll
+    /// Get value of 'Validity_RTK_Roll'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -31951,7 +32064,7 @@ impl RtSbRtkAttitude {
     pub fn validity_rtk_roll(&self) -> bool {
         self.validity_rtk_roll_raw()
     }
-    /// Get raw value of Validity_RTK_Roll
+    /// Get raw value of 'Validity_RTK_Roll'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -31964,14 +32077,14 @@ impl RtSbRtkAttitude {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_RTK_Roll
+    /// Set value of 'Validity_RTK_Roll'
     #[inline(always)]
     pub fn set_validity_rtk_roll(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_RTK_Pitch
+    /// Get value of 'Validity_RTK_Pitch'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -31983,7 +32096,7 @@ impl RtSbRtkAttitude {
     pub fn validity_rtk_pitch(&self) -> bool {
         self.validity_rtk_pitch_raw()
     }
-    /// Get raw value of Validity_RTK_Pitch
+    /// Get raw value of 'Validity_RTK_Pitch'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -31996,14 +32109,14 @@ impl RtSbRtkAttitude {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_RTK_Pitch
+    /// Set value of 'Validity_RTK_Pitch'
     #[inline(always)]
     pub fn set_validity_rtk_pitch(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_RTK_Yaw
+    /// Get value of 'Validity_RTK_Yaw'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -32015,7 +32128,7 @@ impl RtSbRtkAttitude {
     pub fn validity_rtk_yaw(&self) -> bool {
         self.validity_rtk_yaw_raw()
     }
-    /// Get raw value of Validity_RTK_Yaw
+    /// Get raw value of 'Validity_RTK_Yaw'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -32028,7 +32141,7 @@ impl RtSbRtkAttitude {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_RTK_Yaw
+    /// Set value of 'Validity_RTK_Yaw'
     #[inline(always)]
     pub fn set_validity_rtk_yaw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -32102,7 +32215,7 @@ impl RtSbGpsMcycleLean {
     pub const GPS_LATERAL_ACCEL_MAX: f32 = 65_f32;
     pub const ACCURACY_GPS_LATERAL_ACCEL_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_LATERAL_ACCEL_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Mcycle_Lean from values
+    /// Construct new 'RT_SB_GPS_Mcycle_Lean' from values
     pub fn new(
         gps_mcycle_lean_angle: f32,
         gps_lateral_accel: f32,
@@ -32122,7 +32235,7 @@ impl RtSbGpsMcycleLean {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Mcycle_Lean_Angle
+    /// Get value of 'GPS_Mcycle_Lean_Angle'
     ///
     /// Motorcycle lean angle, derived from rate of change of heading from GPS.  This is the lean angle of the centre of mass of the combined bike + rider.
     ///
@@ -32134,7 +32247,7 @@ impl RtSbGpsMcycleLean {
     pub fn gps_mcycle_lean_angle(&self) -> f32 {
         self.gps_mcycle_lean_angle_raw()
     }
-    /// Get raw value of GPS_Mcycle_Lean_Angle
+    /// Get raw value of 'GPS_Mcycle_Lean_Angle'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -32149,7 +32262,7 @@ impl RtSbGpsMcycleLean {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Mcycle_Lean_Angle
+    /// Set value of 'GPS_Mcycle_Lean_Angle'
     #[inline(always)]
     pub fn set_gps_mcycle_lean_angle(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -32164,7 +32277,7 @@ impl RtSbGpsMcycleLean {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// GPS_Lateral_Accel
+    /// Get value of 'GPS_Lateral_Accel'
     ///
     /// GPS-derived lateral acceleration.  This is derived by differentiating GPS heading - it is much more noisy than lateral accel from the accelerometers, but useful for m/cycle applications.
     ///
@@ -32176,7 +32289,7 @@ impl RtSbGpsMcycleLean {
     pub fn gps_lateral_accel(&self) -> f32 {
         self.gps_lateral_accel_raw()
     }
-    /// Get raw value of GPS_Lateral_Accel
+    /// Get raw value of 'GPS_Lateral_Accel'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -32191,7 +32304,7 @@ impl RtSbGpsMcycleLean {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Lateral_Accel
+    /// Set value of 'GPS_Lateral_Accel'
     #[inline(always)]
     pub fn set_gps_lateral_accel(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -32206,7 +32319,7 @@ impl RtSbGpsMcycleLean {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Lateral_Accel
+    /// Get value of 'Accuracy_GPS_Lateral_Accel'
     ///
     /// This accuracy value applies to both GPS-derived lateral acceleration and motorcycle lean angle, since both are derived from the rate of change of GPS heading.
     ///
@@ -32218,7 +32331,7 @@ impl RtSbGpsMcycleLean {
     pub fn accuracy_gps_lateral_accel(&self) -> u8 {
         self.accuracy_gps_lateral_accel_raw()
     }
-    /// Get raw value of Accuracy_GPS_Lateral_Accel
+    /// Get raw value of 'Accuracy_GPS_Lateral_Accel'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -32232,7 +32345,7 @@ impl RtSbGpsMcycleLean {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Lateral_Accel
+    /// Set value of 'Accuracy_GPS_Lateral_Accel'
     #[inline(always)]
     pub fn set_accuracy_gps_lateral_accel(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -32250,7 +32363,7 @@ impl RtSbGpsMcycleLean {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Mcycle_Lean
+    /// Get value of 'Validity_GPS_Mcycle_Lean'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -32262,7 +32375,7 @@ impl RtSbGpsMcycleLean {
     pub fn validity_gps_mcycle_lean(&self) -> bool {
         self.validity_gps_mcycle_lean_raw()
     }
-    /// Get raw value of Validity_GPS_Mcycle_Lean
+    /// Get raw value of 'Validity_GPS_Mcycle_Lean'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -32275,14 +32388,14 @@ impl RtSbGpsMcycleLean {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Mcycle_Lean
+    /// Set value of 'Validity_GPS_Mcycle_Lean'
     #[inline(always)]
     pub fn set_validity_gps_mcycle_lean(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Lateral_Accel
+    /// Get value of 'Validity_GPS_Lateral_Accel'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -32294,7 +32407,7 @@ impl RtSbGpsMcycleLean {
     pub fn validity_gps_lateral_accel(&self) -> bool {
         self.validity_gps_lateral_accel_raw()
     }
-    /// Get raw value of Validity_GPS_Lateral_Accel
+    /// Get raw value of 'Validity_GPS_Lateral_Accel'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -32307,7 +32420,7 @@ impl RtSbGpsMcycleLean {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Lateral_Accel
+    /// Set value of 'Validity_GPS_Lateral_Accel'
     #[inline(always)]
     pub fn set_validity_gps_lateral_accel(
         &mut self,
@@ -32394,16 +32507,16 @@ impl RtSbGpsStatus {
     pub const FIRMWARE_VERSION_MAJOR_MAX: u8 = 255_u8;
     pub const GPS_STATUS_MIN: u8 = 0_u8;
     pub const GPS_STATUS_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Status from values
+    /// Construct new 'RT_SB_GPS_Status' from values
     pub fn new(
-        rtk_status: u8,
+        rtk_status: RtSbGpsStatusRtkStatus,
         gps_n_sv_rtk: u8,
         gps_n_sv_2: u8,
         gps_n_sv: u8,
         firmware_version_minor: u8,
         firmware_version_intermediate: u8,
         firmware_version_major: u8,
-        gps_status: u8,
+        gps_status: RtSbGpsStatusGpsStatus,
     ) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_rtk_status(rtk_status)?;
@@ -32420,7 +32533,7 @@ impl RtSbGpsStatus {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// RTK_Status
+    /// Get value of 'RTK_Status'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -32438,7 +32551,7 @@ impl RtSbGpsStatus {
             _ => RtSbGpsStatusRtkStatus::_Other(self.rtk_status_raw()),
         }
     }
-    /// Get raw value of RTK_Status
+    /// Get raw value of 'RTK_Status'
     ///
     /// - Start bit: 56
     /// - Signal size: 8 bits
@@ -32452,9 +32565,17 @@ impl RtSbGpsStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of RTK_Status
+    /// Set value of 'RTK_Status'
     #[inline(always)]
-    pub fn set_rtk_status(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_rtk_status(
+        &mut self,
+        value: RtSbGpsStatusRtkStatus,
+    ) -> Result<(), CanError> {
+        self.set_rtk_status_raw(u8::from(value))
+    }
+    /// Set raw value of 'RTK_Status'
+    #[inline(always)]
+    pub fn set_rtk_status_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: RtSbGpsStatus::MESSAGE_ID,
@@ -32470,7 +32591,7 @@ impl RtSbGpsStatus {
         self.raw.view_bits_mut::<Lsb0>()[56..64].store_le(value);
         Ok(())
     }
-    /// GPS_nSv_RTK
+    /// Get value of 'GPS_nSv_RTK'
     ///
     /// Number of common satellites available to RTK solution
     ///
@@ -32482,7 +32603,7 @@ impl RtSbGpsStatus {
     pub fn gps_n_sv_rtk(&self) -> u8 {
         self.gps_n_sv_rtk_raw()
     }
-    /// Get raw value of GPS_nSv_RTK
+    /// Get raw value of 'GPS_nSv_RTK'
     ///
     /// - Start bit: 48
     /// - Signal size: 8 bits
@@ -32496,7 +32617,7 @@ impl RtSbGpsStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GPS_nSv_RTK
+    /// Set value of 'GPS_nSv_RTK'
     #[inline(always)]
     pub fn set_gps_n_sv_rtk(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 16_u8 < value {
@@ -32514,7 +32635,7 @@ impl RtSbGpsStatus {
         self.raw.view_bits_mut::<Lsb0>()[48..56].store_le(value);
         Ok(())
     }
-    /// GPS_nSv_2
+    /// Get value of 'GPS_nSv_2'
     ///
     /// Number of satellites used in GPS solution by module 2 on RTK units.
     ///
@@ -32526,7 +32647,7 @@ impl RtSbGpsStatus {
     pub fn gps_n_sv_2(&self) -> u8 {
         self.gps_n_sv_2_raw()
     }
-    /// Get raw value of GPS_nSv_2
+    /// Get raw value of 'GPS_nSv_2'
     ///
     /// - Start bit: 40
     /// - Signal size: 8 bits
@@ -32540,7 +32661,7 @@ impl RtSbGpsStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GPS_nSv_2
+    /// Set value of 'GPS_nSv_2'
     #[inline(always)]
     pub fn set_gps_n_sv_2(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 16_u8 < value {
@@ -32558,7 +32679,7 @@ impl RtSbGpsStatus {
         self.raw.view_bits_mut::<Lsb0>()[40..48].store_le(value);
         Ok(())
     }
-    /// GPS_nSv
+    /// Get value of 'GPS_nSv'
     ///
     /// Number of satellites used in GPS solution
     ///
@@ -32570,7 +32691,7 @@ impl RtSbGpsStatus {
     pub fn gps_n_sv(&self) -> u8 {
         self.gps_n_sv_raw()
     }
-    /// Get raw value of GPS_nSv
+    /// Get raw value of 'GPS_nSv'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -32584,7 +32705,7 @@ impl RtSbGpsStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GPS_nSv
+    /// Set value of 'GPS_nSv'
     #[inline(always)]
     pub fn set_gps_n_sv(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 16_u8 < value {
@@ -32602,7 +32723,7 @@ impl RtSbGpsStatus {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// Firmware_Version_Minor
+    /// Get value of 'Firmware_Version_Minor'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -32612,7 +32733,7 @@ impl RtSbGpsStatus {
     pub fn firmware_version_minor(&self) -> u8 {
         self.firmware_version_minor_raw()
     }
-    /// Get raw value of Firmware_Version_Minor
+    /// Get raw value of 'Firmware_Version_Minor'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -32626,7 +32747,7 @@ impl RtSbGpsStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Firmware_Version_Minor
+    /// Set value of 'Firmware_Version_Minor'
     #[inline(always)]
     pub fn set_firmware_version_minor(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -32644,7 +32765,7 @@ impl RtSbGpsStatus {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Firmware_Version_Intermediate
+    /// Get value of 'Firmware_Version_Intermediate'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -32654,7 +32775,7 @@ impl RtSbGpsStatus {
     pub fn firmware_version_intermediate(&self) -> u8 {
         self.firmware_version_intermediate_raw()
     }
-    /// Get raw value of Firmware_Version_Intermediate
+    /// Get raw value of 'Firmware_Version_Intermediate'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -32668,7 +32789,7 @@ impl RtSbGpsStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Firmware_Version_Intermediate
+    /// Set value of 'Firmware_Version_Intermediate'
     #[inline(always)]
     pub fn set_firmware_version_intermediate(
         &mut self,
@@ -32689,7 +32810,7 @@ impl RtSbGpsStatus {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Firmware_Version_Major
+    /// Get value of 'Firmware_Version_Major'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -32699,7 +32820,7 @@ impl RtSbGpsStatus {
     pub fn firmware_version_major(&self) -> u8 {
         self.firmware_version_major_raw()
     }
-    /// Get raw value of Firmware_Version_Major
+    /// Get raw value of 'Firmware_Version_Major'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -32713,7 +32834,7 @@ impl RtSbGpsStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Firmware_Version_Major
+    /// Set value of 'Firmware_Version_Major'
     #[inline(always)]
     pub fn set_firmware_version_major(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -32731,7 +32852,7 @@ impl RtSbGpsStatus {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// GPS_Status
+    /// Get value of 'GPS_Status'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -32757,7 +32878,7 @@ impl RtSbGpsStatus {
             _ => RtSbGpsStatusGpsStatus::_Other(self.gps_status_raw()),
         }
     }
-    /// Get raw value of GPS_Status
+    /// Get raw value of 'GPS_Status'
     ///
     /// - Start bit: 0
     /// - Signal size: 8 bits
@@ -32771,9 +32892,17 @@ impl RtSbGpsStatus {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GPS_Status
+    /// Set value of 'GPS_Status'
     #[inline(always)]
-    pub fn set_gps_status(&mut self, value: u8) -> Result<(), CanError> {
+    pub fn set_gps_status(
+        &mut self,
+        value: RtSbGpsStatusGpsStatus,
+    ) -> Result<(), CanError> {
+        self.set_gps_status_raw(u8::from(value))
+    }
+    /// Set raw value of 'GPS_Status'
+    #[inline(always)]
+    pub fn set_gps_status_raw(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
             return Err(CanError::ParameterOutOfRange {
                 message_id: RtSbGpsStatus::MESSAGE_ID,
@@ -32926,7 +33055,7 @@ impl RtSbGpsPosEcef2 {
     pub const GPS_POS_ECEF_Z_MAX: f32 = 10000000_f32;
     pub const GPS_POS_ECEF_Y_MIN: f32 = -10000000_f32;
     pub const GPS_POS_ECEF_Y_MAX: f32 = 10000000_f32;
-    /// Construct new RT_SB_GPS_Pos_ECEF_2 from values
+    /// Construct new 'RT_SB_GPS_Pos_ECEF_2' from values
     pub fn new(gps_pos_ecef_z: f32, gps_pos_ecef_y: f32) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_gps_pos_ecef_z(gps_pos_ecef_z)?;
@@ -32937,7 +33066,7 @@ impl RtSbGpsPosEcef2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Pos_ECEF_Z
+    /// Get value of 'GPS_Pos_ECEF_Z'
     ///
     /// ECEF Z position.  The ECEF Z axis originates from the Earth centre, and the positive Z axis intersects the Earth surface at the North Pole.
     ///
@@ -32949,7 +33078,7 @@ impl RtSbGpsPosEcef2 {
     pub fn gps_pos_ecef_z(&self) -> f32 {
         self.gps_pos_ecef_z_raw()
     }
-    /// Get raw value of GPS_Pos_ECEF_Z
+    /// Get raw value of 'GPS_Pos_ECEF_Z'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -32964,7 +33093,7 @@ impl RtSbGpsPosEcef2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Pos_ECEF_Z
+    /// Set value of 'GPS_Pos_ECEF_Z'
     #[inline(always)]
     pub fn set_gps_pos_ecef_z(&mut self, value: f32) -> Result<(), CanError> {
         if value < -10000000_f32 || 10000000_f32 < value {
@@ -32979,7 +33108,7 @@ impl RtSbGpsPosEcef2 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// GPS_Pos_ECEF_Y
+    /// Get value of 'GPS_Pos_ECEF_Y'
     ///
     /// ECEF Y position.  The ECEF Y axis originates from the Earth centre, and the positive Y axis intersects the Earth surface at zero degrees latittude and 90 degrees longitude.
     ///
@@ -32991,7 +33120,7 @@ impl RtSbGpsPosEcef2 {
     pub fn gps_pos_ecef_y(&self) -> f32 {
         self.gps_pos_ecef_y_raw()
     }
-    /// Get raw value of GPS_Pos_ECEF_Y
+    /// Get raw value of 'GPS_Pos_ECEF_Y'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -33006,7 +33135,7 @@ impl RtSbGpsPosEcef2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Pos_ECEF_Y
+    /// Set value of 'GPS_Pos_ECEF_Y'
     #[inline(always)]
     pub fn set_gps_pos_ecef_y(&mut self, value: f32) -> Result<(), CanError> {
         if value < -10000000_f32 || 10000000_f32 < value {
@@ -33090,7 +33219,7 @@ impl RtSbGpsPosEcef1 {
     pub const ACCURACY_GPS_POS_ECEF_Y_MAX: u8 = 255_u8;
     pub const ACCURACY_GPS_POS_ECEF_X_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_POS_ECEF_X_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Pos_ECEF_1 from values
+    /// Construct new 'RT_SB_GPS_Pos_ECEF_1' from values
     pub fn new(
         gps_pos_ecef_x: f32,
         accuracy_gps_pos_ecef_z: u8,
@@ -33114,7 +33243,7 @@ impl RtSbGpsPosEcef1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Pos_ECEF_X
+    /// Get value of 'GPS_Pos_ECEF_X'
     ///
     /// ECEF X position.  The ECEF X axis originates from the Earth centre, and the positive X axis intersects the Earth surface at zero degrees latittude and zero degrees longitude (the intersection of the equator and the prime meridian).
     ///
@@ -33126,7 +33255,7 @@ impl RtSbGpsPosEcef1 {
     pub fn gps_pos_ecef_x(&self) -> f32 {
         self.gps_pos_ecef_x_raw()
     }
-    /// Get raw value of GPS_Pos_ECEF_X
+    /// Get raw value of 'GPS_Pos_ECEF_X'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -33141,7 +33270,7 @@ impl RtSbGpsPosEcef1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Pos_ECEF_X
+    /// Set value of 'GPS_Pos_ECEF_X'
     #[inline(always)]
     pub fn set_gps_pos_ecef_x(&mut self, value: f32) -> Result<(), CanError> {
         if value < -10000000_f32 || 10000000_f32 < value {
@@ -33156,7 +33285,7 @@ impl RtSbGpsPosEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Pos_ECEF_Z
+    /// Get value of 'Accuracy_GPS_Pos_ECEF_Z'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -33168,7 +33297,7 @@ impl RtSbGpsPosEcef1 {
     pub fn accuracy_gps_pos_ecef_z(&self) -> u8 {
         self.accuracy_gps_pos_ecef_z_raw()
     }
-    /// Get raw value of Accuracy_GPS_Pos_ECEF_Z
+    /// Get raw value of 'Accuracy_GPS_Pos_ECEF_Z'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -33182,7 +33311,7 @@ impl RtSbGpsPosEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Pos_ECEF_Z
+    /// Set value of 'Accuracy_GPS_Pos_ECEF_Z'
     #[inline(always)]
     pub fn set_accuracy_gps_pos_ecef_z(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -33200,7 +33329,7 @@ impl RtSbGpsPosEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Pos_ECEF_Y
+    /// Get value of 'Accuracy_GPS_Pos_ECEF_Y'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -33212,7 +33341,7 @@ impl RtSbGpsPosEcef1 {
     pub fn accuracy_gps_pos_ecef_y(&self) -> u8 {
         self.accuracy_gps_pos_ecef_y_raw()
     }
-    /// Get raw value of Accuracy_GPS_Pos_ECEF_Y
+    /// Get raw value of 'Accuracy_GPS_Pos_ECEF_Y'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -33226,7 +33355,7 @@ impl RtSbGpsPosEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Pos_ECEF_Y
+    /// Set value of 'Accuracy_GPS_Pos_ECEF_Y'
     #[inline(always)]
     pub fn set_accuracy_gps_pos_ecef_y(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -33244,7 +33373,7 @@ impl RtSbGpsPosEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Pos_ECEF_X
+    /// Get value of 'Accuracy_GPS_Pos_ECEF_X'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -33256,7 +33385,7 @@ impl RtSbGpsPosEcef1 {
     pub fn accuracy_gps_pos_ecef_x(&self) -> u8 {
         self.accuracy_gps_pos_ecef_x_raw()
     }
-    /// Get raw value of Accuracy_GPS_Pos_ECEF_X
+    /// Get raw value of 'Accuracy_GPS_Pos_ECEF_X'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -33270,7 +33399,7 @@ impl RtSbGpsPosEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Pos_ECEF_X
+    /// Set value of 'Accuracy_GPS_Pos_ECEF_X'
     #[inline(always)]
     pub fn set_accuracy_gps_pos_ecef_x(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -33288,7 +33417,7 @@ impl RtSbGpsPosEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Pos_ECEF_Z
+    /// Get value of 'Validity_GPS_Pos_ECEF_Z'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -33300,7 +33429,7 @@ impl RtSbGpsPosEcef1 {
     pub fn validity_gps_pos_ecef_z(&self) -> bool {
         self.validity_gps_pos_ecef_z_raw()
     }
-    /// Get raw value of Validity_GPS_Pos_ECEF_Z
+    /// Get raw value of 'Validity_GPS_Pos_ECEF_Z'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -33313,14 +33442,14 @@ impl RtSbGpsPosEcef1 {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Pos_ECEF_Z
+    /// Set value of 'Validity_GPS_Pos_ECEF_Z'
     #[inline(always)]
     pub fn set_validity_gps_pos_ecef_z(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Pos_ECEF_Y
+    /// Get value of 'Validity_GPS_Pos_ECEF_Y'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -33332,7 +33461,7 @@ impl RtSbGpsPosEcef1 {
     pub fn validity_gps_pos_ecef_y(&self) -> bool {
         self.validity_gps_pos_ecef_y_raw()
     }
-    /// Get raw value of Validity_GPS_Pos_ECEF_Y
+    /// Get raw value of 'Validity_GPS_Pos_ECEF_Y'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -33345,14 +33474,14 @@ impl RtSbGpsPosEcef1 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Pos_ECEF_Y
+    /// Set value of 'Validity_GPS_Pos_ECEF_Y'
     #[inline(always)]
     pub fn set_validity_gps_pos_ecef_y(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Pos_ECEF_X
+    /// Get value of 'Validity_GPS_Pos_ECEF_X'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -33364,7 +33493,7 @@ impl RtSbGpsPosEcef1 {
     pub fn validity_gps_pos_ecef_x(&self) -> bool {
         self.validity_gps_pos_ecef_x_raw()
     }
-    /// Get raw value of Validity_GPS_Pos_ECEF_X
+    /// Get raw value of 'Validity_GPS_Pos_ECEF_X'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -33377,7 +33506,7 @@ impl RtSbGpsPosEcef1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Pos_ECEF_X
+    /// Set value of 'Validity_GPS_Pos_ECEF_X'
     #[inline(always)]
     pub fn set_validity_gps_pos_ecef_x(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -33449,7 +33578,7 @@ impl RtSbGpsPosLlh2 {
     pub const GPS_POS_LLH_ALTITUDE_MAX: f32 = 100000_f32;
     pub const GPS_POS_LLH_LONGITUDE_MIN: f32 = -180_f32;
     pub const GPS_POS_LLH_LONGITUDE_MAX: f32 = 180_f32;
-    /// Construct new RT_SB_GPS_Pos_LLH_2 from values
+    /// Construct new 'RT_SB_GPS_Pos_LLH_2' from values
     pub fn new(
         gps_pos_llh_altitude: f32,
         gps_pos_llh_longitude: f32,
@@ -33463,7 +33592,7 @@ impl RtSbGpsPosLlh2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Pos_LLH_Altitude
+    /// Get value of 'GPS_Pos_LLH_Altitude'
     ///
     /// - Min: -1000
     /// - Max: 100000
@@ -33473,7 +33602,7 @@ impl RtSbGpsPosLlh2 {
     pub fn gps_pos_llh_altitude(&self) -> f32 {
         self.gps_pos_llh_altitude_raw()
     }
-    /// Get raw value of GPS_Pos_LLH_Altitude
+    /// Get raw value of 'GPS_Pos_LLH_Altitude'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -33488,7 +33617,7 @@ impl RtSbGpsPosLlh2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Pos_LLH_Altitude
+    /// Set value of 'GPS_Pos_LLH_Altitude'
     #[inline(always)]
     pub fn set_gps_pos_llh_altitude(&mut self, value: f32) -> Result<(), CanError> {
         if value < -1000_f32 || 100000_f32 < value {
@@ -33503,7 +33632,7 @@ impl RtSbGpsPosLlh2 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// GPS_Pos_LLH_Longitude
+    /// Get value of 'GPS_Pos_LLH_Longitude'
     ///
     /// - Min: -180
     /// - Max: 180
@@ -33513,7 +33642,7 @@ impl RtSbGpsPosLlh2 {
     pub fn gps_pos_llh_longitude(&self) -> f32 {
         self.gps_pos_llh_longitude_raw()
     }
-    /// Get raw value of GPS_Pos_LLH_Longitude
+    /// Get raw value of 'GPS_Pos_LLH_Longitude'
     ///
     /// - Start bit: 0
     /// - Signal size: 32 bits
@@ -33528,7 +33657,7 @@ impl RtSbGpsPosLlh2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Pos_LLH_Longitude
+    /// Set value of 'GPS_Pos_LLH_Longitude'
     #[inline(always)]
     pub fn set_gps_pos_llh_longitude(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -33612,7 +33741,7 @@ impl RtSbGpsPosLlh1 {
     pub const ACCURACY_GPS_POS_LLH_LONGITUDE_MAX: u8 = 255_u8;
     pub const ACCURACY_GPS_POS_LLH_LATITUDE_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_POS_LLH_LATITUDE_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Pos_LLH_1 from values
+    /// Construct new 'RT_SB_GPS_Pos_LLH_1' from values
     pub fn new(
         gps_pos_llh_latitude: f32,
         accuracy_gps_pos_llh_altitude: u8,
@@ -33636,7 +33765,7 @@ impl RtSbGpsPosLlh1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Pos_LLH_Latitude
+    /// Get value of 'GPS_Pos_LLH_Latitude'
     ///
     /// - Min: -90
     /// - Max: 90
@@ -33646,7 +33775,7 @@ impl RtSbGpsPosLlh1 {
     pub fn gps_pos_llh_latitude(&self) -> f32 {
         self.gps_pos_llh_latitude_raw()
     }
-    /// Get raw value of GPS_Pos_LLH_Latitude
+    /// Get raw value of 'GPS_Pos_LLH_Latitude'
     ///
     /// - Start bit: 32
     /// - Signal size: 32 bits
@@ -33661,7 +33790,7 @@ impl RtSbGpsPosLlh1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Pos_LLH_Latitude
+    /// Set value of 'GPS_Pos_LLH_Latitude'
     #[inline(always)]
     pub fn set_gps_pos_llh_latitude(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -33676,7 +33805,7 @@ impl RtSbGpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[32..64].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Pos_LLH_Altitude
+    /// Get value of 'Accuracy_GPS_Pos_LLH_Altitude'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -33688,7 +33817,7 @@ impl RtSbGpsPosLlh1 {
     pub fn accuracy_gps_pos_llh_altitude(&self) -> u8 {
         self.accuracy_gps_pos_llh_altitude_raw()
     }
-    /// Get raw value of Accuracy_GPS_Pos_LLH_Altitude
+    /// Get raw value of 'Accuracy_GPS_Pos_LLH_Altitude'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -33702,7 +33831,7 @@ impl RtSbGpsPosLlh1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Pos_LLH_Altitude
+    /// Set value of 'Accuracy_GPS_Pos_LLH_Altitude'
     #[inline(always)]
     pub fn set_accuracy_gps_pos_llh_altitude(
         &mut self,
@@ -33723,7 +33852,7 @@ impl RtSbGpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Pos_LLH_Longitude
+    /// Get value of 'Accuracy_GPS_Pos_LLH_Longitude'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -33735,7 +33864,7 @@ impl RtSbGpsPosLlh1 {
     pub fn accuracy_gps_pos_llh_longitude(&self) -> u8 {
         self.accuracy_gps_pos_llh_longitude_raw()
     }
-    /// Get raw value of Accuracy_GPS_Pos_LLH_Longitude
+    /// Get raw value of 'Accuracy_GPS_Pos_LLH_Longitude'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -33749,7 +33878,7 @@ impl RtSbGpsPosLlh1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Pos_LLH_Longitude
+    /// Set value of 'Accuracy_GPS_Pos_LLH_Longitude'
     #[inline(always)]
     pub fn set_accuracy_gps_pos_llh_longitude(
         &mut self,
@@ -33770,7 +33899,7 @@ impl RtSbGpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Pos_LLH_Latitude
+    /// Get value of 'Accuracy_GPS_Pos_LLH_Latitude'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -33782,7 +33911,7 @@ impl RtSbGpsPosLlh1 {
     pub fn accuracy_gps_pos_llh_latitude(&self) -> u8 {
         self.accuracy_gps_pos_llh_latitude_raw()
     }
-    /// Get raw value of Accuracy_GPS_Pos_LLH_Latitude
+    /// Get raw value of 'Accuracy_GPS_Pos_LLH_Latitude'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -33796,7 +33925,7 @@ impl RtSbGpsPosLlh1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Pos_LLH_Latitude
+    /// Set value of 'Accuracy_GPS_Pos_LLH_Latitude'
     #[inline(always)]
     pub fn set_accuracy_gps_pos_llh_latitude(
         &mut self,
@@ -33817,7 +33946,7 @@ impl RtSbGpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Pos_LLH_Altitude
+    /// Get value of 'Validity_GPS_Pos_LLH_Altitude'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -33829,7 +33958,7 @@ impl RtSbGpsPosLlh1 {
     pub fn validity_gps_pos_llh_altitude(&self) -> bool {
         self.validity_gps_pos_llh_altitude_raw()
     }
-    /// Get raw value of Validity_GPS_Pos_LLH_Altitude
+    /// Get raw value of 'Validity_GPS_Pos_LLH_Altitude'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -33842,7 +33971,7 @@ impl RtSbGpsPosLlh1 {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Pos_LLH_Altitude
+    /// Set value of 'Validity_GPS_Pos_LLH_Altitude'
     #[inline(always)]
     pub fn set_validity_gps_pos_llh_altitude(
         &mut self,
@@ -33852,7 +33981,7 @@ impl RtSbGpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Pos_LLH_Longitude
+    /// Get value of 'Validity_GPS_Pos_LLH_Longitude'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -33864,7 +33993,7 @@ impl RtSbGpsPosLlh1 {
     pub fn validity_gps_pos_llh_longitude(&self) -> bool {
         self.validity_gps_pos_llh_longitude_raw()
     }
-    /// Get raw value of Validity_GPS_Pos_LLH_Longitude
+    /// Get raw value of 'Validity_GPS_Pos_LLH_Longitude'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -33877,7 +34006,7 @@ impl RtSbGpsPosLlh1 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Pos_LLH_Longitude
+    /// Set value of 'Validity_GPS_Pos_LLH_Longitude'
     #[inline(always)]
     pub fn set_validity_gps_pos_llh_longitude(
         &mut self,
@@ -33887,7 +34016,7 @@ impl RtSbGpsPosLlh1 {
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Pos_LLH_Latitude
+    /// Get value of 'Validity_GPS_Pos_LLH_Latitude'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -33899,7 +34028,7 @@ impl RtSbGpsPosLlh1 {
     pub fn validity_gps_pos_llh_latitude(&self) -> bool {
         self.validity_gps_pos_llh_latitude_raw()
     }
-    /// Get raw value of Validity_GPS_Pos_LLH_Latitude
+    /// Get raw value of 'Validity_GPS_Pos_LLH_Latitude'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -33912,7 +34041,7 @@ impl RtSbGpsPosLlh1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Pos_LLH_Latitude
+    /// Set value of 'Validity_GPS_Pos_LLH_Latitude'
     #[inline(always)]
     pub fn set_validity_gps_pos_llh_latitude(
         &mut self,
@@ -33991,7 +34120,7 @@ impl RtSbGpsHeadingGradient {
     pub const GPS_HEADING_MAX: f32 = 180_f32;
     pub const ACCURACY_GPS_HEADING_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_HEADING_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Heading_Gradient from values
+    /// Construct new 'RT_SB_GPS_Heading_Gradient' from values
     pub fn new(
         gps_gradient: f32,
         accuracy_gps_gradient: u8,
@@ -34013,7 +34142,7 @@ impl RtSbGpsHeadingGradient {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Gradient
+    /// Get value of 'GPS_Gradient'
     ///
     /// This is GPS gradient, i.e. the vertical direction that the vehicle is travelling, NOT pointing (pitch).
     ///
@@ -34025,7 +34154,7 @@ impl RtSbGpsHeadingGradient {
     pub fn gps_gradient(&self) -> f32 {
         self.gps_gradient_raw()
     }
-    /// Get raw value of GPS_Gradient
+    /// Get raw value of 'GPS_Gradient'
     ///
     /// - Start bit: 40
     /// - Signal size: 16 bits
@@ -34040,7 +34169,7 @@ impl RtSbGpsHeadingGradient {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Gradient
+    /// Set value of 'GPS_Gradient'
     #[inline(always)]
     pub fn set_gps_gradient(&mut self, value: f32) -> Result<(), CanError> {
         if value < -90_f32 || 90_f32 < value {
@@ -34055,7 +34184,7 @@ impl RtSbGpsHeadingGradient {
         self.raw.view_bits_mut::<Lsb0>()[40..56].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Gradient
+    /// Get value of 'Accuracy_GPS_Gradient'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -34067,7 +34196,7 @@ impl RtSbGpsHeadingGradient {
     pub fn accuracy_gps_gradient(&self) -> u8 {
         self.accuracy_gps_gradient_raw()
     }
-    /// Get raw value of Accuracy_GPS_Gradient
+    /// Get raw value of 'Accuracy_GPS_Gradient'
     ///
     /// - Start bit: 32
     /// - Signal size: 8 bits
@@ -34081,7 +34210,7 @@ impl RtSbGpsHeadingGradient {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Gradient
+    /// Set value of 'Accuracy_GPS_Gradient'
     #[inline(always)]
     pub fn set_accuracy_gps_gradient(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -34099,7 +34228,7 @@ impl RtSbGpsHeadingGradient {
         self.raw.view_bits_mut::<Lsb0>()[32..40].store_le(value);
         Ok(())
     }
-    /// GPS_Heading
+    /// Get value of 'GPS_Heading'
     ///
     /// This is GPS heading, the direction that the vehicle is travelling in the local horizontal plane.
     ///
@@ -34111,7 +34240,7 @@ impl RtSbGpsHeadingGradient {
     pub fn gps_heading(&self) -> f32 {
         self.gps_heading_raw()
     }
-    /// Get raw value of GPS_Heading
+    /// Get raw value of 'GPS_Heading'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -34126,7 +34255,7 @@ impl RtSbGpsHeadingGradient {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Heading
+    /// Set value of 'GPS_Heading'
     #[inline(always)]
     pub fn set_gps_heading(&mut self, value: f32) -> Result<(), CanError> {
         if value < -180_f32 || 180_f32 < value {
@@ -34141,7 +34270,7 @@ impl RtSbGpsHeadingGradient {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Heading
+    /// Get value of 'Accuracy_GPS_Heading'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -34153,7 +34282,7 @@ impl RtSbGpsHeadingGradient {
     pub fn accuracy_gps_heading(&self) -> u8 {
         self.accuracy_gps_heading_raw()
     }
-    /// Get raw value of Accuracy_GPS_Heading
+    /// Get raw value of 'Accuracy_GPS_Heading'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -34167,7 +34296,7 @@ impl RtSbGpsHeadingGradient {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Heading
+    /// Set value of 'Accuracy_GPS_Heading'
     #[inline(always)]
     pub fn set_accuracy_gps_heading(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -34185,7 +34314,7 @@ impl RtSbGpsHeadingGradient {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Gradient
+    /// Get value of 'Validity_GPS_Gradient'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -34197,7 +34326,7 @@ impl RtSbGpsHeadingGradient {
     pub fn validity_gps_gradient(&self) -> bool {
         self.validity_gps_gradient_raw()
     }
-    /// Get raw value of Validity_GPS_Gradient
+    /// Get raw value of 'Validity_GPS_Gradient'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -34210,14 +34339,14 @@ impl RtSbGpsHeadingGradient {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Gradient
+    /// Set value of 'Validity_GPS_Gradient'
     #[inline(always)]
     pub fn set_validity_gps_gradient(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Heading
+    /// Get value of 'Validity_GPS_Heading'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -34229,7 +34358,7 @@ impl RtSbGpsHeadingGradient {
     pub fn validity_gps_heading(&self) -> bool {
         self.validity_gps_heading_raw()
     }
-    /// Get raw value of Validity_GPS_Heading
+    /// Get raw value of 'Validity_GPS_Heading'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -34242,7 +34371,7 @@ impl RtSbGpsHeadingGradient {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Heading
+    /// Set value of 'Validity_GPS_Heading'
     #[inline(always)]
     pub fn set_validity_gps_heading(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -34314,7 +34443,7 @@ impl RtSbGpsVelEcef2 {
     pub const GPS_VEL_ECEF_Z_MAX: f32 = 838_f32;
     pub const GPS_VEL_ECEF_Y_MIN: f32 = -838_f32;
     pub const GPS_VEL_ECEF_Y_MAX: f32 = 838_f32;
-    /// Construct new RT_SB_GPS_Vel_ECEF_2 from values
+    /// Construct new 'RT_SB_GPS_Vel_ECEF_2' from values
     pub fn new(
         gps_vel_ecef_z: f32,
         gps_vel_ecef_y: f32,
@@ -34332,7 +34461,7 @@ impl RtSbGpsVelEcef2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Vel_ECEF_Z
+    /// Get value of 'GPS_Vel_ECEF_Z'
     ///
     /// ECEF Z velocity.  The ECEF Z axis originates from the Earth centre, and the positive Z axis intersects the Earth surface at the North Pole.
     ///
@@ -34344,7 +34473,7 @@ impl RtSbGpsVelEcef2 {
     pub fn gps_vel_ecef_z(&self) -> f32 {
         self.gps_vel_ecef_z_raw()
     }
-    /// Get raw value of GPS_Vel_ECEF_Z
+    /// Get raw value of 'GPS_Vel_ECEF_Z'
     ///
     /// - Start bit: 32
     /// - Signal size: 24 bits
@@ -34359,7 +34488,7 @@ impl RtSbGpsVelEcef2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Vel_ECEF_Z
+    /// Set value of 'GPS_Vel_ECEF_Z'
     #[inline(always)]
     pub fn set_gps_vel_ecef_z(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -34374,7 +34503,7 @@ impl RtSbGpsVelEcef2 {
         self.raw.view_bits_mut::<Lsb0>()[32..56].store_le(value);
         Ok(())
     }
-    /// GPS_Vel_ECEF_Y
+    /// Get value of 'GPS_Vel_ECEF_Y'
     ///
     /// ECEF Y velocity.  The ECEF Y axis originates from the Earth centre, and the positive Y axis intersects the Earth surface at zero degrees latittude and 90 degrees longitude.
     ///
@@ -34386,7 +34515,7 @@ impl RtSbGpsVelEcef2 {
     pub fn gps_vel_ecef_y(&self) -> f32 {
         self.gps_vel_ecef_y_raw()
     }
-    /// Get raw value of GPS_Vel_ECEF_Y
+    /// Get raw value of 'GPS_Vel_ECEF_Y'
     ///
     /// - Start bit: 8
     /// - Signal size: 24 bits
@@ -34401,7 +34530,7 @@ impl RtSbGpsVelEcef2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Vel_ECEF_Y
+    /// Set value of 'GPS_Vel_ECEF_Y'
     #[inline(always)]
     pub fn set_gps_vel_ecef_y(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -34416,7 +34545,7 @@ impl RtSbGpsVelEcef2 {
         self.raw.view_bits_mut::<Lsb0>()[8..32].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Vel_ECEF_Z
+    /// Get value of 'Validity_GPS_Vel_ECEF_Z'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -34428,7 +34557,7 @@ impl RtSbGpsVelEcef2 {
     pub fn validity_gps_vel_ecef_z(&self) -> bool {
         self.validity_gps_vel_ecef_z_raw()
     }
-    /// Get raw value of Validity_GPS_Vel_ECEF_Z
+    /// Get raw value of 'Validity_GPS_Vel_ECEF_Z'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -34441,14 +34570,14 @@ impl RtSbGpsVelEcef2 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Vel_ECEF_Z
+    /// Set value of 'Validity_GPS_Vel_ECEF_Z'
     #[inline(always)]
     pub fn set_validity_gps_vel_ecef_z(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Vel_ECEF_Y
+    /// Get value of 'Validity_GPS_Vel_ECEF_Y'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -34460,7 +34589,7 @@ impl RtSbGpsVelEcef2 {
     pub fn validity_gps_vel_ecef_y(&self) -> bool {
         self.validity_gps_vel_ecef_y_raw()
     }
-    /// Get raw value of Validity_GPS_Vel_ECEF_Y
+    /// Get raw value of 'Validity_GPS_Vel_ECEF_Y'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -34473,7 +34602,7 @@ impl RtSbGpsVelEcef2 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Vel_ECEF_Y
+    /// Set value of 'Validity_GPS_Vel_ECEF_Y'
     #[inline(always)]
     pub fn set_validity_gps_vel_ecef_y(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -34549,7 +34678,7 @@ impl RtSbGpsVelEcef1 {
     pub const ACCURACY_GPS_VEL_ECEF_Y_MAX: u8 = 255_u8;
     pub const ACCURACY_GPS_VEL_ECEF_X_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_VEL_ECEF_X_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Vel_ECEF_1 from values
+    /// Construct new 'RT_SB_GPS_Vel_ECEF_1' from values
     pub fn new(
         gps_vel_ecef_x: f32,
         accuracy_gps_vel_ecef_z: u8,
@@ -34569,7 +34698,7 @@ impl RtSbGpsVelEcef1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Vel_ECEF_X
+    /// Get value of 'GPS_Vel_ECEF_X'
     ///
     /// ECEF X velocity.  The ECEF X axis originates from the Earth centre, and the positive X axis intersects the Earth surface at zero degrees latittude and zero degrees longitude (the intersection of the equator and the prime meridian).
     ///
@@ -34581,7 +34710,7 @@ impl RtSbGpsVelEcef1 {
     pub fn gps_vel_ecef_x(&self) -> f32 {
         self.gps_vel_ecef_x_raw()
     }
-    /// Get raw value of GPS_Vel_ECEF_X
+    /// Get raw value of 'GPS_Vel_ECEF_X'
     ///
     /// - Start bit: 32
     /// - Signal size: 24 bits
@@ -34596,7 +34725,7 @@ impl RtSbGpsVelEcef1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Vel_ECEF_X
+    /// Set value of 'GPS_Vel_ECEF_X'
     #[inline(always)]
     pub fn set_gps_vel_ecef_x(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -34611,7 +34740,7 @@ impl RtSbGpsVelEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[32..56].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Vel_ECEF_Z
+    /// Get value of 'Accuracy_GPS_Vel_ECEF_Z'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -34621,7 +34750,7 @@ impl RtSbGpsVelEcef1 {
     pub fn accuracy_gps_vel_ecef_z(&self) -> u8 {
         self.accuracy_gps_vel_ecef_z_raw()
     }
-    /// Get raw value of Accuracy_GPS_Vel_ECEF_Z
+    /// Get raw value of 'Accuracy_GPS_Vel_ECEF_Z'
     ///
     /// - Start bit: 24
     /// - Signal size: 8 bits
@@ -34635,7 +34764,7 @@ impl RtSbGpsVelEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Vel_ECEF_Z
+    /// Set value of 'Accuracy_GPS_Vel_ECEF_Z'
     #[inline(always)]
     pub fn set_accuracy_gps_vel_ecef_z(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -34653,7 +34782,7 @@ impl RtSbGpsVelEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[24..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Vel_ECEF_Y
+    /// Get value of 'Accuracy_GPS_Vel_ECEF_Y'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -34663,7 +34792,7 @@ impl RtSbGpsVelEcef1 {
     pub fn accuracy_gps_vel_ecef_y(&self) -> u8 {
         self.accuracy_gps_vel_ecef_y_raw()
     }
-    /// Get raw value of Accuracy_GPS_Vel_ECEF_Y
+    /// Get raw value of 'Accuracy_GPS_Vel_ECEF_Y'
     ///
     /// - Start bit: 16
     /// - Signal size: 8 bits
@@ -34677,7 +34806,7 @@ impl RtSbGpsVelEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Vel_ECEF_Y
+    /// Set value of 'Accuracy_GPS_Vel_ECEF_Y'
     #[inline(always)]
     pub fn set_accuracy_gps_vel_ecef_y(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -34695,7 +34824,7 @@ impl RtSbGpsVelEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[16..24].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Vel_ECEF_X
+    /// Get value of 'Accuracy_GPS_Vel_ECEF_X'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -34705,7 +34834,7 @@ impl RtSbGpsVelEcef1 {
     pub fn accuracy_gps_vel_ecef_x(&self) -> u8 {
         self.accuracy_gps_vel_ecef_x_raw()
     }
-    /// Get raw value of Accuracy_GPS_Vel_ECEF_X
+    /// Get raw value of 'Accuracy_GPS_Vel_ECEF_X'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -34719,7 +34848,7 @@ impl RtSbGpsVelEcef1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Vel_ECEF_X
+    /// Set value of 'Accuracy_GPS_Vel_ECEF_X'
     #[inline(always)]
     pub fn set_accuracy_gps_vel_ecef_x(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -34737,7 +34866,7 @@ impl RtSbGpsVelEcef1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Vel_ECEF_X
+    /// Get value of 'Validity_GPS_Vel_ECEF_X'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -34749,7 +34878,7 @@ impl RtSbGpsVelEcef1 {
     pub fn validity_gps_vel_ecef_x(&self) -> bool {
         self.validity_gps_vel_ecef_x_raw()
     }
-    /// Get raw value of Validity_GPS_Vel_ECEF_X
+    /// Get raw value of 'Validity_GPS_Vel_ECEF_X'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -34762,7 +34891,7 @@ impl RtSbGpsVelEcef1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Vel_ECEF_X
+    /// Set value of 'Validity_GPS_Vel_ECEF_X'
     #[inline(always)]
     pub fn set_validity_gps_vel_ecef_x(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -34834,7 +34963,7 @@ impl RtSbGpsVelNed2 {
     pub const GPS_VEL_NED_D_MAX: f32 = 838_f32;
     pub const ACCURACY_GPS_VEL_D_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_VEL_D_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Vel_NED_2 from values
+    /// Construct new 'RT_SB_GPS_Vel_NED_2' from values
     pub fn new(
         gps_vel_ned_d: f32,
         accuracy_gps_vel_d: u8,
@@ -34850,7 +34979,7 @@ impl RtSbGpsVelNed2 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Vel_NED_D
+    /// Get value of 'GPS_Vel_NED_D'
     ///
     /// VELNED D velocity.  This is the velocity vector directly downwards towards the Earth centre at the current local Earth surface position.
     ///
@@ -34862,7 +34991,7 @@ impl RtSbGpsVelNed2 {
     pub fn gps_vel_ned_d(&self) -> f32 {
         self.gps_vel_ned_d_raw()
     }
-    /// Get raw value of GPS_Vel_NED_D
+    /// Get raw value of 'GPS_Vel_NED_D'
     ///
     /// - Start bit: 16
     /// - Signal size: 24 bits
@@ -34877,7 +35006,7 @@ impl RtSbGpsVelNed2 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Vel_NED_D
+    /// Set value of 'GPS_Vel_NED_D'
     #[inline(always)]
     pub fn set_gps_vel_ned_d(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -34892,7 +35021,7 @@ impl RtSbGpsVelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[16..40].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Vel_D
+    /// Get value of 'Accuracy_GPS_Vel_D'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -34902,7 +35031,7 @@ impl RtSbGpsVelNed2 {
     pub fn accuracy_gps_vel_d(&self) -> u8 {
         self.accuracy_gps_vel_d_raw()
     }
-    /// Get raw value of Accuracy_GPS_Vel_D
+    /// Get raw value of 'Accuracy_GPS_Vel_D'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -34916,7 +35045,7 @@ impl RtSbGpsVelNed2 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Vel_D
+    /// Set value of 'Accuracy_GPS_Vel_D'
     #[inline(always)]
     pub fn set_accuracy_gps_vel_d(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -34934,7 +35063,7 @@ impl RtSbGpsVelNed2 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Vel_NED_D
+    /// Get value of 'Validity_GPS_Vel_NED_D'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -34946,7 +35075,7 @@ impl RtSbGpsVelNed2 {
     pub fn validity_gps_vel_ned_d(&self) -> bool {
         self.validity_gps_vel_ned_d_raw()
     }
-    /// Get raw value of Validity_GPS_Vel_NED_D
+    /// Get raw value of 'Validity_GPS_Vel_NED_D'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -34959,7 +35088,7 @@ impl RtSbGpsVelNed2 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Vel_NED_D
+    /// Set value of 'Validity_GPS_Vel_NED_D'
     #[inline(always)]
     pub fn set_validity_gps_vel_ned_d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -35033,7 +35162,7 @@ impl RtSbGpsVelNed1 {
     pub const GPS_VEL_NED_N_MAX: f32 = 838_f32;
     pub const ACCURACY_GPS_VEL_NE_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_VEL_NE_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Vel_NED_1 from values
+    /// Construct new 'RT_SB_GPS_Vel_NED_1' from values
     pub fn new(
         gps_vel_ned_e: f32,
         gps_vel_ned_n: f32,
@@ -35053,7 +35182,7 @@ impl RtSbGpsVelNed1 {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Vel_NED_E
+    /// Get value of 'GPS_Vel_NED_E'
     ///
     /// VELNED E velocity.  This is the velocity vector directly East at the current local Earth surface position.
     ///
@@ -35065,7 +35194,7 @@ impl RtSbGpsVelNed1 {
     pub fn gps_vel_ned_e(&self) -> f32 {
         self.gps_vel_ned_e_raw()
     }
-    /// Get raw value of GPS_Vel_NED_E
+    /// Get raw value of 'GPS_Vel_NED_E'
     ///
     /// - Start bit: 40
     /// - Signal size: 24 bits
@@ -35080,7 +35209,7 @@ impl RtSbGpsVelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Vel_NED_E
+    /// Set value of 'GPS_Vel_NED_E'
     #[inline(always)]
     pub fn set_gps_vel_ned_e(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -35095,7 +35224,7 @@ impl RtSbGpsVelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[40..64].store_le(value);
         Ok(())
     }
-    /// GPS_Vel_NED_N
+    /// Get value of 'GPS_Vel_NED_N'
     ///
     /// VELNED N velocity.  This is the velocity vector directly North at the current local Earth surface position.
     ///
@@ -35107,7 +35236,7 @@ impl RtSbGpsVelNed1 {
     pub fn gps_vel_ned_n(&self) -> f32 {
         self.gps_vel_ned_n_raw()
     }
-    /// Get raw value of GPS_Vel_NED_N
+    /// Get raw value of 'GPS_Vel_NED_N'
     ///
     /// - Start bit: 16
     /// - Signal size: 24 bits
@@ -35122,7 +35251,7 @@ impl RtSbGpsVelNed1 {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Vel_NED_N
+    /// Set value of 'GPS_Vel_NED_N'
     #[inline(always)]
     pub fn set_gps_vel_ned_n(&mut self, value: f32) -> Result<(), CanError> {
         if value < -838_f32 || 838_f32 < value {
@@ -35137,7 +35266,7 @@ impl RtSbGpsVelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[16..40].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Vel_NE
+    /// Get value of 'Accuracy_GPS_Vel_NE'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -35147,7 +35276,7 @@ impl RtSbGpsVelNed1 {
     pub fn accuracy_gps_vel_ne(&self) -> u8 {
         self.accuracy_gps_vel_ne_raw()
     }
-    /// Get raw value of Accuracy_GPS_Vel_NE
+    /// Get raw value of 'Accuracy_GPS_Vel_NE'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -35161,7 +35290,7 @@ impl RtSbGpsVelNed1 {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Vel_NE
+    /// Set value of 'Accuracy_GPS_Vel_NE'
     #[inline(always)]
     pub fn set_accuracy_gps_vel_ne(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -35179,7 +35308,7 @@ impl RtSbGpsVelNed1 {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Vel_NED_E
+    /// Get value of 'Validity_GPS_Vel_NED_E'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -35191,7 +35320,7 @@ impl RtSbGpsVelNed1 {
     pub fn validity_gps_vel_ned_e(&self) -> bool {
         self.validity_gps_vel_ned_e_raw()
     }
-    /// Get raw value of Validity_GPS_Vel_NED_E
+    /// Get raw value of 'Validity_GPS_Vel_NED_E'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -35204,14 +35333,14 @@ impl RtSbGpsVelNed1 {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Vel_NED_E
+    /// Set value of 'Validity_GPS_Vel_NED_E'
     #[inline(always)]
     pub fn set_validity_gps_vel_ned_e(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Vel_NED_N
+    /// Get value of 'Validity_GPS_Vel_NED_N'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -35223,7 +35352,7 @@ impl RtSbGpsVelNed1 {
     pub fn validity_gps_vel_ned_n(&self) -> bool {
         self.validity_gps_vel_ned_n_raw()
     }
-    /// Get raw value of Validity_GPS_Vel_NED_N
+    /// Get raw value of 'Validity_GPS_Vel_NED_N'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -35236,7 +35365,7 @@ impl RtSbGpsVelNed1 {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Vel_NED_N
+    /// Set value of 'Validity_GPS_Vel_NED_N'
     #[inline(always)]
     pub fn set_validity_gps_vel_ned_n(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -35310,7 +35439,7 @@ impl RtSbGpsSpeed {
     pub const GPS_SPEED_2D_MAX: f32 = 1675_f32;
     pub const ACCURACY_GPS_SPEED_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_SPEED_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Speed from values
+    /// Construct new 'RT_SB_GPS_Speed' from values
     pub fn new(
         gps_speed_3d: f32,
         gps_speed_2d: f32,
@@ -35330,7 +35459,7 @@ impl RtSbGpsSpeed {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Speed_3D
+    /// Get value of 'GPS_Speed_3D'
     ///
     /// This is GPS scalar 3D speed - scalar speed with the local Z axis component included.
     ///
@@ -35342,7 +35471,7 @@ impl RtSbGpsSpeed {
     pub fn gps_speed_3d(&self) -> f32 {
         self.gps_speed_3d_raw()
     }
-    /// Get raw value of GPS_Speed_3D
+    /// Get raw value of 'GPS_Speed_3D'
     ///
     /// - Start bit: 40
     /// - Signal size: 24 bits
@@ -35357,7 +35486,7 @@ impl RtSbGpsSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Speed_3D
+    /// Set value of 'GPS_Speed_3D'
     #[inline(always)]
     pub fn set_gps_speed_3d(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 1675_f32 < value {
@@ -35371,7 +35500,7 @@ impl RtSbGpsSpeed {
         self.raw.view_bits_mut::<Lsb0>()[40..64].store_le(value);
         Ok(())
     }
-    /// GPS_Speed_2D
+    /// Get value of 'GPS_Speed_2D'
     ///
     /// This is GPS scalar 2D speed - scalar speed with no local Z axis component included.
     ///
@@ -35383,7 +35512,7 @@ impl RtSbGpsSpeed {
     pub fn gps_speed_2d(&self) -> f32 {
         self.gps_speed_2d_raw()
     }
-    /// Get raw value of GPS_Speed_2D
+    /// Get raw value of 'GPS_Speed_2D'
     ///
     /// - Start bit: 16
     /// - Signal size: 24 bits
@@ -35398,7 +35527,7 @@ impl RtSbGpsSpeed {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Speed_2D
+    /// Set value of 'GPS_Speed_2D'
     #[inline(always)]
     pub fn set_gps_speed_2d(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 1675_f32 < value {
@@ -35412,7 +35541,7 @@ impl RtSbGpsSpeed {
         self.raw.view_bits_mut::<Lsb0>()[16..40].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Speed
+    /// Get value of 'Accuracy_GPS_Speed'
     ///
     /// This accuracy value applies to both 2D and 3D GPS speed.
     ///
@@ -35424,7 +35553,7 @@ impl RtSbGpsSpeed {
     pub fn accuracy_gps_speed(&self) -> u8 {
         self.accuracy_gps_speed_raw()
     }
-    /// Get raw value of Accuracy_GPS_Speed
+    /// Get raw value of 'Accuracy_GPS_Speed'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -35438,7 +35567,7 @@ impl RtSbGpsSpeed {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Speed
+    /// Set value of 'Accuracy_GPS_Speed'
     #[inline(always)]
     pub fn set_accuracy_gps_speed(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -35456,7 +35585,7 @@ impl RtSbGpsSpeed {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Speed_3D
+    /// Get value of 'Validity_GPS_Speed_3D'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -35468,7 +35597,7 @@ impl RtSbGpsSpeed {
     pub fn validity_gps_speed_3d(&self) -> bool {
         self.validity_gps_speed_3d_raw()
     }
-    /// Get raw value of Validity_GPS_Speed_3D
+    /// Get raw value of 'Validity_GPS_Speed_3D'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -35481,14 +35610,14 @@ impl RtSbGpsSpeed {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Speed_3D
+    /// Set value of 'Validity_GPS_Speed_3D'
     #[inline(always)]
     pub fn set_validity_gps_speed_3d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Speed_2D
+    /// Get value of 'Validity_GPS_Speed_2D'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -35500,7 +35629,7 @@ impl RtSbGpsSpeed {
     pub fn validity_gps_speed_2d(&self) -> bool {
         self.validity_gps_speed_2d_raw()
     }
-    /// Get raw value of Validity_GPS_Speed_2D
+    /// Get raw value of 'Validity_GPS_Speed_2D'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -35513,7 +35642,7 @@ impl RtSbGpsSpeed {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Speed_2D
+    /// Set value of 'Validity_GPS_Speed_2D'
     #[inline(always)]
     pub fn set_validity_gps_speed_2d(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -35587,7 +35716,7 @@ impl RtSbGpsTime {
     pub const GPS_TIME_MAX: f32 = 604800_f32;
     pub const ACCURACY_GPS_TIME_MIN: u8 = 0_u8;
     pub const ACCURACY_GPS_TIME_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_GPS_Time from values
+    /// Construct new 'RT_SB_GPS_Time' from values
     pub fn new(
         gps_week: u16,
         gps_time: f32,
@@ -35607,7 +35736,7 @@ impl RtSbGpsTime {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// GPS_Week
+    /// Get value of 'GPS_Week'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -35617,7 +35746,7 @@ impl RtSbGpsTime {
     pub fn gps_week(&self) -> u16 {
         self.gps_week_raw()
     }
-    /// Get raw value of GPS_Week
+    /// Get raw value of 'GPS_Week'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -35631,7 +35760,7 @@ impl RtSbGpsTime {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of GPS_Week
+    /// Set value of 'GPS_Week'
     #[inline(always)]
     pub fn set_gps_week(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -35649,7 +35778,7 @@ impl RtSbGpsTime {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// GPS_Time
+    /// Get value of 'GPS_Time'
     ///
     /// GPS time is the time in seconds since midnight GMT on Saturday night.
     ///
@@ -35661,7 +35790,7 @@ impl RtSbGpsTime {
     pub fn gps_time(&self) -> f32 {
         self.gps_time_raw()
     }
-    /// Get raw value of GPS_Time
+    /// Get raw value of 'GPS_Time'
     ///
     /// - Start bit: 16
     /// - Signal size: 32 bits
@@ -35676,7 +35805,7 @@ impl RtSbGpsTime {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of GPS_Time
+    /// Set value of 'GPS_Time'
     #[inline(always)]
     pub fn set_gps_time(&mut self, value: f32) -> Result<(), CanError> {
         if value < 0_f32 || 604800_f32 < value {
@@ -35690,7 +35819,7 @@ impl RtSbGpsTime {
         self.raw.view_bits_mut::<Lsb0>()[16..48].store_le(value);
         Ok(())
     }
-    /// Accuracy_GPS_Time
+    /// Get value of 'Accuracy_GPS_Time'
     ///
     /// - Min: 0
     /// - Max: 255
@@ -35700,7 +35829,7 @@ impl RtSbGpsTime {
     pub fn accuracy_gps_time(&self) -> u8 {
         self.accuracy_gps_time_raw()
     }
-    /// Get raw value of Accuracy_GPS_Time
+    /// Get raw value of 'Accuracy_GPS_Time'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -35714,7 +35843,7 @@ impl RtSbGpsTime {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_GPS_Time
+    /// Set value of 'Accuracy_GPS_Time'
     #[inline(always)]
     pub fn set_accuracy_gps_time(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -35732,7 +35861,7 @@ impl RtSbGpsTime {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Week
+    /// Get value of 'Validity_GPS_Week'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -35744,7 +35873,7 @@ impl RtSbGpsTime {
     pub fn validity_gps_week(&self) -> bool {
         self.validity_gps_week_raw()
     }
-    /// Get raw value of Validity_GPS_Week
+    /// Get raw value of 'Validity_GPS_Week'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -35757,14 +35886,14 @@ impl RtSbGpsTime {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Week
+    /// Set value of 'Validity_GPS_Week'
     #[inline(always)]
     pub fn set_validity_gps_week(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_GPS_Time
+    /// Get value of 'Validity_GPS_Time'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -35776,7 +35905,7 @@ impl RtSbGpsTime {
     pub fn validity_gps_time(&self) -> bool {
         self.validity_gps_time_raw()
     }
-    /// Get raw value of Validity_GPS_Time
+    /// Get raw value of 'Validity_GPS_Time'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -35789,7 +35918,7 @@ impl RtSbGpsTime {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_GPS_Time
+    /// Set value of 'Validity_GPS_Time'
     #[inline(always)]
     pub fn set_validity_gps_time(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
@@ -35865,7 +35994,7 @@ impl RtSbAccel {
     pub const ACCEL_LONGITUDINAL_MAX: f32 = 65_f32;
     pub const ACCURACY_ACCEL_MIN: u8 = 0_u8;
     pub const ACCURACY_ACCEL_MAX: u8 = 255_u8;
-    /// Construct new RT_SB_Accel from values
+    /// Construct new 'RT_SB_Accel' from values
     pub fn new(
         accel_vertical: f32,
         accel_lateral: f32,
@@ -35889,7 +36018,7 @@ impl RtSbAccel {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Accel_Vertical
+    /// Get value of 'Accel_Vertical'
     ///
     /// Vertical acceleration.  This is positive when the vehicle accelerates in an upwards direction, e.g. when travelling through a dip.
     ///
@@ -35901,7 +36030,7 @@ impl RtSbAccel {
     pub fn accel_vertical(&self) -> f32 {
         self.accel_vertical_raw()
     }
-    /// Get raw value of Accel_Vertical
+    /// Get raw value of 'Accel_Vertical'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -35916,7 +36045,7 @@ impl RtSbAccel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Accel_Vertical
+    /// Set value of 'Accel_Vertical'
     #[inline(always)]
     pub fn set_accel_vertical(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -35931,7 +36060,7 @@ impl RtSbAccel {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Accel_Lateral
+    /// Get value of 'Accel_Lateral'
     ///
     /// Lateral acceleration.  This is positive when the vehicle accelerates towards the right, e.g. when cornering around a right-hand bend.
     ///
@@ -35943,7 +36072,7 @@ impl RtSbAccel {
     pub fn accel_lateral(&self) -> f32 {
         self.accel_lateral_raw()
     }
-    /// Get raw value of Accel_Lateral
+    /// Get raw value of 'Accel_Lateral'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -35958,7 +36087,7 @@ impl RtSbAccel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Accel_Lateral
+    /// Set value of 'Accel_Lateral'
     #[inline(always)]
     pub fn set_accel_lateral(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -35973,7 +36102,7 @@ impl RtSbAccel {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Accel_Longitudinal
+    /// Get value of 'Accel_Longitudinal'
     ///
     /// Longitudinal acceleration.  This is positive when the vehicle accelerates in a forwards direction.
     ///
@@ -35985,7 +36114,7 @@ impl RtSbAccel {
     pub fn accel_longitudinal(&self) -> f32 {
         self.accel_longitudinal_raw()
     }
-    /// Get raw value of Accel_Longitudinal
+    /// Get raw value of 'Accel_Longitudinal'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -36000,7 +36129,7 @@ impl RtSbAccel {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Accel_Longitudinal
+    /// Set value of 'Accel_Longitudinal'
     #[inline(always)]
     pub fn set_accel_longitudinal(&mut self, value: f32) -> Result<(), CanError> {
         if value < -65_f32 || 65_f32 < value {
@@ -36015,7 +36144,7 @@ impl RtSbAccel {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_Accel
+    /// Get value of 'Accuracy_Accel'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -36027,7 +36156,7 @@ impl RtSbAccel {
     pub fn accuracy_accel(&self) -> u8 {
         self.accuracy_accel_raw()
     }
-    /// Get raw value of Accuracy_Accel
+    /// Get raw value of 'Accuracy_Accel'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -36041,7 +36170,7 @@ impl RtSbAccel {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_Accel
+    /// Set value of 'Accuracy_Accel'
     #[inline(always)]
     pub fn set_accuracy_accel(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 255_u8 < value {
@@ -36059,7 +36188,7 @@ impl RtSbAccel {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_Accel_Vertical
+    /// Get value of 'Validity_Accel_Vertical'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -36071,7 +36200,7 @@ impl RtSbAccel {
     pub fn validity_accel_vertical(&self) -> bool {
         self.validity_accel_vertical_raw()
     }
-    /// Get raw value of Validity_Accel_Vertical
+    /// Get raw value of 'Validity_Accel_Vertical'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -36084,14 +36213,14 @@ impl RtSbAccel {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Accel_Vertical
+    /// Set value of 'Validity_Accel_Vertical'
     #[inline(always)]
     pub fn set_validity_accel_vertical(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_Accel_Lateral
+    /// Get value of 'Validity_Accel_Lateral'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -36103,7 +36232,7 @@ impl RtSbAccel {
     pub fn validity_accel_lateral(&self) -> bool {
         self.validity_accel_lateral_raw()
     }
-    /// Get raw value of Validity_Accel_Lateral
+    /// Get raw value of 'Validity_Accel_Lateral'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -36116,14 +36245,14 @@ impl RtSbAccel {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Accel_Lateral
+    /// Set value of 'Validity_Accel_Lateral'
     #[inline(always)]
     pub fn set_validity_accel_lateral(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_Accel_Longitudinal
+    /// Get value of 'Validity_Accel_Longitudinal'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -36135,7 +36264,7 @@ impl RtSbAccel {
     pub fn validity_accel_longitudinal(&self) -> bool {
         self.validity_accel_longitudinal_raw()
     }
-    /// Get raw value of Validity_Accel_Longitudinal
+    /// Get raw value of 'Validity_Accel_Longitudinal'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -36148,7 +36277,7 @@ impl RtSbAccel {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Accel_Longitudinal
+    /// Set value of 'Validity_Accel_Longitudinal'
     #[inline(always)]
     pub fn set_validity_accel_longitudinal(
         &mut self,
@@ -36227,7 +36356,7 @@ impl RtSbGyroRates {
     pub const GYRO_RATE_YAW_MAX: f32 = 327_f32;
     pub const ACCURACY_GYRO_RATES_MIN: u8 = 0_u8;
     pub const ACCURACY_GYRO_RATES_MAX: u8 = 0_u8;
-    /// Construct new RT_SB_Gyro_Rates from values
+    /// Construct new 'RT_SB_Gyro_Rates' from values
     pub fn new(
         gyro_rate_roll: f32,
         gyro_rate_pitch: f32,
@@ -36251,7 +36380,7 @@ impl RtSbGyroRates {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Gyro_Rate_Roll
+    /// Get value of 'Gyro_Rate_Roll'
     ///
     /// Roll rate is positive for clockwise rotation when looking at the rear of the vehicle from behind the vehicle.
     ///
@@ -36263,7 +36392,7 @@ impl RtSbGyroRates {
     pub fn gyro_rate_roll(&self) -> f32 {
         self.gyro_rate_roll_raw()
     }
-    /// Get raw value of Gyro_Rate_Roll
+    /// Get raw value of 'Gyro_Rate_Roll'
     ///
     /// - Start bit: 48
     /// - Signal size: 16 bits
@@ -36278,7 +36407,7 @@ impl RtSbGyroRates {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Gyro_Rate_Roll
+    /// Set value of 'Gyro_Rate_Roll'
     #[inline(always)]
     pub fn set_gyro_rate_roll(&mut self, value: f32) -> Result<(), CanError> {
         if value < -327_f32 || 327_f32 < value {
@@ -36293,7 +36422,7 @@ impl RtSbGyroRates {
         self.raw.view_bits_mut::<Lsb0>()[48..64].store_le(value);
         Ok(())
     }
-    /// Gyro_Rate_Pitch
+    /// Get value of 'Gyro_Rate_Pitch'
     ///
     /// Pitch rate is positive for clockwise rotation when looking at the left hand side of the vehicle from the left of the vehicle.
     ///
@@ -36305,7 +36434,7 @@ impl RtSbGyroRates {
     pub fn gyro_rate_pitch(&self) -> f32 {
         self.gyro_rate_pitch_raw()
     }
-    /// Get raw value of Gyro_Rate_Pitch
+    /// Get raw value of 'Gyro_Rate_Pitch'
     ///
     /// - Start bit: 32
     /// - Signal size: 16 bits
@@ -36320,7 +36449,7 @@ impl RtSbGyroRates {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Gyro_Rate_Pitch
+    /// Set value of 'Gyro_Rate_Pitch'
     #[inline(always)]
     pub fn set_gyro_rate_pitch(&mut self, value: f32) -> Result<(), CanError> {
         if value < -327_f32 || 327_f32 < value {
@@ -36335,7 +36464,7 @@ impl RtSbGyroRates {
         self.raw.view_bits_mut::<Lsb0>()[32..48].store_le(value);
         Ok(())
     }
-    /// Gyro_Rate_Yaw
+    /// Get value of 'Gyro_Rate_Yaw'
     ///
     /// Yaw rate is positive for clockwise rotation when looking down on the vehicle from above.
     ///
@@ -36347,7 +36476,7 @@ impl RtSbGyroRates {
     pub fn gyro_rate_yaw(&self) -> f32 {
         self.gyro_rate_yaw_raw()
     }
-    /// Get raw value of Gyro_Rate_Yaw
+    /// Get raw value of 'Gyro_Rate_Yaw'
     ///
     /// - Start bit: 16
     /// - Signal size: 16 bits
@@ -36362,7 +36491,7 @@ impl RtSbGyroRates {
         let offset = 0_f32;
         (signal as f32) * factor + offset
     }
-    /// Set value of Gyro_Rate_Yaw
+    /// Set value of 'Gyro_Rate_Yaw'
     #[inline(always)]
     pub fn set_gyro_rate_yaw(&mut self, value: f32) -> Result<(), CanError> {
         if value < -327_f32 || 327_f32 < value {
@@ -36377,7 +36506,7 @@ impl RtSbGyroRates {
         self.raw.view_bits_mut::<Lsb0>()[16..32].store_le(value);
         Ok(())
     }
-    /// Accuracy_Gyro_Rates
+    /// Get value of 'Accuracy_Gyro_Rates'
     ///
     /// Dimensionless.  Lower values imply but do not guarantee better accuracy than higher values.
     ///
@@ -36389,7 +36518,7 @@ impl RtSbGyroRates {
     pub fn accuracy_gyro_rates(&self) -> u8 {
         self.accuracy_gyro_rates_raw()
     }
-    /// Get raw value of Accuracy_Gyro_Rates
+    /// Get raw value of 'Accuracy_Gyro_Rates'
     ///
     /// - Start bit: 8
     /// - Signal size: 8 bits
@@ -36403,7 +36532,7 @@ impl RtSbGyroRates {
         let factor = 1;
         u8::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Accuracy_Gyro_Rates
+    /// Set value of 'Accuracy_Gyro_Rates'
     #[inline(always)]
     pub fn set_accuracy_gyro_rates(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -36421,7 +36550,7 @@ impl RtSbGyroRates {
         self.raw.view_bits_mut::<Lsb0>()[8..16].store_le(value);
         Ok(())
     }
-    /// Validity_Gyro_Rate_Roll
+    /// Get value of 'Validity_Gyro_Rate_Roll'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -36433,7 +36562,7 @@ impl RtSbGyroRates {
     pub fn validity_gyro_rate_roll(&self) -> bool {
         self.validity_gyro_rate_roll_raw()
     }
-    /// Get raw value of Validity_Gyro_Rate_Roll
+    /// Get raw value of 'Validity_Gyro_Rate_Roll'
     ///
     /// - Start bit: 2
     /// - Signal size: 1 bits
@@ -36446,14 +36575,14 @@ impl RtSbGyroRates {
         let signal = self.raw.view_bits::<Lsb0>()[2..3].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Gyro_Rate_Roll
+    /// Set value of 'Validity_Gyro_Rate_Roll'
     #[inline(always)]
     pub fn set_validity_gyro_rate_roll(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[2..3].store_le(value);
         Ok(())
     }
-    /// Validity_Gyro_Rate_Pitch
+    /// Get value of 'Validity_Gyro_Rate_Pitch'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -36465,7 +36594,7 @@ impl RtSbGyroRates {
     pub fn validity_gyro_rate_pitch(&self) -> bool {
         self.validity_gyro_rate_pitch_raw()
     }
-    /// Get raw value of Validity_Gyro_Rate_Pitch
+    /// Get raw value of 'Validity_Gyro_Rate_Pitch'
     ///
     /// - Start bit: 1
     /// - Signal size: 1 bits
@@ -36478,14 +36607,14 @@ impl RtSbGyroRates {
         let signal = self.raw.view_bits::<Lsb0>()[1..2].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Gyro_Rate_Pitch
+    /// Set value of 'Validity_Gyro_Rate_Pitch'
     #[inline(always)]
     pub fn set_validity_gyro_rate_pitch(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;
         self.raw.view_bits_mut::<Lsb0>()[1..2].store_le(value);
         Ok(())
     }
-    /// Validity_Gyro_Rate_Yaw
+    /// Get value of 'Validity_Gyro_Rate_Yaw'
     ///
     /// Valid when bit is set, invalid when bit is clear.
     ///
@@ -36497,7 +36626,7 @@ impl RtSbGyroRates {
     pub fn validity_gyro_rate_yaw(&self) -> bool {
         self.validity_gyro_rate_yaw_raw()
     }
-    /// Get raw value of Validity_Gyro_Rate_Yaw
+    /// Get raw value of 'Validity_Gyro_Rate_Yaw'
     ///
     /// - Start bit: 0
     /// - Signal size: 1 bits
@@ -36510,7 +36639,7 @@ impl RtSbGyroRates {
         let signal = self.raw.view_bits::<Lsb0>()[0..1].load_le::<u8>();
         signal == 1
     }
-    /// Set value of Validity_Gyro_Rate_Yaw
+    /// Set value of 'Validity_Gyro_Rate_Yaw'
     #[inline(always)]
     pub fn set_validity_gyro_rate_yaw(&mut self, value: bool) -> Result<(), CanError> {
         let value = value as u8;

--- a/tests-snapshots/oxibus/bug_dbc-codegen_98.snap.rs
+++ b/tests-snapshots/oxibus/bug_dbc-codegen_98.snap.rs
@@ -82,7 +82,7 @@ impl TestInput {
     pub const VAR3_MAX: u16 = 65535_u16;
     pub const VAR4_MIN: u16 = 0_u16;
     pub const VAR4_MAX: u16 = 65535_u16;
-    /// Construct new Test_input from values
+    /// Construct new 'Test_input' from values
     pub fn new(test_input_mux: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_test_input_mux(test_input_mux)?;
@@ -92,7 +92,7 @@ impl TestInput {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Test_input_Mux
+    /// Get raw value of 'Test_input_Mux'
     ///
     /// - Start bit: 56
     /// - Signal size: 4 bits
@@ -144,7 +144,7 @@ impl TestInput {
             }
         }
     }
-    /// Set value of Test_input_Mux
+    /// Set value of 'Test_input_Mux'
     #[inline(always)]
     fn set_test_input_mux(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -162,7 +162,7 @@ impl TestInput {
         self.raw.view_bits_mut::<Lsb0>()[56..60].store_le(value);
         Ok(())
     }
-    /// Set value of Test_input_Mux
+    /// Set value of 'Test_input_Mux'
     #[inline(always)]
     pub fn set_m0(&mut self, value: TestInputTestInputMuxM0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -171,7 +171,7 @@ impl TestInput {
         self.set_test_input_mux(0)?;
         Ok(())
     }
-    /// Set value of Test_input_Mux
+    /// Set value of 'Test_input_Mux'
     #[inline(always)]
     pub fn set_m1(&mut self, value: TestInputTestInputMuxM1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -180,7 +180,7 @@ impl TestInput {
         self.set_test_input_mux(1)?;
         Ok(())
     }
-    /// Set value of Test_input_Mux
+    /// Set value of 'Test_input_Mux'
     #[inline(always)]
     pub fn set_m2(&mut self, value: TestInputTestInputMuxM2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -189,7 +189,7 @@ impl TestInput {
         self.set_test_input_mux(2)?;
         Ok(())
     }
-    /// Set value of Test_input_Mux
+    /// Set value of 'Test_input_Mux'
     #[inline(always)]
     pub fn set_m3(&mut self, value: TestInputTestInputMuxM3) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -308,7 +308,7 @@ impl TestInputTestInputMuxM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Var1
+    /// Get value of 'Var1'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -318,7 +318,7 @@ impl TestInputTestInputMuxM0 {
     pub fn var1(&self) -> u16 {
         self.var1_raw()
     }
-    /// Get raw value of Var1
+    /// Get raw value of 'Var1'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -332,7 +332,7 @@ impl TestInputTestInputMuxM0 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Var1
+    /// Set value of 'Var1'
     #[inline(always)]
     pub fn set_var1(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -377,7 +377,7 @@ impl TestInputTestInputMuxM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Var2
+    /// Get value of 'Var2'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -387,7 +387,7 @@ impl TestInputTestInputMuxM1 {
     pub fn var2(&self) -> u16 {
         self.var2_raw()
     }
-    /// Get raw value of Var2
+    /// Get raw value of 'Var2'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -401,7 +401,7 @@ impl TestInputTestInputMuxM1 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Var2
+    /// Set value of 'Var2'
     #[inline(always)]
     pub fn set_var2(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -446,7 +446,7 @@ impl TestInputTestInputMuxM2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Var3
+    /// Get value of 'Var3'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -456,7 +456,7 @@ impl TestInputTestInputMuxM2 {
     pub fn var3(&self) -> u16 {
         self.var3_raw()
     }
-    /// Get raw value of Var3
+    /// Get raw value of 'Var3'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -470,7 +470,7 @@ impl TestInputTestInputMuxM2 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Var3
+    /// Set value of 'Var3'
     #[inline(always)]
     pub fn set_var3(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -515,7 +515,7 @@ impl TestInputTestInputMuxM3 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Var4
+    /// Get value of 'Var4'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -525,7 +525,7 @@ impl TestInputTestInputMuxM3 {
     pub fn var4(&self) -> u16 {
         self.var4_raw()
     }
-    /// Get raw value of Var4
+    /// Get raw value of 'Var4'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -539,7 +539,7 @@ impl TestInputTestInputMuxM3 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Var4
+    /// Set value of 'Var4'
     #[inline(always)]
     pub fn set_var4(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -590,7 +590,7 @@ impl TestOutput {
     pub const VAR7_MAX: u16 = 65535_u16;
     pub const VAR8_MIN: u16 = 0_u16;
     pub const VAR8_MAX: u16 = 65535_u16;
-    /// Construct new Test_output from values
+    /// Construct new 'Test_output' from values
     pub fn new(test_output_mux: u8) -> Result<Self, CanError> {
         let mut res = Self { raw: [0x00; 8] };
         res.set_test_output_mux(test_output_mux)?;
@@ -600,7 +600,7 @@ impl TestOutput {
     pub fn raw(&self) -> &[u8; 8] {
         &self.raw
     }
-    /// Get raw value of Test_output_Mux
+    /// Get raw value of 'Test_output_Mux'
     ///
     /// - Start bit: 56
     /// - Signal size: 4 bits
@@ -652,7 +652,7 @@ impl TestOutput {
             }
         }
     }
-    /// Set value of Test_output_Mux
+    /// Set value of 'Test_output_Mux'
     #[inline(always)]
     fn set_test_output_mux(&mut self, value: u8) -> Result<(), CanError> {
         if value < 0_u8 || 0_u8 < value {
@@ -670,7 +670,7 @@ impl TestOutput {
         self.raw.view_bits_mut::<Lsb0>()[56..60].store_le(value);
         Ok(())
     }
-    /// Set value of Test_output_Mux
+    /// Set value of 'Test_output_Mux'
     #[inline(always)]
     pub fn set_m0(&mut self, value: TestOutputTestOutputMuxM0) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -679,7 +679,7 @@ impl TestOutput {
         self.set_test_output_mux(0)?;
         Ok(())
     }
-    /// Set value of Test_output_Mux
+    /// Set value of 'Test_output_Mux'
     #[inline(always)]
     pub fn set_m1(&mut self, value: TestOutputTestOutputMuxM1) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -688,7 +688,7 @@ impl TestOutput {
         self.set_test_output_mux(1)?;
         Ok(())
     }
-    /// Set value of Test_output_Mux
+    /// Set value of 'Test_output_Mux'
     #[inline(always)]
     pub fn set_m2(&mut self, value: TestOutputTestOutputMuxM2) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -697,7 +697,7 @@ impl TestOutput {
         self.set_test_output_mux(2)?;
         Ok(())
     }
-    /// Set value of Test_output_Mux
+    /// Set value of 'Test_output_Mux'
     #[inline(always)]
     pub fn set_m3(&mut self, value: TestOutputTestOutputMuxM3) -> Result<(), CanError> {
         let b0 = BitArray::<_, LocalBits>::new(self.raw);
@@ -816,7 +816,7 @@ impl TestOutputTestOutputMuxM0 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Var5
+    /// Get value of 'Var5'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -826,7 +826,7 @@ impl TestOutputTestOutputMuxM0 {
     pub fn var5(&self) -> u16 {
         self.var5_raw()
     }
-    /// Get raw value of Var5
+    /// Get raw value of 'Var5'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -840,7 +840,7 @@ impl TestOutputTestOutputMuxM0 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Var5
+    /// Set value of 'Var5'
     #[inline(always)]
     pub fn set_var5(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -885,7 +885,7 @@ impl TestOutputTestOutputMuxM1 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Var6
+    /// Get value of 'Var6'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -895,7 +895,7 @@ impl TestOutputTestOutputMuxM1 {
     pub fn var6(&self) -> u16 {
         self.var6_raw()
     }
-    /// Get raw value of Var6
+    /// Get raw value of 'Var6'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -909,7 +909,7 @@ impl TestOutputTestOutputMuxM1 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Var6
+    /// Set value of 'Var6'
     #[inline(always)]
     pub fn set_var6(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -954,7 +954,7 @@ impl TestOutputTestOutputMuxM2 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Var7
+    /// Get value of 'Var7'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -964,7 +964,7 @@ impl TestOutputTestOutputMuxM2 {
     pub fn var7(&self) -> u16 {
         self.var7_raw()
     }
-    /// Get raw value of Var7
+    /// Get raw value of 'Var7'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -978,7 +978,7 @@ impl TestOutputTestOutputMuxM2 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Var7
+    /// Set value of 'Var7'
     #[inline(always)]
     pub fn set_var7(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {
@@ -1023,7 +1023,7 @@ impl TestOutputTestOutputMuxM3 {
     pub fn new() -> Self {
         Self { raw: [0u8; 8] }
     }
-    /// Var8
+    /// Get value of 'Var8'
     ///
     /// - Min: 0
     /// - Max: 65535
@@ -1033,7 +1033,7 @@ impl TestOutputTestOutputMuxM3 {
     pub fn var8(&self) -> u16 {
         self.var8_raw()
     }
-    /// Get raw value of Var8
+    /// Get raw value of 'Var8'
     ///
     /// - Start bit: 0
     /// - Signal size: 16 bits
@@ -1047,7 +1047,7 @@ impl TestOutputTestOutputMuxM3 {
         let factor = 1;
         u16::from(signal).saturating_mul(factor).saturating_add(0)
     }
-    /// Set value of Var8
+    /// Set value of 'Var8'
     #[inline(always)]
     pub fn set_var8(&mut self, value: u16) -> Result<(), CanError> {
         if value < 0_u16 || 65535_u16 < value {


### PR DESCRIPTION
- Updates the generated `new()` constructors and `set_<signal>()` setters to accept enums for signals that have an associated enum type (value description in the DBC). This mirrors the existing enum-typed getters, making the getter and setter APIs symmetrical.
- Cleans up the formatting of some generated getter/setter function comments for readability and consistency.

This is a breaking change for DBCs that have signals with value descriptions, but should make these signals much cleaner to handle. The best approach is to directly pass the enum-typed value into `set_<signal>()` and `new()`. Raw or undescribed values can still be set through the enum's `_Other` variant, e.g. `set_<signal>(SignalEnum::_Other(value))`.

This PR should be stacked on top of https://github.com/oxibus/dbc-codegen/pull/176.