### PR TITLE
Emit MESSAGE_CYCLE_TIME as integer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,9 +205,6 @@ impl Config<'_> {
         writeln!(w, "use bitvec::prelude::*;")?;
         writeln!(w, "#[allow(unused_imports)]")?;
         writeln!(w, "use embedded_can::{{Id, StandardId, ExtendedId}};")?;
-        if get_relevant_messages(&dbc).any(|m| message_cycle_time_ms(&dbc, m.id).is_some()) {
-            writeln!(w, "use core::time::Duration;")?;
-        }
 
         self.impl_arbitrary.fmt_cfg(&mut w, |w| {
             writeln!(w, "use arbitrary::{{Arbitrary, Unstructured}};")
@@ -665,10 +662,7 @@ impl Config<'_> {
         let Some(ms) = message_cycle_time_ms(dbc, msg.id) else {
             return Ok(());
         };
-        writeln!(
-            w,
-            "pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis({ms});"
-        )?;
+        writeln!(w, "pub const MESSAGE_CYCLE_TIME_MS: u32 = {ms};")?;
         Ok(())
     }
 
@@ -1623,12 +1617,12 @@ fn attr_value_literal(value: &AttributeValue) -> String {
     }
 }
 
-/// Cycle time in milliseconds from an assigned and valid
-// `GenMsgCycleTime` (`BA_`) attribute.
-fn message_cycle_time_ms(dbc: &Dbc, id: MessageId) -> Option<u64> {
+/// Cycle time in milliseconds from an assigned `GenMsgCycleTime` (`BA_`)
+/// attribute, if it is present and a non-negative integer that fits within a `u32`.
+fn message_cycle_time_ms(dbc: &Dbc, id: MessageId) -> Option<u32> {
     match dbc.message_attribute(id, "GenMsgCycleTime")? {
-        AttributeValue::Uint(v) => Some(*v),
-        AttributeValue::Int(v) => u64::try_from(*v).ok(),
+        AttributeValue::Uint(v) => u32::try_from(*v).ok(),
+        AttributeValue::Int(v) => u32::try_from(*v).ok(),
         AttributeValue::Double(_) | AttributeValue::String(_) => None,
     }
 }

--- a/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
+++ b/tests-snapshots/dbc-cantools/attribute_Event.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -71,7 +70,7 @@ impl Inv2EventMsg1 {
         StandardId::new_unchecked(0x4d2)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(0);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 0;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
     /// Construct new INV2EventMsg1 from values

--- a/tests-snapshots/dbc-cantools/attributes.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -75,7 +74,7 @@ impl TheMessage {
         ExtendedId::new_unchecked(0x39)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
     /// Construct new TheMessage from values

--- a/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
+++ b/tests-snapshots/dbc-cantools/attributes_relation.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -72,7 +71,7 @@ impl Message2 {
         StandardId::new_unchecked(0x53)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(50);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 50;
     pub const SIGNAL_2_MIN: i8 = 0_i8;
     pub const SIGNAL_2_MAX: i8 = 0_i8;
     /// Construct new Message_2 from values

--- a/tests-snapshots/dbc-cantools/big_numbers.snap.rs
+++ b/tests-snapshots/dbc-cantools/big_numbers.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -75,7 +74,7 @@ impl TheMessage {
         ExtendedId::new_unchecked(0x39)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const THE_SIGNAL_MIN: i8 = 0_i8;
     pub const THE_SIGNAL_MAX: i8 = 0_i8;
     /// Construct new TheMessage from values

--- a/tests-snapshots/dbc-cantools/foobar.snap.rs
+++ b/tests-snapshots/dbc-cantools/foobar.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -242,7 +241,7 @@ impl Fum {
         ExtendedId::new_unchecked(0x12331)
     });
     pub const MESSAGE_SIZE: usize = 5;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 1;
     pub const FUM_MIN: i16 = 0_i16;
     pub const FUM_MAX: i16 = 10_i16;
     pub const FAM_MIN: i16 = 0_i16;

--- a/tests-snapshots/dbc-cantools/issue_168.snap.rs
+++ b/tests-snapshots/dbc-cantools/issue_168.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -242,7 +241,7 @@ impl Fum {
         ExtendedId::new_unchecked(0x12331)
     });
     pub const MESSAGE_SIZE: usize = 5;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 1;
     pub const FUM_MIN: i16 = 0_i16;
     pub const FUM_MAX: i16 = 10_i16;
     pub const FAM_MIN: i16 = 0_i16;

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-default-sort-signals.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -89,7 +88,7 @@ impl DriverHeartbeat {
         StandardId::new_unchecked(0x64)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
     /// Construct new DRIVER_HEARTBEAT from values
@@ -243,7 +242,7 @@ impl IoDebug {
         StandardId::new_unchecked(0x1f4)
     });
     pub const MESSAGE_SIZE: usize = 4;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const IO_DEBUG_TEST_FLOAT_MIN: f32 = 0_f32;
     pub const IO_DEBUG_TEST_FLOAT_MAX: f32 = 0_f32;
     pub const IO_DEBUG_TEST_SIGNED_MIN: i8 = 0_i8;
@@ -529,7 +528,7 @@ impl MotorCmd {
         StandardId::new_unchecked(0x65)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
     pub const MOTOR_CMD_DRIVE_MAX: u8 = 9_u8;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
@@ -693,7 +692,7 @@ impl MotorStatus {
         StandardId::new_unchecked(0x190)
     });
     pub const MESSAGE_SIZE: usize = 3;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
     /// Construct new MOTOR_STATUS from values
@@ -841,7 +840,7 @@ impl SensorSonars {
         StandardId::new_unchecked(0xc8)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const SENSOR_SONARS_NO_FILT_REAR_MIN: f32 = 0_f32;
     pub const SENSOR_SONARS_NO_FILT_REAR_MAX: f32 = 0_f32;
     pub const SENSOR_SONARS_REAR_MIN: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools-with-sort-signals-by-name.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -89,7 +88,7 @@ impl DriverHeartbeat {
         StandardId::new_unchecked(0x64)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
     /// Construct new DRIVER_HEARTBEAT from values
@@ -243,7 +242,7 @@ impl IoDebug {
         StandardId::new_unchecked(0x1f4)
     });
     pub const MESSAGE_SIZE: usize = 4;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const IO_DEBUG_TEST_ENUM_MIN: u8 = 0_u8;
     pub const IO_DEBUG_TEST_ENUM_MAX: u8 = 0_u8;
     pub const IO_DEBUG_TEST_FLOAT_MIN: f32 = 0_f32;
@@ -529,7 +528,7 @@ impl MotorCmd {
         StandardId::new_unchecked(0x65)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
     pub const MOTOR_CMD_DRIVE_MAX: u8 = 9_u8;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
@@ -693,7 +692,7 @@ impl MotorStatus {
         StandardId::new_unchecked(0x190)
     });
     pub const MESSAGE_SIZE: usize = 3;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
     /// Construct new MOTOR_STATUS from values
@@ -841,7 +840,7 @@ impl SensorSonars {
         StandardId::new_unchecked(0xc8)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const SENSOR_SONARS_ERR_COUNT_MIN: u16 = 0_u16;
     pub const SENSOR_SONARS_ERR_COUNT_MAX: u16 = 0_u16;
     pub const SENSOR_SONARS_LEFT_MIN: f32 = 0_f32;

--- a/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge-written-by-cantools.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -89,7 +88,7 @@ impl DriverHeartbeat {
         StandardId::new_unchecked(0x64)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
     /// Construct new DRIVER_HEARTBEAT from values
@@ -243,7 +242,7 @@ impl IoDebug {
         StandardId::new_unchecked(0x1f4)
     });
     pub const MESSAGE_SIZE: usize = 4;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const IO_DEBUG_TEST_UNSIGNED_MIN: u8 = 0_u8;
     pub const IO_DEBUG_TEST_UNSIGNED_MAX: u8 = 0_u8;
     pub const IO_DEBUG_TEST_ENUM_MIN: u8 = 0_u8;
@@ -529,7 +528,7 @@ impl MotorCmd {
         StandardId::new_unchecked(0x65)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
     pub const MOTOR_CMD_STEER_MAX: i8 = 5_i8;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
@@ -693,7 +692,7 @@ impl MotorStatus {
         StandardId::new_unchecked(0x190)
     });
     pub const MESSAGE_SIZE: usize = 3;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
     /// Construct new MOTOR_STATUS from values
@@ -841,7 +840,7 @@ impl SensorSonars {
         StandardId::new_unchecked(0xc8)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const SENSOR_SONARS_MUX_MIN: u8 = 0_u8;
     pub const SENSOR_SONARS_MUX_MAX: u8 = 0_u8;
     pub const SENSOR_SONARS_ERR_COUNT_MIN: u16 = 0_u16;

--- a/tests-snapshots/dbc-cantools/socialledge.snap.rs
+++ b/tests-snapshots/dbc-cantools/socialledge.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -89,7 +88,7 @@ impl DriverHeartbeat {
         StandardId::new_unchecked(0x64)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(1000);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 1000;
     pub const DRIVER_HEARTBEAT_CMD_MIN: u8 = 0_u8;
     pub const DRIVER_HEARTBEAT_CMD_MAX: u8 = 0_u8;
     /// Construct new DRIVER_HEARTBEAT from values
@@ -243,7 +242,7 @@ impl IoDebug {
         StandardId::new_unchecked(0x1f4)
     });
     pub const MESSAGE_SIZE: usize = 4;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const IO_DEBUG_TEST_UNSIGNED_MIN: u8 = 0_u8;
     pub const IO_DEBUG_TEST_UNSIGNED_MAX: u8 = 0_u8;
     pub const IO_DEBUG_TEST_ENUM_MIN: u8 = 0_u8;
@@ -529,7 +528,7 @@ impl MotorCmd {
         StandardId::new_unchecked(0x65)
     });
     pub const MESSAGE_SIZE: usize = 1;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_CMD_STEER_MIN: i8 = -5_i8;
     pub const MOTOR_CMD_STEER_MAX: i8 = 5_i8;
     pub const MOTOR_CMD_DRIVE_MIN: u8 = 0_u8;
@@ -693,7 +692,7 @@ impl MotorStatus {
         StandardId::new_unchecked(0x190)
     });
     pub const MESSAGE_SIZE: usize = 3;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const MOTOR_STATUS_SPEED_KPH_MIN: f32 = 0_f32;
     pub const MOTOR_STATUS_SPEED_KPH_MAX: f32 = 0_f32;
     /// Construct new MOTOR_STATUS from values
@@ -841,7 +840,7 @@ impl SensorSonars {
         StandardId::new_unchecked(0xc8)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(100);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 100;
     pub const SENSOR_SONARS_MUX_MIN: u8 = 0_u8;
     pub const SENSOR_SONARS_MUX_MAX: u8 = 0_u8;
     pub const SENSOR_SONARS_ERR_COUNT_MIN: u16 = 0_u16;

--- a/tests-snapshots/dbc-cantools/timing.snap.rs
+++ b/tests-snapshots/dbc-cantools/timing.snap.rs
@@ -10,7 +10,6 @@ use core::ops::BitOr;
 use bitvec::prelude::*;
 #[allow(unused_imports)]
 use embedded_can::{Id, StandardId, ExtendedId};
-use core::time::Duration;
 /// All messages
 #[allow(
     clippy::absurd_extreme_comparisons,
@@ -72,7 +71,7 @@ impl Foo {
         StandardId::new_unchecked(0x1)
     });
     pub const MESSAGE_SIZE: usize = 8;
-    pub const MESSAGE_CYCLE_TIME: Duration = Duration::from_millis(200);
+    pub const MESSAGE_CYCLE_TIME_MS: u32 = 200;
     pub const FOO_MIN: f32 = 229.53_f32;
     pub const FOO_MAX: f32 = 270.47_f32;
     /// Construct new Foo from values


### PR DESCRIPTION
Emits the `MESSAGE_CYCLE_TIME` constant as an raw integer instead of a `core::time::Duration` and renames it to `MESSAGE_CYCLE_TIME_MS`. This allows downstream users to ingest the value cleanly into any timing library (`core`, `fugit`, `embassy_time`, etc.).