### PR TITLE
chore: rust ver bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with: { tool: 'just,cargo-binstall' }
       - uses: dtolnay/rust-toolchain@stable
-        with: { toolchain: '1.94.0', components: 'rust-src,rust-docs,rustfmt,clippy' }
+        with: { toolchain: '1.97.0', components: 'rust-src,rust-docs,rustfmt,clippy' }
       - run: just ci-test
 
   test-msrv:
@@ -62,7 +62,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with: { tool: 'just,cargo-llvm-cov' }
       - uses: dtolnay/rust-toolchain@stable
-        with: { toolchain: '1.94.0', components: 'rust-src,rust-docs,rustfmt,clippy' }
+        with: { toolchain: '1.97.0', components: 'rust-src,rust-docs,rustfmt,clippy' }
       - run: just ci-coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.stderr
@@ -101,7 +101,7 @@ error[E0592]: duplicate definitions with name `set_m1`
 245 |       pub fn set_m1(&mut self, value: ExtMuxCascadedMuxAM1) -> Result<(), CanError> {
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m1`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxCascadedMuxAIndex`
+error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:195:21
     |
 195 |                     ExtMuxCascadedMuxAIndex::M0(ExtMuxCascadedMuxAM0 {
@@ -113,7 +113,7 @@ help: an enum with a similar name exists
 195 +                     ExtMuxCascadedMuxedA2MuxBIndex::M0(ExtMuxCascadedMuxAM0 {
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxCascadedMuxAIndex`
+error[E0433]: cannot find type `ExtMuxCascadedMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_cascaded_dumped.snap.rs:202:21
     |
 202 |                     ExtMuxCascadedMuxAIndex::M1(ExtMuxCascadedMuxAM1 {

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.stderr
@@ -152,7 +152,7 @@ error[E0592]: duplicate definitions with name `set_m2`
 291 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:216:21
     |
 216 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
@@ -164,7 +164,7 @@ help: an enum with a similar name exists
 216 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:223:21
     |
 223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
@@ -176,7 +176,7 @@ help: an enum with a similar name exists
 223 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors.snap.rs:230:21
     |
 230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {

--- a/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.stderr
@@ -152,7 +152,7 @@ error[E0592]: duplicate definitions with name `set_m2`
 291 | |     ) -> Result<(), CanError> {
     | |_____________________________^ duplicate definitions for `set_m2`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:216:21
     |
 216 |                     ExtMuxIndepMultiplexorsMuxAIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
@@ -164,7 +164,7 @@ help: an enum with a similar name exists
 216 +                     ExtMuxIndepMultiplexorsMuxBIndex::M0(ExtMuxIndepMultiplexorsMuxAM0 {
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:223:21
     |
 223 |                     ExtMuxIndepMultiplexorsMuxAIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
@@ -176,7 +176,7 @@ help: an enum with a similar name exists
 223 +                     ExtMuxIndepMultiplexorsMuxBIndex::M1(ExtMuxIndepMultiplexorsMuxAM1 {
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtMuxIndepMultiplexorsMuxAIndex`
+error[E0433]: cannot find type `ExtMuxIndepMultiplexorsMuxAIndex` in this scope
    --> tests-snapshots/dbc-cantools/issue_184_extended_mux_independent_multiplexors_dumped.snap.rs:230:21
     |
 230 |                     ExtMuxIndepMultiplexorsMuxAIndex::M2(ExtMuxIndepMultiplexorsMuxAM2 {

--- a/tests-snapshots/dbc-cantools/issue_199.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199.snap.stderr
@@ -28,7 +28,7 @@ help: an enum with a similar name exists
 2054 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
      |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:994:18
     |
 994 |             3 => GearShifterGearShifter::Park,
@@ -40,7 +40,7 @@ help: an enum with a similar name exists
 994 +             3 => GearShifterLeftBlinker::Park,
     |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:995:18
     |
 995 |             0 => GearShifterGearShifter::DriveLow,
@@ -52,7 +52,7 @@ help: an enum with a similar name exists
 995 +             0 => GearShifterLeftBlinker::DriveLow,
     |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199.snap.rs:996:18
     |
 996 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
@@ -64,7 +64,7 @@ help: an enum with a similar name exists
 996 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2057:18
      |
 2057 |             6 => CruiseButtonsCruiseButtons::Cancel,
@@ -76,7 +76,7 @@ help: an enum with a similar name exists
 2057 +             6 => CruiseButtons2LkaGapButton::Cancel,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2058:18
      |
 2058 |             5 => CruiseButtonsCruiseButtons::Main,
@@ -88,7 +88,7 @@ help: an enum with a similar name exists
 2058 +             5 => CruiseButtons2LkaGapButton::Main,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2059:18
      |
 2059 |             3 => CruiseButtonsCruiseButtons::Set,
@@ -100,7 +100,7 @@ help: an enum with a similar name exists
 2059 +             3 => CruiseButtons2LkaGapButton::Set,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2060:18
      |
 2060 |             2 => CruiseButtonsCruiseButtons::Resume,
@@ -112,7 +112,7 @@ help: an enum with a similar name exists
 2060 +             2 => CruiseButtons2LkaGapButton::Resume,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2061:18
      |
 2061 |             1 => CruiseButtonsCruiseButtons::None,
@@ -124,7 +124,7 @@ help: an enum with a similar name exists
 2061 +             1 => CruiseButtons2LkaGapButton::None,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199.snap.rs:2062:18
      |
 2062 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),

--- a/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
+++ b/tests-snapshots/dbc-cantools/issue_199_extended.snap.stderr
@@ -28,7 +28,7 @@ help: an enum with a similar name exists
 1954 +     pub fn cruise_buttons(&self) -> CruiseButtons2LkaGapButton {
      |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:944:18
     |
 944 |             3 => GearShifterGearShifter::Park,
@@ -40,7 +40,7 @@ help: an enum with a similar name exists
 944 +             3 => GearShifterLeftBlinker::Park,
     |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:945:18
     |
 945 |             0 => GearShifterGearShifter::DriveLow,
@@ -52,7 +52,7 @@ help: an enum with a similar name exists
 945 +             0 => GearShifterLeftBlinker::DriveLow,
     |
 
-error[E0433]: failed to resolve: use of undeclared type `GearShifterGearShifter`
+error[E0433]: cannot find type `GearShifterGearShifter` in this scope
    --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:946:18
     |
 946 |             _ => GearShifterGearShifter::_Other(self.gear_shifter_raw()),
@@ -64,7 +64,7 @@ help: an enum with a similar name exists
 946 +             _ => GearShifterLeftBlinker::_Other(self.gear_shifter_raw()),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1957:18
      |
 1957 |             6 => CruiseButtonsCruiseButtons::Cancel,
@@ -76,7 +76,7 @@ help: an enum with a similar name exists
 1957 +             6 => CruiseButtons2LkaGapButton::Cancel,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1958:18
      |
 1958 |             5 => CruiseButtonsCruiseButtons::Main,
@@ -88,7 +88,7 @@ help: an enum with a similar name exists
 1958 +             5 => CruiseButtons2LkaGapButton::Main,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1959:18
      |
 1959 |             3 => CruiseButtonsCruiseButtons::Set,
@@ -100,7 +100,7 @@ help: an enum with a similar name exists
 1959 +             3 => CruiseButtons2LkaGapButton::Set,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1960:18
      |
 1960 |             2 => CruiseButtonsCruiseButtons::Resume,
@@ -112,7 +112,7 @@ help: an enum with a similar name exists
 1960 +             2 => CruiseButtons2LkaGapButton::Resume,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1961:18
      |
 1961 |             1 => CruiseButtonsCruiseButtons::None,
@@ -124,7 +124,7 @@ help: an enum with a similar name exists
 1961 +             1 => CruiseButtons2LkaGapButton::None,
      |
 
-error[E0433]: failed to resolve: use of undeclared type `CruiseButtonsCruiseButtons`
+error[E0433]: cannot find type `CruiseButtonsCruiseButtons` in this scope
     --> tests-snapshots/dbc-cantools/issue_199_extended.snap.rs:1962:18
      |
 1962 |             _ => CruiseButtonsCruiseButtons::_Other(self.cruise_buttons_raw()),

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.stderr
@@ -29,7 +29,7 @@ error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest
 672 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
-error[E0119]: conflicting implementations of trait `std::marker::Copy` for type `MsgCaseTest`
+error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
    --> tests-snapshots/dbc-cantools/long_names_multiple_relations.snap.rs:672:17
     |
 603 | #[derive(Clone, Copy)]

--- a/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.stderr
@@ -29,7 +29,7 @@ error[E0119]: conflicting implementations of trait `Clone` for type `MsgCaseTest
 672 | #[derive(Clone, Copy)]
     |          ^^^^^ conflicting implementation for `MsgCaseTest`
 
-error[E0119]: conflicting implementations of trait `std::marker::Copy` for type `MsgCaseTest`
+error[E0119]: conflicting implementations of trait `Copy` for type `MsgCaseTest`
    --> tests-snapshots/dbc-cantools/long_names_multiple_relations_dumped.snap.rs:672:17
     |
 603 | #[derive(Clone, Copy)]

--- a/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2.snap.stderr
@@ -150,7 +150,7 @@ error[E0592]: duplicate definitions with name `set_m2`
 842 |     pub fn set_m2(&mut self, value: ExtendedS0M2) -> Result<(), CanError> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m2`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:792:21
     |
 792 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
@@ -162,7 +162,7 @@ help: an enum with a similar name exists
 792 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:793:21
     |
 793 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
@@ -174,7 +174,7 @@ help: an enum with a similar name exists
 793 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2.snap.rs:794:21
     |
 794 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),

--- a/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
+++ b/tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.stderr
@@ -383,7 +383,7 @@ error[E0592]: duplicate definitions with name `set_m5`
 1494 |     pub fn set_m5(&mut self, value: ExtendedTypesS11M5) -> Result<(), CanError> {
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `set_m5`
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS1Index`
+error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:793:21
     |
 793 |             0 => Ok(ExtendedS1Index::M0(ExtendedS1M0 { raw: self.raw })),
@@ -395,7 +395,7 @@ help: an enum with a similar name exists
 793 +             0 => Ok(ExtendedS6Index::M0(ExtendedS1M0 { raw: self.raw })),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS1Index`
+error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:794:21
     |
 794 |             1 => Ok(ExtendedS1Index::M1(ExtendedS1M1 { raw: self.raw })),
@@ -407,7 +407,7 @@ help: an enum with a similar name exists
 794 +             1 => Ok(ExtendedS6Index::M1(ExtendedS1M1 { raw: self.raw })),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS1Index`
+error[E0433]: cannot find type `ExtendedS1Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:795:21
     |
 795 |             2 => Ok(ExtendedS1Index::M2(ExtendedS1M2 { raw: self.raw })),
@@ -419,7 +419,7 @@ help: an enum with a similar name exists
 795 +             2 => Ok(ExtendedS6Index::M2(ExtendedS1M2 { raw: self.raw })),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:867:21
     |
 867 |             0 => Ok(ExtendedS0Index::M0(ExtendedS0M0 { raw: self.raw })),
@@ -431,7 +431,7 @@ help: an enum with a similar name exists
 867 +             0 => Ok(ExtendedS6Index::M0(ExtendedS0M0 { raw: self.raw })),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:868:21
     |
 868 |             1 => Ok(ExtendedS0Index::M1(ExtendedS0M1 { raw: self.raw })),
@@ -443,7 +443,7 @@ help: an enum with a similar name exists
 868 +             1 => Ok(ExtendedS6Index::M1(ExtendedS0M1 { raw: self.raw })),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedS0Index`
+error[E0433]: cannot find type `ExtendedS0Index` in this scope
    --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:869:21
     |
 869 |             2 => Ok(ExtendedS0Index::M2(ExtendedS0M2 { raw: self.raw })),
@@ -455,7 +455,7 @@ help: an enum with a similar name exists
 869 +             2 => Ok(ExtendedS6Index::M2(ExtendedS0M2 { raw: self.raw })),
     |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedTypesS11Index`
+error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1445:21
      |
 1445 |                     ExtendedTypesS11Index::M0(ExtendedTypesS11M0 {
@@ -467,7 +467,7 @@ help: an enum with a similar name exists
 1445 +                     ExtendedTypesS0Index::M0(ExtendedTypesS11M0 {
      |
 
-error[E0433]: failed to resolve: use of undeclared type `ExtendedTypesS11Index`
+error[E0433]: cannot find type `ExtendedTypesS11Index` in this scope
     --> tests-snapshots/dbc-cantools/multiplex_2_dumped.snap.rs:1452:21
      |
 1452 |                     ExtendedTypesS11Index::M5(ExtendedTypesS11M5 {


### PR DESCRIPTION
rust compiler often changes error messages - so updating to 1.97 for consistency